### PR TITLE
GitHub tests all python versions

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -80,3 +80,6 @@ runs:
         with:
           name: ${{ inputs.test-report-file }}
           path: projects/${{ inputs.project }}/${{ inputs.test-report-file }}
+
+      - name: Checkout current repo for post cleanup
+        uses: actions/checkout@v2

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -3,7 +3,6 @@ description: 'Run the integration tests for a given Python version. These tests 
 
 BACKEND_REPO: cord-team/cord-backend
 PROJECT: sdk-integration-tests
-PRIVATE_KEY: ${{ secrets.SDK_TESTS_PRIVATE_KEY }}
 TEST_DIR: ./src/cord/sdk_integration_tests/tests
 ENVIRONMENT: DEV
 
@@ -18,6 +17,9 @@ inputs:
     required: false
   test-report-file:
     description: 'File name to save the test report in'
+    required: true
+  private-key:
+    description: 'Private key for integration tests'
     required: true
 
 runs:
@@ -53,7 +55,7 @@ runs:
           cd projects/${{ env.PROJECT }}
           source .venv/bin/activate
           export CORD_ENV=${{ env.ENVIRONMENT }}
-          export PRIVATE_KEY="${{ env.PRIVATE_KEY }}"
+          export PRIVATE_KEY="${{ inputs.private-key }}"
           python -m pytest ${{ env.TEST_DIR }} --rootdir=${{ env.TEST_DIR }} --verbose --junitxml=${{ env.SDK_TEST_REPORT }}
         shell: bash
 

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -21,6 +21,9 @@ inputs:
   private-key:
     description: 'Private key for integration tests'
     required: true
+  backend-access-token:
+    description: 'Access token to backend repo'
+    required: true
 
 runs:
   using: "composite"
@@ -30,7 +33,7 @@ runs:
         uses: actions/checkout@v2
         with:
           repository: ${{ env.BACKEND_REPO }}
-          token: ${{ secrets.ACCESS_TOKEN }}
+          token: ${{ inputs.backend-access-token }}
 
       - name: Setup Poetry environment
         uses: ./.github/actions/setup-poetry-environment

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -52,6 +52,7 @@ runs:
         with:
           project: ${{ inputs.project }}
           cache-key: sdk-${{ hashFiles('projects/sdk-integration-tests/poetry.lock') }}-1
+          python-version: ${{ inputs.python-version }}
 
       - name: Setup FFMPEG
         uses: FedericoCarboni/setup-ffmpeg@v1

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -1,19 +1,10 @@
 name: 'Run integration tests'
 description: 'Run the integration tests for a given Python version. These tests come from the cord-backend.'
 
-BACKEND_REPO: cord-team/cord-backend
-PROJECT: sdk-integration-tests
-TEST_DIR: ./src/cord/sdk_integration_tests/tests
-ENVIRONMENT: DEV
-
 inputs:
   python-version:
     description: 'Python version to use'
     default: 3.7.12
-    required: false
-  poetry-version:
-    description: 'Poetry version to use'
-    default: 1.1.12
     required: false
   test-report-file:
     description: 'File name to save the test report in'
@@ -25,23 +16,41 @@ inputs:
     description: 'Access token to backend repo'
     required: true
 
+  poetry-version:
+    description: 'Poetry version to use'
+    default: 1.1.12
+    required: false
+  backend-repo:
+    description: 'Backend repo name'
+    default: cord-team/cord-backend
+    required: false
+  project: 
+    description: 'project of the backend repo.'
+    default: sdk-integration-tests
+    required: false
+  test-dir:
+    description: 'Test directory of the integration tests project.'
+    default: ./src/cord/sdk_integration_tests/tests
+    required: false
+  environment:
+    default: DEV
+    required: false
+
+
 runs:
   using: "composite"
 
   steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
       - name: Checkout backend repo
         uses: actions/checkout@v2
         with:
-          repository: ${{ env.BACKEND_REPO }}
+          repository: ${{ inputs.backend-repo }}
           token: ${{ inputs.backend-access-token }}
 
       - name: Setup Poetry environment
         uses: ./.github/actions/setup-poetry-environment
         with:
-          project: ${{ env.PROJECT }}
+          project: ${{ inputs.project }}
           cache-key: sdk-${{ hashFiles('projects/sdk-integration-tests/poetry.lock') }}-1
 
       - name: Setup FFMPEG
@@ -49,7 +58,7 @@ runs:
 
       - name: Get SDK
         run: |
-          cd projects/${{ env.PROJECT }}
+          cd projects/${{ inputs.project }}
           python -m pip install --upgrade pip
           GIT_REPO=${{ github.repositoryUrl }}
           poetry add git+"${GIT_REPO/"git:"/"https:"}"
@@ -58,16 +67,16 @@ runs:
 
       - name: Run tests
         run: |
-          cd projects/${{ env.PROJECT }}
+          cd projects/${{ inputs.project }}
           source .venv/bin/activate
-          export CORD_ENV=${{ env.ENVIRONMENT }}
+          export CORD_ENV=${{ inputs.environment }}
           export PRIVATE_KEY="${{ inputs.private-key }}"
-          python -m pytest ${{ env.TEST_DIR }} --rootdir=${{ env.TEST_DIR }} --verbose --junitxml=${{ env.SDK_TEST_REPORT }}
+          python -m pytest ${{ inputs.test-dir }} --rootdir=${{ inputs.test-dir }} --verbose --junitxml=${{ inputs.test-report-file }}
         shell: bash
 
       - name: Upload report
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: ${{ env.SDK_TEST_REPORT }}
-          path: projects/${{ env.PROJECT }}/${{ env.SDK_TEST_REPORT }}
+          name: ${{ inputs.test-report-file }}
+          path: projects/${{ inputs.project }}/${{ inputs.test-report-file }}

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -1,0 +1,65 @@
+name: 'Run integration tests'
+description: 'Run the integration tests for a given Python version. These tests come from the cord-backend.'
+
+BACKEND_REPO: cord-team/cord-backend
+PROJECT: sdk-integration-tests
+PRIVATE_KEY: ${{ secrets.SDK_TESTS_PRIVATE_KEY }}
+TEST_DIR: ./src/cord/sdk_integration_tests/tests
+ENVIRONMENT: DEV
+
+inputs:
+  python-version:
+    description: 'Python version to use'
+    default: 3.7.12
+    required: false
+  poetry-version:
+    description: 'Poetry version to use'
+    default: 1.1.12
+    required: false
+  test-report-file:
+    description: 'File name to save the test report in'
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+      - name: Checkout backend repo
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.BACKEND_REPO }}
+          token: ${{ secrets.ACCESS_TOKEN }}
+
+      - name: Setup Poetry environment
+        uses: ./.github/actions/setup-poetry-environment
+        with:
+          project: ${{ env.PROJECT }}
+          cache-key: sdk-${{ hashFiles('projects/sdk-integration-tests/poetry.lock') }}-1
+
+      - name: Setup FFMPEG
+        uses: FedericoCarboni/setup-ffmpeg@v1
+
+      - name: Get SDK
+        run: |
+          cd projects/${{ env.PROJECT }}
+          python -m pip install --upgrade pip
+          GIT_REPO=${{ github.repositoryUrl }}
+          poetry add git+"${GIT_REPO/"git:"/"https:"}"
+          poetry install
+        shell: bash
+
+      - name: Run tests
+        run: |
+          cd projects/${{ env.PROJECT }}
+          source .venv/bin/activate
+          export CORD_ENV=${{ env.ENVIRONMENT }}
+          export PRIVATE_KEY="${{ env.PRIVATE_KEY }}"
+          python -m pytest ${{ env.TEST_DIR }} --rootdir=${{ env.TEST_DIR }} --verbose --junitxml=${{ env.SDK_TEST_REPORT }}
+        shell: bash
+
+      - name: Upload report
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: ${{ env.SDK_TEST_REPORT }}
+          path: projects/${{ env.PROJECT }}/${{ env.SDK_TEST_REPORT }}

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -29,6 +29,9 @@ runs:
   using: "composite"
 
   steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
       - name: Checkout backend repo
         uses: actions/checkout@v2
         with:

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -52,7 +52,7 @@ runs:
         with:
           project: ${{ inputs.project }}
           cache-key: sdk-${{ hashFiles('projects/sdk-integration-tests/poetry.lock') }}-1
-          python-version: ${{ inputs.python-version }}
+          python: ${{ inputs.python-version }}
 
       - name: Setup FFMPEG
         uses: FedericoCarboni/setup-ffmpeg@v1

--- a/.github/actions/run-unit-tests/action.yml
+++ b/.github/actions/run-unit-tests/action.yml
@@ -1,0 +1,55 @@
+name: 'Run unit tests'
+description: 'Run the unit tests for a given Python version'
+
+inputs:
+  python-version:
+    description: 'Python version to use'
+    default: 3.7.12
+    required: false
+  poetry-version:
+    description: 'Poetry version to use'
+    default: 1.1.12
+    required: false
+  test-report-file:
+    description: 'File name to save the test report in'
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Set up python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - uses: snok/install-poetry@v1
+        with:
+          version: ${{ inputs.poetry-version }}
+          virtualenvs-in-project: true
+
+      - name: Check cache
+        id: cached-poetry
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: unit-${{ hashFiles('poetry.lock') }}-${{ inputs.python-version }}-1
+
+      - name: Install dependencies
+        if: steps.cached-poetry.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction
+
+      - name: Run tests
+        run: |
+          source .venv/bin/activate
+          python -m pytest tests --verbose --junitxml=${{ inputs.test-report-file }}
+
+      - name: Upload report
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: ${{ inputs.test-report-file }}
+          path: ${{ inputs.test-report-file }}

--- a/.github/actions/run-unit-tests/action.yml
+++ b/.github/actions/run-unit-tests/action.yml
@@ -38,11 +38,13 @@ runs:
       - name: Install dependencies
         if: steps.cached-poetry.outputs.cache-hit != 'true'
         run: poetry install --no-interaction
+        shell: bash
 
       - name: Run tests
         run: |
           source .venv/bin/activate
           python -m pytest tests --verbose --junitxml=${{ inputs.test-report-file }}
+        shell: bash
 
       - name: Upload report
         uses: actions/upload-artifact@v2

--- a/.github/actions/run-unit-tests/action.yml
+++ b/.github/actions/run-unit-tests/action.yml
@@ -18,9 +18,6 @@ runs:
   using: "composite"
 
   steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
       - name: Set up python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -116,7 +116,7 @@ jobs:
         unit-tests-python-3-8, 
         unit-tests-python-3-9, 
         unit-tests-python-3-10, 
-        sdk-tests]
+        tegration-tests-python3-7]
       if: success() || failure()
 
       steps:

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -21,41 +21,11 @@ jobs:
     name: Run unit tests
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
-      - name: Set up python
-        uses: actions/setup-python@v2
+      - name: Run unit tests for Python 3.7
+        uses: actions/run-unit-tests
         with:
-          python-version: ${{ env.PYTHON }}
-
-      - uses: snok/install-poetry@v1
-        with:
-          version: ${{ env.POETRY }}
-          virtualenvs-in-project: true
-
-      - name: Check cache
-        id: cached-poetry
-        uses: actions/cache@v2
-        with:
-          path: .venv
-          key: unit-${{ hashFiles('poetry.lock') }}-${{ env.PYTHON }}-1
-
-      - name: Install dependencies
-        if: steps.cached-poetry.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction
-
-      - name: Run tests
-        run: |
-          source .venv/bin/activate
-          python -m pytest tests --verbose --junitxml=${{ env.UNIT_TEST_REPORT }}
-
-      - name: Upload report
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: ${{ env.UNIT_TEST_REPORT }}
-          path: ${{ env.UNIT_TEST_REPORT }}
+          python-version: 3.7.12
+          test-report-file: ${{ SDK_TEST_REPORT }}
 
   sdk-tests:
     name: Run SDK tests

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -116,7 +116,7 @@ jobs:
         unit-tests-python-3-8, 
         unit-tests-python-3-9, 
         unit-tests-python-3-10, 
-        tegration-tests-python3-7]
+        integration-tests-python3-7]
       if: success() || failure()
 
       steps:

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -22,6 +22,8 @@ concurrency:
 jobs:
   checkout-repo:
     name: Checkout repo for github actions
+    runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-          uses: actions/checkout@v2
+        uses: actions/checkout@v2
 
       - name: Run unit tests for Python 3.7
         uses: ./.github/actions/run-unit-tests

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -91,7 +91,7 @@ jobs:
           test-report-file: ${{ env.UNIT_TEST_REPORT_PYTHON_3_10 }}
 
 
-  integration-tests-python3-7:
+  integration-tests-python-3-7:
     name: Run integration tests
     runs-on: ubuntu-latest
     steps:
@@ -113,7 +113,7 @@ jobs:
         unit-tests-python-3-8, 
         unit-tests-python-3-9, 
         unit-tests-python-3-10, 
-        integration-tests-python3-7]
+        integration-tests-python-3-7]
       if: success() || failure()
 
       steps:

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Run integration tests for Python 3.7
         uses: ./.github/actions/run-integration-tests
         with:
-          python: 3.7.12
+          python-version: 3.7.12
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_7 }}
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
           backend-access-token: ${{ env.BACKEND_ACCESS_TOKEN }}
@@ -104,7 +104,7 @@ jobs:
       - name: Run integration tests for Python 3.8
         uses: ./.github/actions/run-integration-tests
         with:
-          python: 3.8.12
+          python-version: 3.8.12
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_8 }}
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
           backend-access-token: ${{ env.BACKEND_ACCESS_TOKEN }}
@@ -119,7 +119,7 @@ jobs:
       - name: Run integration tests for Python 3.9
         uses: ./.github/actions/run-integration-tests
         with:
-          python: 3.9.10
+          python-version: 3.9.10
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_9 }}
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
           backend-access-token: ${{ env.BACKEND_ACCESS_TOKEN }}
@@ -134,7 +134,7 @@ jobs:
       - name: Run integration tests for Python 3.10
         uses: ./.github/actions/run-integration-tests
         with:
-          python: 3.10.2
+          python-version: 3.10.2
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_10 }}
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
           backend-access-token: ${{ env.BACKEND_ACCESS_TOKEN }}

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -12,12 +12,15 @@ env:
   UNIT_TEST_REPORT_PYTHON_3_8: unit-test-report-python3_8.xml
   UNIT_TEST_REPORT_PYTHON_3_9: unit-test-report-python3_9.xml
   UNIT_TEST_REPORT_PYTHON_3_10: unit-test-report-python3_10.xml
+  
   INTEGRATION_TEST_REPORT_PYTHON_3_6: integration-test-report-python3_6.xml
   INTEGRATION_TEST_REPORT_PYTHON_3_7: integration-test-report-python3_7.xml
   INTEGRATION_TEST_REPORT_PYTHON_3_8: integration-test-report-python3_8.xml
   INTEGRATION_TEST_REPORT_PYTHON_3_9: integration-test-report-python3_9.xml
   INTEGRATION_TEST_REPORT_PYTHON_3_10: integration-test-report-python3_10.xml
   INTEGRATION_TESTS_PRIVATE_KEY: ${{ secrets.SDK_TESTS_PRIVATE_KEY }}
+
+  BACKEND_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
 concurrency:
   group: cord-client-${{ github.ref }}-test
@@ -103,6 +106,7 @@ jobs:
           python-version: 3.7.12
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_7 }}
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
+          backend-access-token: ${{ env.BACKEND_ACCESS_TOKEN }}
 
   publish-test-reports:
       name: Publish test reports

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Run integration tests for Python 3.7
         uses: ./.github/actions/run-integration-tests
         with:
-          python-version: 3.7.12
+          python: 3.7.12
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_7 }}
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
           backend-access-token: ${{ env.BACKEND_ACCESS_TOKEN }}
@@ -104,7 +104,7 @@ jobs:
       - name: Run integration tests for Python 3.8
         uses: ./.github/actions/run-integration-tests
         with:
-          python-version: 3.8.12
+          python: 3.8.12
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_8 }}
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
           backend-access-token: ${{ env.BACKEND_ACCESS_TOKEN }}
@@ -119,7 +119,7 @@ jobs:
       - name: Run integration tests for Python 3.9
         uses: ./.github/actions/run-integration-tests
         with:
-          python-version: 3.9.10
+          python: 3.9.10
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_9 }}
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
           backend-access-token: ${{ env.BACKEND_ACCESS_TOKEN }}
@@ -134,7 +134,7 @@ jobs:
       - name: Run integration tests for Python 3.10
         uses: ./.github/actions/run-integration-tests
         with:
-          python-version: 3.10.2
+          python: 3.10.2
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_10 }}
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
           backend-access-token: ${{ env.BACKEND_ACCESS_TOKEN }}

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -21,6 +21,9 @@ jobs:
     name: Run unit tests
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+          uses: actions/checkout@v2
+
       - name: Run unit tests for Python 3.7
         uses: ./.github/actions/run-unit-tests
         with:

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run unit tests for Python 3.7
-        uses: actions/run-unit-tests
+        uses: ./.github/actions/run-unit-tests
         with:
           python-version: 3.7.12
           test-report-file: ${{ SDK_TEST_REPORT }}

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -7,13 +7,11 @@ on:
   workflow_dispatch:
 
 env:
-  UNIT_TEST_REPORT_PYTHON_3_6: unit-test-report-python3_6.xml
   UNIT_TEST_REPORT_PYTHON_3_7: unit-test-report-python3_7.xml
   UNIT_TEST_REPORT_PYTHON_3_8: unit-test-report-python3_8.xml
   UNIT_TEST_REPORT_PYTHON_3_9: unit-test-report-python3_9.xml
   UNIT_TEST_REPORT_PYTHON_3_10: unit-test-report-python3_10.xml
-  
-  INTEGRATION_TEST_REPORT_PYTHON_3_6: integration-test-report-python3_6.xml
+
   INTEGRATION_TEST_REPORT_PYTHON_3_7: integration-test-report-python3_7.xml
   INTEGRATION_TEST_REPORT_PYTHON_3_8: integration-test-report-python3_8.xml
   INTEGRATION_TEST_REPORT_PYTHON_3_9: integration-test-report-python3_9.xml
@@ -27,19 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit-tests-python-3-6:
-    name: Run unit tests for Python 3.6
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
-      - name: Run unit tests for Python 3.6
-        uses: ./.github/actions/run-unit-tests
-        with:
-          python-version: 3.6.15
-          test-report-file: ${{ env.UNIT_TEST_REPORT_PYTHON_3_6 }}
-
+  # deliberately skipping Python 3.6 because some support for dev dependencies is dropped
   unit-tests-python-3-7:
     name: Run unit tests for Python 3.7
     runs-on: ubuntu-latest
@@ -108,25 +94,67 @@ jobs:
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
           backend-access-token: ${{ env.BACKEND_ACCESS_TOKEN }}
 
+  integration-tests-python-3-8:
+    name: Run integration tests for Python 3.8
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Run integration tests for Python 3.8
+        uses: ./.github/actions/run-integration-tests
+        with:
+          python-version: 3.8.12
+          test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_8 }}
+          private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
+          backend-access-token: ${{ env.BACKEND_ACCESS_TOKEN }}
+
+  integration-tests-python-3-9:
+    name: Run integration tests for Python 3.9
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Run integration tests for Python 3.9
+        uses: ./.github/actions/run-integration-tests
+        with:
+          python-version: 3.9.10
+          test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_9 }}
+          private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
+          backend-access-token: ${{ env.BACKEND_ACCESS_TOKEN }}
+
+  integration-tests-python-3-10:
+    name: Run integration tests for Python 3.10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Run integration tests for Python 3.10
+        uses: ./.github/actions/run-integration-tests
+        with:
+          python-version: 3.10.2
+          test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_10 }}
+          private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
+          backend-access-token: ${{ env.BACKEND_ACCESS_TOKEN }}
+
   publish-test-reports:
       name: Publish test reports
       runs-on: ubuntu-latest
       needs: [
-        unit-tests-python-3-6, 
-        unit-tests-python-3-7, 
+        unit-tests-python-3-7,
         unit-tests-python-3-8, 
         unit-tests-python-3-9, 
         unit-tests-python-3-10, 
-        integration-tests-python-3-7]
+        integration-tests-python-3-7,
+        integration-tests-python-3-8,
+        integration-tests-python-3-9,
+        integration-tests-python-3-10,
+        ]
       if: success() || failure()
 
       steps:
-        - name: Download unit test report Python 3.6
-          uses: actions/download-artifact@v2
-          with:
-            name: ${{ env.UNIT_TEST_REPORT_PYTHON_3_6 }}
-            path: ${{ env.UNIT_TEST_REPORT_PYTHON_3_6 }}
-
         - name: Download unit test report Python 3.7
           uses: actions/download-artifact@v2
           with:
@@ -151,17 +179,29 @@ jobs:
             name: ${{ env.UNIT_TEST_REPORT_PYTHON_3_10 }}
             path: ${{ env.UNIT_TEST_REPORT_PYTHON_3_10 }}
 
-        - name: Download SDK integration test report
+        - name: Download integration test report Python 3.7
           uses: actions/download-artifact@v2
           with:
             name: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_7 }}
             path: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_7 }}
 
-        - name: Publish unit test report Python 3.6
-          uses: EnricoMi/publish-unit-test-result-action@v1
+        - name: Download integration test report Python 3.8
+          uses: actions/download-artifact@v2
           with:
-            files: ${{ env.UNIT_TEST_REPORT_PYTHON_3_6 }}/*.xml
-            check_name: Unit test report
+            name: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_8 }}
+            path: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_8 }}
+
+        - name: Download integration test report Python 3.9
+          uses: actions/download-artifact@v2
+          with:
+            name: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_9 }}
+            path: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_9 }}
+
+        - name: Download integration test report Python 3.10
+          uses: actions/download-artifact@v2
+          with:
+            name: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_10 }}
+            path: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_10 }}
 
         - name: Publish unit test report Python 3.7
           uses: EnricoMi/publish-unit-test-result-action@v1
@@ -187,10 +227,28 @@ jobs:
             files: ${{ env.UNIT_TEST_REPORT_PYTHON_3_10 }}/*.xml
             check_name: Unit test report
 
-        - name: Publish SDK integration test report
+        - name: Publish integration test report Python 3.7
           uses: EnricoMi/publish-unit-test-result-action@v1
           with:
             files: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_7 }}/*.xml
+            check_name: SDK integration test report
+
+        - name: Publish integration test report Python 3.8
+          uses: EnricoMi/publish-unit-test-result-action@v1
+          with:
+            files: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_8 }}/*.xml
+            check_name: SDK integration test report
+
+        - name: Publish integration test report Python 3.9
+          uses: EnricoMi/publish-unit-test-result-action@v1
+          with:
+            files: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_9 }}/*.xml
+            check_name: SDK integration test report
+
+        - name: Publish integration test report Python 3.10
+          uses: EnricoMi/publish-unit-test-result-action@v1
+          with:
+            files: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_10 }}/*.xml
             check_name: SDK integration test report
 
   send-slack-notification:

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -17,6 +17,7 @@ env:
   INTEGRATION_TEST_REPORT_PYTHON_3_8: integration-test-report-python3_8.xml
   INTEGRATION_TEST_REPORT_PYTHON_3_9: integration-test-report-python3_9.xml
   INTEGRATION_TEST_REPORT_PYTHON_3_10: integration-test-report-python3_10.xml
+  INTEGRATION_TESTS_PRIVATE_KEY: ${{ secrets.SDK_TESTS_PRIVATE_KEY }}
 
 concurrency:
   group: cord-client-${{ github.ref }}-test
@@ -101,6 +102,7 @@ jobs:
         with:
           python-version: 3.7.12
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_7 }}
+          private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
 
   publish-test-reports:
       name: Publish test reports

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -90,7 +90,7 @@ jobs:
 
 
   integration-tests-python-3-7:
-    name: Run integration tests
+    name: Run integration tests for Python 3.7
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -20,13 +20,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  checkout-repo:
+    name: Checkout repo for github actions
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
   unit-tests-python-3-6:
     name: Run unit tests for Python 3.6
     runs-on: ubuntu-latest
+    needs: [checkout-repo]
     steps:
     # DENIS: do I need t o repeat this?
-      - name: Checkout repo
-        uses: actions/checkout@v2
 
       - name: Run unit tests for Python 3.6
         uses: ./.github/actions/run-unit-tests
@@ -87,14 +92,14 @@ jobs:
           test-report-file: ${{ env.SDK_TEST_REPORT_PYTHON_3_10 }}
 
 
-  sdk-tests:
+  integration-tests-python3-7:
     name: Run SDK tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Run unit tests for Python 3.10
+      - name: Run integration tests for Python 3.7
         uses: ./.github/actions/run-unit-tests
         with:
           python-version: 3.7.12

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -7,39 +7,36 @@ on:
   workflow_dispatch:
 
 env:
-  UNIT_TEST_REPORT: unit-test-report.xml
+  UNIT_TEST_REPORT_PYTHON_3_6: unit-test-report-python3_6.xml
+  UNIT_TEST_REPORT_PYTHON_3_7: unit-test-report-python3_7.xml
+  UNIT_TEST_REPORT_PYTHON_3_8: unit-test-report-python3_8.xml
+  UNIT_TEST_REPORT_PYTHON_3_9: unit-test-report-python3_9.xml
+  UNIT_TEST_REPORT_PYTHON_3_10: unit-test-report-python3_10.xml
   # DENIS: I mixed up the test reports!
-  SDK_TEST_REPORT_PYTHON_3_6: sdk-test-report-python3_6.xml
-  SDK_TEST_REPORT_PYTHON_3_7: sdk-test-report-python3_7.xml
-  SDK_TEST_REPORT_PYTHON_3_8: sdk-test-report-python3_8.xml
-  SDK_TEST_REPORT_PYTHON_3_9: sdk-test-report-python3_9.xml
-  SDK_TEST_REPORT_PYTHON_3_10: sdk-test-report-python3_10.xml
+  INTEGRATION_TEST_REPORT_PYTHON_3_6: integration-test-report-python3_6.xml
+  INTEGRATION_TEST_REPORT_PYTHON_3_7: integration-test-report-python3_7.xml
+  INTEGRATION_TEST_REPORT_PYTHON_3_8: integration-test-report-python3_8.xml
+  INTEGRATION_TEST_REPORT_PYTHON_3_9: integration-test-report-python3_9.xml
+  INTEGRATION_TEST_REPORT_PYTHON_3_10: integration-test-report-python3_10.xml
 
 concurrency:
   group: cord-client-${{ github.ref }}-test
   cancel-in-progress: true
 
 jobs:
-  checkout-repo:
-    name: Checkout repo for github actions
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
   unit-tests-python-3-6:
     name: Run unit tests for Python 3.6
     runs-on: ubuntu-latest
     needs: [checkout-repo]
     steps:
-    # DENIS: do I need t o repeat this?
+      - name: Checkout repo
+        uses: actions/checkout@v2
 
       - name: Run unit tests for Python 3.6
         uses: ./.github/actions/run-unit-tests
         with:
           python-version: 3.6.15
-          test-report-file: ${{ env.SDK_TEST_REPORT_PYTHON_3_6 }}
+          test-report-file: ${{ env.UNIT_TEST_REPORT_PYTHON_3_6 }}
 
   unit-tests-python-3-7:
     name: Run unit tests for Python 3.7
@@ -52,7 +49,7 @@ jobs:
         uses: ./.github/actions/run-unit-tests
         with:
           python-version: 3.7.12
-          test-report-file: ${{ env.SDK_TEST_REPORT_PYTHON_3_7 }}
+          test-report-file: ${{ env.UNIT_TEST_REPORT_PYTHON_3_7 }}
 
   unit-tests-python-3-8:
     name: Run unit tests for Python 3.8
@@ -65,7 +62,7 @@ jobs:
         uses: ./.github/actions/run-unit-tests
         with:
           python-version: 3.8.12
-          test-report-file: ${{ env.SDK_TEST_REPORT_PYTHON_3_8 }}
+          test-report-file: ${{ env.UNIT_TEST_REPORT_PYTHON_3_8 }}
 
   unit-tests-python-3-9:
     name: Run unit tests for Python 3.9
@@ -78,7 +75,7 @@ jobs:
         uses: ./.github/actions/run-unit-tests
         with:
           python-version: 3.9.10
-          test-report-file: ${{ env.SDK_TEST_REPORT_PYTHON_3_9 }}
+          test-report-file: ${{ env.UNIT_TEST_REPORT_PYTHON_3_9 }}
 
   unit-tests-python-3-10:
     name: Run unit tests for Python 3.10
@@ -91,21 +88,21 @@ jobs:
         uses: ./.github/actions/run-unit-tests
         with:
           python-version: 3.10.2
-          test-report-file: ${{ env.SDK_TEST_REPORT_PYTHON_3_10 }}
+          test-report-file: ${{ env.UNIT_TEST_REPORT_PYTHON_3_10 }}
 
 
   integration-tests-python3-7:
-    name: Run SDK tests
+    name: Run integration tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
 
       - name: Run integration tests for Python 3.7
-        uses: ./.github/actions/run-unit-tests
+        uses: ./.github/actions/run-integration-tests
         with:
           python-version: 3.7.12
-          test-report-file: ${{ env.UNIT_TEST_REPORT }}
+          test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_7 }}
 
   publish-test-reports:
       name: Publish test reports
@@ -153,8 +150,8 @@ jobs:
         - name: Download SDK integration test report
           uses: actions/download-artifact@v2
           with:
-            name: ${{ env.SDK_TEST_REPORT }}
-            path: ${{ env.SDK_TEST_REPORT }}
+            name: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_7 }}
+            path: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_7 }}
 
         - name: Publish unit test report Python 3.6
           uses: EnricoMi/publish-unit-test-result-action@v1
@@ -189,7 +186,7 @@ jobs:
         - name: Publish SDK integration test report
           uses: EnricoMi/publish-unit-test-result-action@v1
           with:
-            files: ${{ env.SDK_TEST_REPORT }}/*.xml
+            files: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_7 }}/*.xml
             check_name: SDK integration test report
 
   send-slack-notification:

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -10,15 +10,32 @@ env:
   PYTHON: 3.7.12
   POETRY: 1.1.12
   UNIT_TEST_REPORT: unit-test-report.xml
-  SDK_TEST_REPORT: sdk-test-report.xml
+  SDK_TEST_REPORT_PYTHON_3_6: sdk-test-report-python3_6.xml
+  SDK_TEST_REPORT_PYTHON_3_7: sdk-test-report-python3_7.xml
+  SDK_TEST_REPORT_PYTHON_3_8: sdk-test-report-python3_8.xml
+  SDK_TEST_REPORT_PYTHON_3_9: sdk-test-report-python3_9.xml
+  SDK_TEST_REPORT_PYTHON_3_10: sdk-test-report-python3_10.xml
 
 concurrency:
   group: cord-client-${{ github.ref }}-test
   cancel-in-progress: true
 
 jobs:
-  unit-tests:
-    name: Run unit tests
+  unit-tests-python-3-6:
+    name: Run unit tests for Python 3.6
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Run unit tests for Python 3.6
+        uses: ./.github/actions/run-unit-tests
+        with:
+          python-version: 3.6.15
+          test-report-file: ${{ env.SDK_TEST_REPORT_PYTHON_3_6 }}
+
+  unit-tests-python-3-7:
+    name: Run unit tests for Python 3.7
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -28,7 +45,47 @@ jobs:
         uses: ./.github/actions/run-unit-tests
         with:
           python-version: 3.7.12
-          test-report-file: ${{ env.SDK_TEST_REPORT }}
+          test-report-file: ${{ env.SDK_TEST_REPORT_PYTHON_3_7 }}
+
+  unit-tests-python-3-8:
+    name: Run unit tests for Python 3.8
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Run unit tests for Python 3.8
+        uses: ./.github/actions/run-unit-tests
+        with:
+          python-version: 3.8.12
+          test-report-file: ${{ env.SDK_TEST_REPORT_PYTHON_3_8 }}
+
+  unit-tests-python-3-9:
+    name: Run unit tests for Python 3.9
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Run unit tests for Python 3.9
+        uses: ./.github/actions/run-unit-tests
+        with:
+          python-version: 3.9.10
+          test-report-file: ${{ env.SDK_TEST_REPORT_PYTHON_3_9 }}
+
+  unit-tests-python-3-10:
+    name: Run unit tests for Python 3.10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Run unit tests for Python 3.10
+        uses: ./.github/actions/run-unit-tests
+        with:
+          python-version: 3.10.2
+          test-report-file: ${{ env.SDK_TEST_REPORT_PYTHON_3_10 }}
+
 
   sdk-tests:
     name: Run SDK tests
@@ -81,15 +138,45 @@ jobs:
   publish-test-reports:
       name: Publish test reports
       runs-on: ubuntu-latest
-      needs: [unit-tests, sdk-tests]
+      needs: [
+        unit-tests-python-3-6, 
+        unit-tests-python-3-7, 
+        unit-tests-python-3-8, 
+        unit-tests-python-3-9, 
+        unit-tests-python-3-10, 
+        sdk-tests]
       if: success() || failure()
 
       steps:
-        - name: Download unit test report
+        - name: Download unit test report Python 3.6
           uses: actions/download-artifact@v2
           with:
-            name: ${{ env.UNIT_TEST_REPORT }}
-            path: ${{ env.UNIT_TEST_REPORT }}
+            name: ${{ env.UNIT_TEST_REPORT_PYTHON_3_6 }}
+            path: ${{ env.UNIT_TEST_REPORT_PYTHON_3_6 }}
+
+        - name: Download unit test report Python 3.7
+          uses: actions/download-artifact@v2
+          with:
+            name: ${{ env.UNIT_TEST_REPORT_PYTHON_3_7 }}
+            path: ${{ env.UNIT_TEST_REPORT_PYTHON_3_7 }}
+
+        - name: Download unit test report Python 3.8
+          uses: actions/download-artifact@v2
+          with:
+            name: ${{ env.UNIT_TEST_REPORT_PYTHON_3_8 }}
+            path: ${{ env.UNIT_TEST_REPORT_PYTHON_3_8 }}
+
+        - name: Download unit test report Python 3.9
+          uses: actions/download-artifact@v2
+          with:
+            name: ${{ env.UNIT_TEST_REPORT_PYTHON_3_9 }}
+            path: ${{ env.UNIT_TEST_REPORT_PYTHON_3_9 }}
+
+        - name: Download unit test report Python 3.10
+          uses: actions/download-artifact@v2
+          with:
+            name: ${{ env.UNIT_TEST_REPORT_PYTHON_3_10 }}
+            path: ${{ env.UNIT_TEST_REPORT_PYTHON_3_10 }}
 
         - name: Download SDK integration test report
           uses: actions/download-artifact@v2
@@ -97,10 +184,34 @@ jobs:
             name: ${{ env.SDK_TEST_REPORT }}
             path: ${{ env.SDK_TEST_REPORT }}
 
-        - name: Publish unit test report
+        - name: Publish unit test report Python 3.6
           uses: EnricoMi/publish-unit-test-result-action@v1
           with:
-            files: ${{ env.UNIT_TEST_REPORT }}/*.xml
+            files: ${{ env.UNIT_TEST_REPORT_PYTHON_3_6 }}/*.xml
+            check_name: Unit test report
+
+        - name: Publish unit test report Python 3.7
+          uses: EnricoMi/publish-unit-test-result-action@v1
+          with:
+            files: ${{ env.UNIT_TEST_REPORT_PYTHON_3_7 }}/*.xml
+            check_name: Unit test report
+
+        - name: Publish unit test report Python 3.8
+          uses: EnricoMi/publish-unit-test-result-action@v1
+          with:
+            files: ${{ env.UNIT_TEST_REPORT_PYTHON_3_8 }}/*.xml
+            check_name: Unit test report
+
+        - name: Publish unit test report Python 3.9
+          uses: EnricoMi/publish-unit-test-result-action@v1
+          with:
+            files: ${{ env.UNIT_TEST_REPORT_PYTHON_3_9 }}/*.xml
+            check_name: Unit test report
+
+        - name: Publish unit test report Python 3.10
+          uses: EnricoMi/publish-unit-test-result-action@v1
+          with:
+            files: ${{ env.UNIT_TEST_REPORT_PYTHON_3_10 }}/*.xml
             check_name: Unit test report
 
         - name: Publish SDK integration test report

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -12,7 +12,6 @@ env:
   UNIT_TEST_REPORT_PYTHON_3_8: unit-test-report-python3_8.xml
   UNIT_TEST_REPORT_PYTHON_3_9: unit-test-report-python3_9.xml
   UNIT_TEST_REPORT_PYTHON_3_10: unit-test-report-python3_10.xml
-  # DENIS: I mixed up the test reports!
   INTEGRATION_TEST_REPORT_PYTHON_3_6: integration-test-report-python3_6.xml
   INTEGRATION_TEST_REPORT_PYTHON_3_7: integration-test-report-python3_7.xml
   INTEGRATION_TEST_REPORT_PYTHON_3_8: integration-test-report-python3_8.xml
@@ -27,7 +26,6 @@ jobs:
   unit-tests-python-3-6:
     name: Run unit tests for Python 3.6
     runs-on: ubuntu-latest
-    needs: [checkout-repo]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -25,7 +25,7 @@ jobs:
         uses: ./.github/actions/run-unit-tests
         with:
           python-version: 3.7.12
-          test-report-file: ${{ SDK_TEST_REPORT }}
+          test-report-file: ${{ env.SDK_TEST_REPORT }}
 
   sdk-tests:
     name: Run SDK tests

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -7,9 +7,8 @@ on:
   workflow_dispatch:
 
 env:
-  PYTHON: 3.7.12
-  POETRY: 1.1.12
   UNIT_TEST_REPORT: unit-test-report.xml
+  # DENIS: I mixed up the test reports!
   SDK_TEST_REPORT_PYTHON_3_6: sdk-test-report-python3_6.xml
   SDK_TEST_REPORT_PYTHON_3_7: sdk-test-report-python3_7.xml
   SDK_TEST_REPORT_PYTHON_3_8: sdk-test-report-python3_8.xml
@@ -25,6 +24,7 @@ jobs:
     name: Run unit tests for Python 3.6
     runs-on: ubuntu-latest
     steps:
+    # DENIS: do I need t o repeat this?
       - name: Checkout repo
         uses: actions/checkout@v2
 
@@ -90,50 +90,15 @@ jobs:
   sdk-tests:
     name: Run SDK tests
     runs-on: ubuntu-latest
-    env:
-      BACKEND_REPO: cord-team/cord-backend
-      PROJECT: sdk-integration-tests
-      PRIVATE_KEY: ${{ secrets.SDK_TESTS_PRIVATE_KEY }}
-      TEST_DIR: ./src/cord/sdk_integration_tests/tests
-      ENVIRONMENT: DEV
     steps:
-      - name: Checkout backend repo
+      - name: Checkout repo
         uses: actions/checkout@v2
+
+      - name: Run unit tests for Python 3.10
+        uses: ./.github/actions/run-unit-tests
         with:
-          repository: ${{ env.BACKEND_REPO }}
-          token: ${{ secrets.ACCESS_TOKEN }}
-
-      - name: Setup Poetry environment
-        uses: ./.github/actions/setup-poetry-environment
-        with:
-          project: ${{ env.PROJECT }}
-          cache-key: sdk-${{ hashFiles('projects/sdk-integration-tests/poetry.lock') }}-1
-
-      - name: Setup FFMPEG
-        uses: FedericoCarboni/setup-ffmpeg@v1
-
-      - name: Get SDK
-        run: |
-          cd projects/${{ env.PROJECT }}
-          python -m pip install --upgrade pip
-          GIT_REPO=${{ github.repositoryUrl }}
-          poetry add git+"${GIT_REPO/"git:"/"https:"}"
-          poetry install
-
-      - name: Run tests
-        run: |
-          cd projects/${{ env.PROJECT }}
-          source .venv/bin/activate
-          export CORD_ENV=${{ env.ENVIRONMENT }}
-          export PRIVATE_KEY="${{ env.PRIVATE_KEY }}"
-          python -m pytest ${{ env.TEST_DIR }} --rootdir=${{ env.TEST_DIR }} --verbose --junitxml=${{ env.SDK_TEST_REPORT }}
-
-      - name: Upload report
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: ${{ env.SDK_TEST_REPORT }}
-          path: projects/${{ env.PROJECT }}/${{ env.SDK_TEST_REPORT }}
+          python-version: 3.7.12
+          test-report-file: ${{ env.UNIT_TEST_REPORT }}
 
   publish-test-reports:
       name: Publish test reports

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -21,7 +21,7 @@ jobs:
     name: Run unit tests
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout repo
           uses: actions/checkout@v2
 
       - name: Run unit tests for Python 3.7


### PR DESCRIPTION
Now on merge all the unit and integration tests will be run for stages 3.7-3.10.

Due to some missing support from dependencies for the deprecated 3.6 version, we cannot run tests there. 

[this](https://github.com/encord-team/encord-client-python/runs/5378009785?check_suite_focus=true) is an example of a job that runs with the latest configurations. It shows catches the errors that slipped through well. 

Annoying it also reports some noise because if the tests fail, we cannot run the last step of the action which is this:

```yml
      - name: Checkout current repo for post cleanup
        uses: actions/checkout@v2
```
and therefore the "Post Run" GitHub job doesn't work. If @rizwancordtech has some ideas here that would be great, otherwise this is good to merge from my side.