### PR TITLE
Remove isort from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,3 +2,5 @@
 # blame. These revisions are considered "unimportant" in that they are unlikely
 # to be what you are interested in when blaming.
 
+# Apply isort
+8de122a3f511350ac47c8fc0aee1fb4a4f6d5c39


### PR DESCRIPTION
Tiny PR to make sure we don't have the last git blame point to this isort introduction.