### PR TITLE
Fix pyproject.toml and run black

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -711,7 +711,7 @@ class EncordClientProject(EncordClient):
         device="cuda",
         detection_frame_range=None,
         allocation_enabled=False,
-        data_hashes=None
+        data_hashes=None,
     ):
         """
         Run inference with model trained on the platform.
@@ -740,12 +740,16 @@ class EncordClientProject(EncordClient):
             DetectionRangeInvalidError: If a detection range is invalid for video inference
         """
         if (file_paths is None and base64_strings is None and data_hashes is None) or (
-            file_paths is not None and len(file_paths) > 0 and base64_strings is not None and len(base64_strings) > 0
-            and data_hashes is not None and len(data_hashes) > 0
+            file_paths is not None
+            and len(file_paths) > 0
+            and base64_strings is not None
+            and len(base64_strings) > 0
+            and data_hashes is not None
+            and len(data_hashes) > 0
         ):
             raise encord.exceptions.EncordException(
                 message="To run model inference, you must pass either a list of files or base64 strings or list of"
-                        " data hash."
+                " data hash."
             )
 
         if detection_frame_range is None:
@@ -779,7 +783,7 @@ class EncordClientProject(EncordClient):
                 "device": device,
                 "detection_frame_range": detection_frame_range,
                 "allocation_enabled": allocation_enabled,
-                "data_hashes": data_hashes
+                "data_hashes": data_hashes,
             }
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,10 @@ version = "0.1.29"
 description = "Cord Python SDK Client"
 authors = ["Cord Technologies Limited <hello@cord.tech>"]
 license = "Apache Software License"
-keywords = ["cord"]
+keywords = ["cord", "encord"]
 packages = [
     { include = "cord"},
+    { include = "encord"},
 ]
 readme = "README.md"
 repository="https://github.com/cord-team/cord-client-python"
@@ -38,4 +39,4 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 120
-include = 'cord\/.*'
+include = 'encord\/.*'


### PR DESCRIPTION
Due to the "copy structure" of the `cord` to `encord` directory the clients will be able to use both `cord` and `encord` names but will not get any autocomplete experience when importing from `cord`, but will only get it when importing from `encord`.