### PR TITLE
Automation models as an enum.

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -688,10 +688,10 @@ class EncordClientProject(EncordClient):
 
     def create_model_row(
         self,
-        title=None,
-        description=None,
-        features=None,
-        model=None,
+        title: str,
+        description: str,
+        features: List[str],
+        model: Union[AutomationModels, str],
     ) -> str:
         """
         Create a model row.
@@ -699,9 +699,11 @@ class EncordClientProject(EncordClient):
         Args:
             title: Model title.
             description: Model description.
-            features: List of feature feature uid's (hashes) to be included in the model.
-            model: Model (resnet18, resnet34, resnet50,
-                resnet101, resnet152, vgg16, vgg19, yolov5, faster_rcnn, mask_rcnn).
+            features: List of <feature_node_hashes> which is id's of ontology objects
+                      or classifications to be included in the model.
+            model: the model type to be used.
+                   For backwards compatibility purposes, we continuously allow strings
+                   corresponding to the values of the :class:`.AutomationModels` Enum.
 
         Returns:
             The uid of the added model row.

--- a/encord/client.py
+++ b/encord/client.py
@@ -47,7 +47,7 @@ import dateutil
 
 import encord.exceptions
 from encord.configs import ENCORD_DOMAIN, Config, EncordConfig
-from encord.constants.model import AUTOMATION_MODELS
+from encord.constants.model import AutomationModels
 from encord.constants.string_constants import *
 from encord.http.querier import Querier
 from encord.http.utils import upload_to_signed_url_list

--- a/encord/client.py
+++ b/encord/client.py
@@ -47,7 +47,7 @@ import dateutil
 
 import encord.exceptions
 from encord.configs import ENCORD_DOMAIN, Config, EncordConfig
-from encord.constants.model import *
+from encord.constants.model import AUTOMATION_MODELS
 from encord.constants.string_constants import *
 from encord.http.querier import Querier
 from encord.http.utils import upload_to_signed_url_list
@@ -720,18 +720,7 @@ class EncordClientProject(EncordClient):
                 message="You must pass a list of feature uid's (hashes) to create a model row."
             )
 
-        if model is None or model not in [
-            RESNET18,
-            RESNET34,
-            RESNET50,
-            RESNET101,
-            RESNET152,
-            VGG16,
-            VGG19,
-            YOLOV5,
-            FASTER_RCNN,
-            MASK_RCNN,
-        ]:
+        if model is None or not AUTOMATION_MODELS.has_value(model):
             raise encord.exceptions.EncordException(
                 message="You must pass a model (resnet18, resnet34, resnet50, resnet101, resnet152, vgg16, vgg19, "
                 "yolov5, faster_rcnn, mask_rcnn) to create a model row."

--- a/encord/client.py
+++ b/encord/client.py
@@ -722,10 +722,13 @@ class EncordClientProject(EncordClient):
                 message="You must pass a list of feature uid's (hashes) to create a model row."
             )
 
-        if model is None or not AUTOMATION_MODELS.has_value(model):
+        if isinstance(model, AutomationModels):
+            model = model.value
+
+        elif model is None or not AutomationModels.has_value(model):  # Backward compatibility with string options
             raise encord.exceptions.EncordException(
-                message="You must pass a model (resnet18, resnet34, resnet50, resnet101, resnet152, vgg16, vgg19, "
-                "yolov5, faster_rcnn, mask_rcnn) to create a model row."
+                message="You must pass a model from the `encord.constants.model.AutomationModels` Enum to create a "
+                "model row."
             )
 
         model_row = ModelRow(

--- a/encord/constants/model.py
+++ b/encord/constants/model.py
@@ -69,7 +69,7 @@ class AutomationModels(Enum):
         """
         return [AutomationModels.MASK_RCNN]
 
-    @staticmethod
+    @classmethod
     def has_value(cls, value) -> bool:
         return value in cls._value2member_map_
 

--- a/encord/constants/model.py
+++ b/encord/constants/model.py
@@ -70,8 +70,8 @@ class AutomationModels(Enum):
         return [AutomationModels.MASK_RCNN]
 
     @staticmethod
-    def has_value(cls, value):
-        return value in set(v for v in cls._value2member_map_)
+    def has_value(cls, value) -> bool:
+        return value in cls._value2member_map_
 
 
 # For backward compatibility

--- a/encord/constants/model.py
+++ b/encord/constants/model.py
@@ -19,7 +19,7 @@ from enum import Enum
 from typing import List
 
 
-class AUTOMATION_MODELS(Enum):
+class AutomationModels(Enum):
     FAST_AI = "fast_ai"
     RESNET18 = "resnet18"
     RESNET34 = "resnet34"
@@ -33,7 +33,7 @@ class AUTOMATION_MODELS(Enum):
     MASK_RCNN = "mask_rcnn"
 
     @staticmethod
-    def classification_options() -> List[AUTOMATION_MODELS]:
+    def classification_options() -> List[AutomationModels]:
         """
         Returns:
             Model types that can be used for frame-level classifications.
@@ -41,33 +41,33 @@ class AUTOMATION_MODELS(Enum):
             the ``classification`` part of the ontology.
         """
         return [
-            AUTOMATION_MODELS.FAST_AI,
-            AUTOMATION_MODELS.RESNET18,
-            AUTOMATION_MODELS.RESNET34,
-            AUTOMATION_MODELS.RESNET50,
-            AUTOMATION_MODELS.RESNET101,
-            AUTOMATION_MODELS.RESNET152,
-            AUTOMATION_MODELS.VGG16,
-            AUTOMATION_MODELS.VGG19,
+            AutomationModels.FAST_AI,
+            AutomationModels.RESNET18,
+            AutomationModels.RESNET34,
+            AutomationModels.RESNET50,
+            AutomationModels.RESNET101,
+            AutomationModels.RESNET152,
+            AutomationModels.VGG16,
+            AutomationModels.VGG19,
         ]
 
     @staticmethod
-    def object_detection_options() -> List[AUTOMATION_MODELS]:
+    def object_detection_options() -> List[AutomationModels]:
         """
         Returns:
             Model types that can be used with bounding_box type
             ``<feature_node_hashes>`` from the ``objects`` part of the project ontology.
         """
-        return [AUTOMATION_MODELS.YOLOV5, AUTOMATION_MODELS.FASTER_RCNN]
+        return [AutomationModels.YOLOV5, AutomationModels.FASTER_RCNN]
 
     @staticmethod
-    def instance_segmentation_options() -> List[AUTOMATION_MODELS]:
+    def instance_segmentation_options() -> List[AutomationModels]:
         """
         Returns:
             Model types that can be used with polygon type ``<feature_node_hashes>``
             from the ``objects`` part of the project ontology.
         """
-        return [AUTOMATION_MODELS.MASK_RCNN]
+        return [AutomationModels.MASK_RCNN]
 
     @staticmethod
     def has_value(cls, value):
@@ -75,14 +75,14 @@ class AUTOMATION_MODELS(Enum):
 
 
 # For backward compatibility
-FAST_AI = AUTOMATION_MODELS.FAST_AI
-RESNET18 = AUTOMATION_MODELS.RESNET18
-RESNET34 = AUTOMATION_MODELS.RESNET34
-RESNET50 = AUTOMATION_MODELS.RESNET50
-RESNET101 = AUTOMATION_MODELS.RESNET101
-RESNET152 = AUTOMATION_MODELS.RESNET152
-VGG16 = AUTOMATION_MODELS.VGG16
-VGG19 = AUTOMATION_MODELS.VGG19
-YOLOV5 = AUTOMATION_MODELS.YOLOV5
-FASTER_RCNN = AUTOMATION_MODELS.FASTER_RCNN
-MASK_RCNN = AUTOMATION_MODELS.MASK_RCNN
+FAST_AI = AutomationModels.FAST_AI.value
+RESNET18 = AutomationModels.RESNET18.value
+RESNET34 = AutomationModels.RESNET34.value
+RESNET50 = AutomationModels.RESNET50.value
+RESNET101 = AutomationModels.RESNET101.value
+RESNET152 = AutomationModels.RESNET152.value
+VGG16 = AutomationModels.VGG16.value
+VGG19 = AutomationModels.VGG19.value
+YOLOV5 = AutomationModels.YOLOV5.value
+FASTER_RCNN = AutomationModels.FASTER_RCNN.value
+MASK_RCNN = AutomationModels.MASK_RCNN.value

--- a/encord/constants/model.py
+++ b/encord/constants/model.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import List
+from typing import Set
 
 
 class AutomationModels(Enum):
@@ -33,14 +33,14 @@ class AutomationModels(Enum):
     MASK_RCNN = "mask_rcnn"
 
     @staticmethod
-    def classification_options() -> List[AutomationModels]:
+    def classification_options() -> Set[AutomationModels]:
         """
         Returns:
             Model types that can be used for frame-level classifications.
             That is, model types that can be used with ``<feature_node_hash>``es from
             the ``classification`` part of the ontology.
         """
-        return [
+        return {
             AutomationModels.FAST_AI,
             AutomationModels.RESNET18,
             AutomationModels.RESNET34,
@@ -49,25 +49,25 @@ class AutomationModels(Enum):
             AutomationModels.RESNET152,
             AutomationModels.VGG16,
             AutomationModels.VGG19,
-        ]
+        }
 
     @staticmethod
-    def object_detection_options() -> List[AutomationModels]:
+    def object_detection_options() -> Set[AutomationModels]:
         """
         Returns:
             Model types that can be used with bounding_box type
             ``<feature_node_hashes>`` from the ``objects`` part of the project ontology.
         """
-        return [AutomationModels.YOLOV5, AutomationModels.FASTER_RCNN]
+        return {AutomationModels.YOLOV5, AutomationModels.FASTER_RCNN}
 
     @staticmethod
-    def instance_segmentation_options() -> List[AutomationModels]:
+    def instance_segmentation_options() -> Set[AutomationModels]:
         """
         Returns:
             Model types that can be used with polygon type ``<feature_node_hashes>``
             from the ``objects`` part of the project ontology.
         """
-        return [AutomationModels.MASK_RCNN]
+        return {AutomationModels.MASK_RCNN}
 
     @classmethod
     def has_value(cls, value) -> bool:

--- a/encord/constants/model.py
+++ b/encord/constants/model.py
@@ -13,14 +13,76 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-FAST_AI = "fast_ai"
-RESNET18 = "resnet18"
-RESNET34 = "resnet34"
-RESNET50 = "resnet50"
-RESNET101 = "resnet101"
-RESNET152 = "resnet152"
-VGG16 = "vgg16"
-VGG19 = "vgg19"
-YOLOV5 = "yolov5"
-FASTER_RCNN = "faster_rcnn"
-MASK_RCNN = "mask_rcnn"
+from __future__ import annotations
+
+from enum import Enum
+from typing import List
+
+
+class AUTOMATION_MODELS(Enum):
+    FAST_AI = "fast_ai"
+    RESNET18 = "resnet18"
+    RESNET34 = "resnet34"
+    RESNET50 = "resnet50"
+    RESNET101 = "resnet101"
+    RESNET152 = "resnet152"
+    VGG16 = "vgg16"
+    VGG19 = "vgg19"
+    YOLOV5 = "yolov5"
+    FASTER_RCNN = "faster_rcnn"
+    MASK_RCNN = "mask_rcnn"
+
+    @staticmethod
+    def classification_options() -> List[AUTOMATION_MODELS]:
+        """
+        Returns:
+            Model types that can be used for frame-level classifications.
+            That is, model types that can be used with ``<feature_node_hash>``es from
+            the ``classification`` part of the ontology.
+        """
+        return [
+            AUTOMATION_MODELS.FAST_AI,
+            AUTOMATION_MODELS.RESNET18,
+            AUTOMATION_MODELS.RESNET34,
+            AUTOMATION_MODELS.RESNET50,
+            AUTOMATION_MODELS.RESNET101,
+            AUTOMATION_MODELS.RESNET152,
+            AUTOMATION_MODELS.VGG16,
+            AUTOMATION_MODELS.VGG19,
+        ]
+
+    @staticmethod
+    def object_detection_options() -> List[AUTOMATION_MODELS]:
+        """
+        Returns:
+            Model types that can be used with bounding_box type
+            ``<feature_node_hashes>`` from the ``objects`` part of the project ontology.
+        """
+        return [AUTOMATION_MODELS.YOLOV5, AUTOMATION_MODELS.FASTER_RCNN]
+
+    @staticmethod
+    def instance_segmentation_options() -> List[AUTOMATION_MODELS]:
+        """
+        Returns:
+            Model types that can be used with polygon type ``<feature_node_hashes>``
+            from the ``objects`` part of the project ontology.
+        """
+        return [AUTOMATION_MODELS.MASK_RCNN]
+
+    @staticmethod
+    def has_value(cls, value):
+        return value in set(v for v in cls._value2member_map_)
+
+
+# For backward compatibility
+FAST_AI = AUTOMATION_MODELS.FAST_AI
+RESNET18 = AUTOMATION_MODELS.RESNET18
+RESNET34 = AUTOMATION_MODELS.RESNET34
+RESNET50 = AUTOMATION_MODELS.RESNET50
+RESNET101 = AUTOMATION_MODELS.RESNET101
+RESNET152 = AUTOMATION_MODELS.RESNET152
+VGG16 = AUTOMATION_MODELS.VGG16
+VGG19 = AUTOMATION_MODELS.VGG19
+YOLOV5 = AUTOMATION_MODELS.YOLOV5
+FASTER_RCNN = AUTOMATION_MODELS.FASTER_RCNN
+MASK_RCNN = AUTOMATION_MODELS.MASK_RCNN

--- a/encord/constants/model_weights.py
+++ b/encord/constants/model_weights.py
@@ -13,14 +13,16 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from encord.constants.model import FAST_AI, FASTER_RCNN, MASK_RCNN, YOLOV5
+from encord.constants.model import AUTOMATION_MODELS
 from encord.orm.model import ModelTrainingWeights
 
-fast_ai = ModelTrainingWeights({"model": FAST_AI, "training_config_link": "", "training_weights_link": ""})
+fast_ai = ModelTrainingWeights(
+    {"model": AUTOMATION_MODELS.FAST_AI, "training_config_link": "", "training_weights_link": ""}
+)
 
 yolov5x = ModelTrainingWeights(
     {
-        "model": YOLOV5,
+        "model": AUTOMATION_MODELS.YOLOV5,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/yolov5x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/yolov5x.pt",
     }
@@ -28,7 +30,7 @@ yolov5x = ModelTrainingWeights(
 
 yolov5s = ModelTrainingWeights(
     {
-        "model": YOLOV5,
+        "model": AUTOMATION_MODELS.YOLOV5,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/yolov5s.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/yolov5s.pt",
     }
@@ -36,7 +38,7 @@ yolov5s = ModelTrainingWeights(
 
 faster_rcnn_R_50_C4_1x = ModelTrainingWeights(
     {
-        "model": FASTER_RCNN,
+        "model": AUTOMATION_MODELS.FASTER_RCNN,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_50_C4_1x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_721ade.pkl",
     }
@@ -44,7 +46,7 @@ faster_rcnn_R_50_C4_1x = ModelTrainingWeights(
 
 faster_rcnn_R_50_DC5_1x = ModelTrainingWeights(
     {
-        "model": FASTER_RCNN,
+        "model": AUTOMATION_MODELS.FASTER_RCNN,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_50_DC5_1x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_51d356.pkl",
     }
@@ -52,7 +54,7 @@ faster_rcnn_R_50_DC5_1x = ModelTrainingWeights(
 
 faster_rcnn_R_50_FPN_1x = ModelTrainingWeights(
     {
-        "model": FASTER_RCNN,
+        "model": AUTOMATION_MODELS.FASTER_RCNN,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_50_FPN_1x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_b275ba.pkl",
     }
@@ -60,7 +62,7 @@ faster_rcnn_R_50_FPN_1x = ModelTrainingWeights(
 
 faster_rcnn_R_50_C4_3x = ModelTrainingWeights(
     {
-        "model": FASTER_RCNN,
+        "model": AUTOMATION_MODELS.FASTER_RCNN,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_50_C4_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_f97cb7.pkl",
     }
@@ -68,7 +70,7 @@ faster_rcnn_R_50_C4_3x = ModelTrainingWeights(
 
 faster_rcnn_R_50_DC5_3x = ModelTrainingWeights(
     {
-        "model": FASTER_RCNN,
+        "model": AUTOMATION_MODELS.FASTER_RCNN,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_50_DC5_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_68d202.pkl",
     }
@@ -76,7 +78,7 @@ faster_rcnn_R_50_DC5_3x = ModelTrainingWeights(
 
 faster_rcnn_R_50_FPN_3x = ModelTrainingWeights(
     {
-        "model": FASTER_RCNN,
+        "model": AUTOMATION_MODELS.FASTER_RCNN,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_50_FPN_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_280758.pkl",
     }
@@ -84,7 +86,7 @@ faster_rcnn_R_50_FPN_3x = ModelTrainingWeights(
 
 faster_rcnn_R_101_C4_3x = ModelTrainingWeights(
     {
-        "model": FASTER_RCNN,
+        "model": AUTOMATION_MODELS.FASTER_RCNN,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_101_C4_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_298dad.pkl",
     }
@@ -92,7 +94,7 @@ faster_rcnn_R_101_C4_3x = ModelTrainingWeights(
 
 faster_rcnn_R_101_DC5_3x = ModelTrainingWeights(
     {
-        "model": FASTER_RCNN,
+        "model": AUTOMATION_MODELS.FASTER_RCNN,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_101_DC5_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_3e0943.pkl",
     }
@@ -100,7 +102,7 @@ faster_rcnn_R_101_DC5_3x = ModelTrainingWeights(
 
 faster_rcnn_R_101_FPN_3x = ModelTrainingWeights(
     {
-        "model": FASTER_RCNN,
+        "model": AUTOMATION_MODELS.FASTER_RCNN,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_101_FPN_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_f6e8b1.pkl",
     }
@@ -108,7 +110,7 @@ faster_rcnn_R_101_FPN_3x = ModelTrainingWeights(
 
 faster_rcnn_X_101_32x8d_FPN_3x = ModelTrainingWeights(
     {
-        "model": FASTER_RCNN,
+        "model": AUTOMATION_MODELS.FASTER_RCNN,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_X_101_32x8d_FPN_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_68b088.pkl",
     }
@@ -116,7 +118,7 @@ faster_rcnn_X_101_32x8d_FPN_3x = ModelTrainingWeights(
 
 mask_rcnn_X_101_32x8d_FPN_3x = ModelTrainingWeights(
     {
-        "model": MASK_RCNN,
+        "model": AUTOMATION_MODELS.MASK_RCNN,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/mask_rcnn_X_101_32x8d_FPN_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/ b.pkl",
     }
@@ -124,7 +126,7 @@ mask_rcnn_X_101_32x8d_FPN_3x = ModelTrainingWeights(
 
 mask_rcnn_R_50_C4_1x = ModelTrainingWeights(
     {
-        "model": MASK_RCNN,
+        "model": AUTOMATION_MODELS.MASK_RCNN,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/mask_rcnn_R_50_C4_1x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_9243eb.pkl",
     }
@@ -132,7 +134,7 @@ mask_rcnn_R_50_C4_1x = ModelTrainingWeights(
 
 mask_rcnn_R_50_C4_3x = ModelTrainingWeights(
     {
-        "model": MASK_RCNN,
+        "model": AUTOMATION_MODELS.MASK_RCNN,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/mask_rcnn_R_50_C4_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_4ce675.pkl",
     }
@@ -140,7 +142,7 @@ mask_rcnn_R_50_C4_3x = ModelTrainingWeights(
 
 mask_rcnn_R_101_FPN_3x = ModelTrainingWeights(
     {
-        "model": MASK_RCNN,
+        "model": AUTOMATION_MODELS.MASK_RCNN,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/mask_rcnn_R_101_FPN_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_a3ec72.pkl",
     }

--- a/encord/constants/model_weights.py
+++ b/encord/constants/model_weights.py
@@ -13,16 +13,16 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from encord.constants.model import AUTOMATION_MODELS
+from encord.constants.model import AutomationModels
 from encord.orm.model import ModelTrainingWeights
 
 fast_ai = ModelTrainingWeights(
-    {"model": AUTOMATION_MODELS.FAST_AI, "training_config_link": "", "training_weights_link": ""}
+    {"model": AutomationModels.FAST_AI.value, "training_config_link": "", "training_weights_link": ""}
 )
 
 yolov5x = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.YOLOV5,
+        "model": AutomationModels.YOLOV5.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/yolov5x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/yolov5x.pt",
     }
@@ -30,7 +30,7 @@ yolov5x = ModelTrainingWeights(
 
 yolov5s = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.YOLOV5,
+        "model": AutomationModels.YOLOV5.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/yolov5s.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/yolov5s.pt",
     }
@@ -38,7 +38,7 @@ yolov5s = ModelTrainingWeights(
 
 faster_rcnn_R_50_C4_1x = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.FASTER_RCNN,
+        "model": AutomationModels.FASTER_RCNN.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_50_C4_1x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_721ade.pkl",
     }
@@ -46,7 +46,7 @@ faster_rcnn_R_50_C4_1x = ModelTrainingWeights(
 
 faster_rcnn_R_50_DC5_1x = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.FASTER_RCNN,
+        "model": AutomationModels.FASTER_RCNN.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_50_DC5_1x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_51d356.pkl",
     }
@@ -54,7 +54,7 @@ faster_rcnn_R_50_DC5_1x = ModelTrainingWeights(
 
 faster_rcnn_R_50_FPN_1x = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.FASTER_RCNN,
+        "model": AutomationModels.FASTER_RCNN.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_50_FPN_1x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_b275ba.pkl",
     }
@@ -62,7 +62,7 @@ faster_rcnn_R_50_FPN_1x = ModelTrainingWeights(
 
 faster_rcnn_R_50_C4_3x = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.FASTER_RCNN,
+        "model": AutomationModels.FASTER_RCNN.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_50_C4_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_f97cb7.pkl",
     }
@@ -70,7 +70,7 @@ faster_rcnn_R_50_C4_3x = ModelTrainingWeights(
 
 faster_rcnn_R_50_DC5_3x = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.FASTER_RCNN,
+        "model": AutomationModels.FASTER_RCNN.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_50_DC5_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_68d202.pkl",
     }
@@ -78,7 +78,7 @@ faster_rcnn_R_50_DC5_3x = ModelTrainingWeights(
 
 faster_rcnn_R_50_FPN_3x = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.FASTER_RCNN,
+        "model": AutomationModels.FASTER_RCNN.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_50_FPN_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_280758.pkl",
     }
@@ -86,7 +86,7 @@ faster_rcnn_R_50_FPN_3x = ModelTrainingWeights(
 
 faster_rcnn_R_101_C4_3x = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.FASTER_RCNN,
+        "model": AutomationModels.FASTER_RCNN.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_101_C4_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_298dad.pkl",
     }
@@ -94,7 +94,7 @@ faster_rcnn_R_101_C4_3x = ModelTrainingWeights(
 
 faster_rcnn_R_101_DC5_3x = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.FASTER_RCNN,
+        "model": AutomationModels.FASTER_RCNN.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_101_DC5_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_3e0943.pkl",
     }
@@ -102,7 +102,7 @@ faster_rcnn_R_101_DC5_3x = ModelTrainingWeights(
 
 faster_rcnn_R_101_FPN_3x = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.FASTER_RCNN,
+        "model": AutomationModels.FASTER_RCNN.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_R_101_FPN_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_f6e8b1.pkl",
     }
@@ -110,7 +110,7 @@ faster_rcnn_R_101_FPN_3x = ModelTrainingWeights(
 
 faster_rcnn_X_101_32x8d_FPN_3x = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.FASTER_RCNN,
+        "model": AutomationModels.FASTER_RCNN.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/faster_rcnn_X_101_32x8d_FPN_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_68b088.pkl",
     }
@@ -118,7 +118,7 @@ faster_rcnn_X_101_32x8d_FPN_3x = ModelTrainingWeights(
 
 mask_rcnn_X_101_32x8d_FPN_3x = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.MASK_RCNN,
+        "model": AutomationModels.MASK_RCNN.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/mask_rcnn_X_101_32x8d_FPN_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/ b.pkl",
     }
@@ -126,7 +126,7 @@ mask_rcnn_X_101_32x8d_FPN_3x = ModelTrainingWeights(
 
 mask_rcnn_R_50_C4_1x = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.MASK_RCNN,
+        "model": AutomationModels.MASK_RCNN.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/mask_rcnn_R_50_C4_1x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_9243eb.pkl",
     }
@@ -134,7 +134,7 @@ mask_rcnn_R_50_C4_1x = ModelTrainingWeights(
 
 mask_rcnn_R_50_C4_3x = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.MASK_RCNN,
+        "model": AutomationModels.MASK_RCNN.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/mask_rcnn_R_50_C4_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_4ce675.pkl",
     }
@@ -142,7 +142,7 @@ mask_rcnn_R_50_C4_3x = ModelTrainingWeights(
 
 mask_rcnn_R_101_FPN_3x = ModelTrainingWeights(
     {
-        "model": AUTOMATION_MODELS.MASK_RCNN,
+        "model": AutomationModels.MASK_RCNN.value,
         "training_config_link": "https://storage.googleapis.com/aws_model_backup/mask_rcnn_R_101_FPN_3x.yml",
         "training_weights_link": "https://storage.googleapis.com/aws_model_backup/model_final_a3ec72.pkl",
     }


### PR DESCRIPTION
# Introduction and Explanation
It would be better to have automation model types as an enum with convenient methods to disentangle which model types works for which types of classifications.

This PR contains a suggested solution.

Plus, it would also make writing documentation much easier :-) 