### PR TITLE
DEV-1181 - DEV-1188 -Allow users to interacts with projects and datasets without API keys

### DIFF
--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -11,6 +11,7 @@ You can authenticate with |company| on a user basis by registering an :xref:`ssh
 Public key authentication
 ----------------------------
 Using the public key authentication will give you full access to all the capabilities of the SDK.
+**This is our recommended default authentication method.**
 
 You will need to choose this authentication method to interact with the :class:`EncordUserClient <encord.EncordUserClient>`.
 

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -13,7 +13,7 @@ Public key authentication
 Public key authentication gives you full access to all the capabilities of the SDK.
 **This is our recommended default authentication method.**
 
-You will need to choose this authentication method to interact with the :class:`.EncordUserClient`.
+Public key authentication is required to use the :class:`.EncordUserClient`.
 
 This authentication method will also allow you to interact with a :ref:`general_concepts:Dataset` or a :ref:`general_concepts:Project` assuming you are either of the following:
 

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -15,7 +15,7 @@ Public key authentication gives you full access to all the capabilities of the S
 
 Public key authentication is required to use the :class:`.EncordUserClient`.
 
-This authentication method will also allow you to interact with a :ref:`general_concepts:Dataset` or a :ref:`general_concepts:Project` assuming you are either of the following:
+You can use the client to interact with a :ref:`general_concepts:Dataset` or a :ref:`general_concepts:Project` assuming you are either of the following:
 
 * An organisation admin of the organisation this project or dataset is part of
 * A project admin or project manager of the project that is being accessed

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -10,7 +10,7 @@ You can authenticate with |company| on a user basis by registering an :xref:`ssh
 
 Public key authentication
 ----------------------------
-Using the public key authentication will give you full access to all the capabilities of the SDK.
+Public key authentication gives you full access to all the capabilities of the SDK.
 **This is our recommended default authentication method.**
 
 You will need to choose this authentication method to interact with the :class:`.EncordUserClient`.

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -29,7 +29,7 @@ An individual API key is always tied to one specific project or dataset.
 We only recommend you to use this authentication if
 
 * You do not have user access rights for a project or dataset
-* You want to access a project or dataset as part of an automated pipeline without using a user access
+* You want to access a project or dataset as part of an automated pipeline without using a specific user account
 
 
 Set up authentication keys

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -28,7 +28,7 @@ An individual API key is always tied to one specific project or dataset.
 
 We only recommend you to use this authentication if
 
-* You do not have the access rights to access a project or dataset
+* You do not have user access rights for a project or dataset
 * You want to access a project or dataset as part of an automated pipeline without using a user access
 
 

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -23,7 +23,7 @@ You can use the client to interact with a :ref:`general_concepts:Dataset` or a :
 
 API key authentication
 ----------------------
-You can additionally access a specific project or dataset via the API key authentication.
+You can access a specific project or dataset via API key authentication.
 An individual API key is always tied to one specific project or dataset.
 
 We only recommend you to use this authentication if

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -4,17 +4,35 @@
 Authentication
 **************
 
+Types of authentication
+========================
+You can authenticate with |company| on a user basis by registering an :xref:`ssh_public_key_authentication` (i.e. "public key" in this document), or on a specific project or dataset basis by using an |company|-generated API key tied to that resource.
+
+Public key authentication
+----------------------------
+Using the public key authentication will give you full access to all the capabilities of the SDK.
+
+You will need to choose this authentication method to interact with the :class:`EncordUserClient <encord.EncordUserClient>`.
+
+This authentication method will also allow you to interact with a :ref:`general_concepts:Dataset` or a :ref:`general_concepts:Project` assuming you are either of the following:
+
+* An organisation admin of the organisation this project or dataset is part of
+* A project admin or project manager of the project that is being accessed
+* A dataset admin of the dataset that is being accessed
+
+API key authentication
+----------------------
+You can additionally access a specific project or dataset via the API key authentication.
+An individual API key is always tied to one specific project or dataset.
+
+We only recommend you to use this authentication if
+
+* You do not have the access rights to access a project or dataset
+* You want to access a project or dataset as part of an automated pipeline without using a user access
+
+
 Set up authentication keys
 ==========================
-You can authenticate with |company| on a user basis by registering a public key, or on a specific project or dataset basis by using an |company|-generated API key tied to that resource.
-
-* :ref:`authentication:Register a public key`: registering a public key gives you full access, allowing you to access all your projects and datasets, as well as create new projects, datasets and API keys
-* :ref:`authentication:Create an API key`: creating an API key gives you restricted access to a particular project or dataset
-
-Public keys are used to authenticate the user for activities that require user-level access, for example creating projects and datasets.
-API keys are more restrictive and are tied to a particular project or dataset.
-API keys are used to authenticate calls that only require resource-level access, for example downloading label rows from a particular project.
-
 
 Register a public key
 ---------------------
@@ -26,7 +44,8 @@ Create an API key
 
 API keys are tied to specific projects or datasets.
 You can generate multiple keys for each project or dataset.
-To create an API key:
+
+To create an API key you can use the |platform|:
 
 #. Log in to your account on :xref:`login_url`
 #. Navigate to the :xref:`project` or :xref:`dataset` tab in the :xref:`navigation_bar`
@@ -39,37 +58,34 @@ To create an API key:
 
     Getting an API key from the |platform|.
 
-Authenticate with Encord
-========================
+You can additionally create them programmatically as you can see in these guides:
+
+* Create :ref:`tutorials/projects:API keys` for projects
+* Create :ref:`tutorials/datasets:API keys` for datasets
+
+
+Authenticate with |company|
+===========================
 
 Once you have registered a public key or created an API key, you can authenticate your SDK client with |company| and get started with the SDK.
 
 
-Public key authentication
--------------------------
+Public key authentication with the SDK
+--------------------------------------------------
 
 If you are using public key authentication, authenticate with |company| by passing the corresponding private key to an :class:`.EncordUserClient`.
-Once you have an :class:`.EncordUserClient`, you can use it to create new projects and datasets, or interact with existing ones by creating separate :class:`.EncordClient` objects tied to them
+Once you have an :class:`.EncordUserClient`, you can use it to create new projects and datasets, or interact with existing ones by creating separate :class:`encord.ProjectManager` or :class:`encord.DatasetManager` objects tied to them
 
 .. literalinclude:: code_examples/authenticate_ssh.py
     :language: python
 
 
 
-API key authentication
-----------------------
+API key authentication with the SDK
+--------------------------------------------
 
 If you are using API key authentication, authenticate with |company| by passing the resource ID (project or dataset ID) and associated API key to an :class:`.EncordClient`.
 This will directly create an :class:`.EncordClient` to interact with a specific project or dataset
 
 .. literalinclude:: code_examples/authenticate_api_key.py
     :language: python
-
-In the example above, the ``<resource_id>`` can either be a ``<project_hash>`` or a ``<dataset_hash>``.
-
-You can instantiate several :class:`.EncordClient` objects by creating an :class:`.EncordConfig` object first.
-Pass the resource ID and API key as strings, and initialise the clients with the config object
-
-.. literalinclude:: code_examples/authenticate_config.py
-    :language: python
-

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -74,7 +74,7 @@ Once you have registered a public key or created an API key, you can authenticat
 Public key authentication with the SDK
 --------------------------------------------------
 
-If you are using public key authentication, authenticate with |company| by passing the corresponding private key to an :class:`.EncordUserClient`.
+After registering your public key, authenticate with |company| by passing the corresponding private key to an :class:`.EncordUserClient`.
 Once you have an :class:`.EncordUserClient`, you can use it to create new projects and datasets, or interact with existing ones by creating separate :class:`.ProjectManager` or :class:`.DatasetManager` objects tied to them
 
 .. literalinclude:: code_examples/authenticate_ssh.py

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -13,7 +13,7 @@ Public key authentication
 Using the public key authentication will give you full access to all the capabilities of the SDK.
 **This is our recommended default authentication method.**
 
-You will need to choose this authentication method to interact with the :class:`EncordUserClient <encord.EncordUserClient>`.
+You will need to choose this authentication method to interact with the :class:`.EncordUserClient`.
 
 This authentication method will also allow you to interact with a :ref:`general_concepts:Dataset` or a :ref:`general_concepts:Project` assuming you are either of the following:
 
@@ -75,7 +75,7 @@ Public key authentication with the SDK
 --------------------------------------------------
 
 If you are using public key authentication, authenticate with |company| by passing the corresponding private key to an :class:`.EncordUserClient`.
-Once you have an :class:`.EncordUserClient`, you can use it to create new projects and datasets, or interact with existing ones by creating separate :class:`encord.ProjectManager` or :class:`encord.DatasetManager` objects tied to them
+Once you have an :class:`.EncordUserClient`, you can use it to create new projects and datasets, or interact with existing ones by creating separate :class:`.ProjectManager` or :class:`.DatasetManager` objects tied to them
 
 .. literalinclude:: code_examples/authenticate_ssh.py
     :language: python
@@ -86,7 +86,11 @@ API key authentication with the SDK
 --------------------------------------------
 
 If you are using API key authentication, authenticate with |company| by passing the resource ID (project or dataset ID) and associated API key to an :class:`.EncordClient`.
-This will directly create an :class:`.EncordClient` to interact with a specific project or dataset
+This will directly create an :class:`.EncordClient` to interact with a specific project or dataset.
 
 .. literalinclude:: code_examples/authenticate_api_key.py
     :language: python
+
+.. note::
+    The :class:`encord.client.EncordClientProject` is functionally equivalent to the :class:`.ProjectManager`.
+    The :class:`encord.client.EncordClientDataset` is functionally equivalent to the :class:`.DatasetManager`.

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -46,7 +46,7 @@ Create an API key
 API keys are tied to specific projects or datasets.
 You can generate multiple keys for each project or dataset.
 
-To create an API key you can use the |platform|:
+To create an API key use the |platform|:
 
 #. Log in to your account on :xref:`login_url`
 #. Navigate to the :xref:`project` or :xref:`dataset` tab in the :xref:`navigation_bar`

--- a/docs/source/code_examples/authenticate_api_key.py
+++ b/docs/source/code_examples/authenticate_api_key.py
@@ -1,5 +1,8 @@
-from encord.client import EncordClient
+from types import Union
 
-client: EncordClient = EncordClient.initialise(
-    "<resource_id>", "<resource_api_key>"
-)
+from encord.client import EncordClient, EncordClientDataset, EncordClientProject
+
+# The client will either be an EncordClientDataset if the
+# resource_id belongs to a dataset or it will be an
+# EncordClientProject if the resource_id belongs to a project.
+client: Union[EncordClientProject, EncordClientDataset] = EncordClient.initialise("<resource_id>", "<resource_api_key>")

--- a/docs/source/code_examples/authenticate_ssh.py
+++ b/docs/source/code_examples/authenticate_ssh.py
@@ -1,10 +1,5 @@
-from encord.client import EncordClientDataset, EncordClientProject
-from encord.user_client import EncordUserClient
+from encord import DatasetManager, EncordUserClient, ProjectManager
 
 user_client = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
-project_client: EncordClientProject = user_client.get_project_client(
-    "<project_id>"
-)
-dataset_client: EncordClientDataset = user_client.get_dataset_client(
-    "<dataset_id>"
-)
+project_client: ProjectManager = user_client.get_project_manager("<project_id>")
+dataset_client: DatasetManager = user_client.get_dataset_manager("<dataset_id>")

--- a/docs/source/code_examples/authenticate_ssh.py
+++ b/docs/source/code_examples/authenticate_ssh.py
@@ -1,5 +1,5 @@
 from encord import DatasetManager, EncordUserClient, ProjectManager
 
 user_client = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
-project_client: ProjectManager = user_client.get_project_manager("<project_id>")
-dataset_client: DatasetManager = user_client.get_dataset_manager("<dataset_id>")
+project_manager: ProjectManager = user_client.get_project_manager("<project_id>")
+dataset_manager: DatasetManager = user_client.get_dataset_manager("<dataset_id>")

--- a/docs/source/code_examples/quickstart.py
+++ b/docs/source/code_examples/quickstart.py
@@ -1,5 +1,4 @@
-from encord.client import EncordClientProject
-from encord.user_client import EncordUserClient
+from encord import EncordUserClient, ProjectManager
 
 user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
     "<your_private_key_content>",
@@ -7,20 +6,12 @@ user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
 )
 
 # Get the project client
-project_hash: str = next(
-    (p["project"]["project_hash"] for p in user_client.get_projects())
-)
-project_client: EncordClientProject = user_client.get_project_client(
-    project_hash
-)
+project_hash: str = next((p["project"]["project_hash"] for p in user_client.get_projects()))
+project_manager: ProjectManager = user_client.get_project_manager(project_hash)
 
 # Get the labels (from one label_row, not entire set of labels from the project).
 label_hash: str = next(
-    (
-        lr["label_hash"]
-        for lr in project_client.get_project().label_rows
-        if lr["label_hash"] is not None
-    )
+    (lr["label_hash"] for lr in project_manager.get_project().label_rows if lr["label_hash"] is not None)
 )
-labels: dict = project_client.get_label_row(label_hash)
+labels: dict = project_manager.get_label_row(label_hash)
 print(labels)

--- a/docs/source/code_examples/quickstart.py
+++ b/docs/source/code_examples/quickstart.py
@@ -5,7 +5,7 @@ user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
     password="<your_private_key_password_if_necessary>",
 )
 
-# Get the project client
+# Get the project manager
 project_hash: str = next((p["project"]["project_hash"] for p in user_client.get_projects()))
 project_manager: ProjectManager = user_client.get_project_manager(project_hash)
 

--- a/docs/source/code_examples/tutorials/datasets/add_private_data.py
+++ b/docs/source/code_examples/tutorials/datasets/add_private_data.py
@@ -1,16 +1,11 @@
 from typing import List
 
-from encord.client import EncordClientDataset
+from encord import DatasetManager, EncordUserClient
 from encord.orm.cloud_integration import CloudIntegration
 from encord.orm.dataset import AddPrivateDataResponse
-from encord.user_client import EncordUserClient
 
-user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
-    "<your_private_key>"
-)
-dataset_client: EncordClientDataset = user_client.get_dataset_client(
-    "<dataset_hash>"
-)
+user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
+dataset_manager: DatasetManager = user_client.get_dataset_manager("<dataset_hash>")
 
 # Choose integration
 integrations: List[CloudIntegration] = user_client.get_cloud_integrations()
@@ -20,7 +15,5 @@ print(integrations)
 integration_idx: int = [i.title for i in integrations].index("AWS")
 integration: str = integrations[integration_idx].id
 
-response: AddPrivateDataResponse = dataset_client.add_private_data_to_dataset(
-    integration, "path/to/json/file.json"
-)
+response: AddPrivateDataResponse = dataset_manager.add_private_data_to_dataset(integration, "path/to/json/file.json")
 print(response.dataset_data_list)

--- a/docs/source/code_examples/tutorials/datasets/creating_a_dataset.py
+++ b/docs/source/code_examples/tutorials/datasets/creating_a_dataset.py
@@ -1,11 +1,7 @@
+from encord import EncordUserClient
 from encord.orm.dataset import CreateDatasetResponse, StorageLocation
-from encord.user_client import EncordUserClient
 
-user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
-    "<your_private_key>"
-)
+user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
 
-dataset: CreateDatasetResponse = user_client.create_dataset(
-    "Example Title", StorageLocation.AWS
-)
+dataset: CreateDatasetResponse = user_client.create_dataset("Example Title", StorageLocation.AWS)
 print(dataset)

--- a/docs/source/code_examples/tutorials/datasets/creating_a_dataset_api_key.py
+++ b/docs/source/code_examples/tutorials/datasets/creating_a_dataset_api_key.py
@@ -1,9 +1,7 @@
+from encord import EncordUserClient
 from encord.orm.dataset import DatasetAPIKey, DatasetScope
-from encord.user_client import EncordUserClient
 
-user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
-    "<your_private_key>"
-)
+user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
 
 dataset_api_key: DatasetAPIKey = user_client.create_dataset_api_key(
     "<dataset_hash>",

--- a/docs/source/code_examples/tutorials/datasets/creating_a_dataset_manager.py
+++ b/docs/source/code_examples/tutorials/datasets/creating_a_dataset_manager.py
@@ -1,0 +1,5 @@
+from encord import DatasetManager, EncordUserClient
+
+user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
+
+dataset_manager: DatasetManager = user_client.get_dataset_manager("<dataset_hash>")

--- a/docs/source/code_examples/tutorials/datasets/creating_a_master_api_key.py
+++ b/docs/source/code_examples/tutorials/datasets/creating_a_master_api_key.py
@@ -1,11 +1,7 @@
+from encord import EncordUserClient
 from encord.orm.dataset import DatasetAPIKey
-from encord.user_client import EncordUserClient
 
-user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
-    "<your_private_key>"
-)
+user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
 
-dataset_api_key: DatasetAPIKey = user_client.get_or_create_dataset_api_key(
-    "<dataset_hash>"
-)
+dataset_api_key: DatasetAPIKey = user_client.get_or_create_dataset_api_key("<dataset_hash>")
 print(dataset_api_key)

--- a/docs/source/code_examples/tutorials/datasets/fetching_dataset_api_keys.py
+++ b/docs/source/code_examples/tutorials/datasets/fetching_dataset_api_keys.py
@@ -1,11 +1,9 @@
 from typing import List
 
+from encord import EncordUserClient
 from encord.orm.dataset import DatasetAPIKey
-from encord.user_client import EncordUserClient
 
-user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
-    "<your_private_key>"
-)
+user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
 
 keys: List[DatasetAPIKey] = user_client.get_dataset_api_keys("<dataset_hash>")
 print(keys)

--- a/docs/source/code_examples/tutorials/datasets/listing_existing_datasets.py
+++ b/docs/source/code_examples/tutorials/datasets/listing_existing_datasets.py
@@ -1,10 +1,8 @@
 from typing import Dict, List
 
-from encord.user_client import EncordUserClient
+from encord import EncordUserClient
 
-user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
-    "<your_private_key>"
-)
+user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
 
 datasets: List[Dict] = user_client.get_datasets()
 print(datasets)

--- a/docs/source/code_examples/tutorials/projects/adding_classifications_to_a_project_ontology.py
+++ b/docs/source/code_examples/tutorials/projects/adding_classifications_to_a_project_ontology.py
@@ -1,15 +1,10 @@
-from encord.client import EncordClientProject
+from encord import EncordUserClient, ProjectManager
 from encord.project_ontology.classification_type import ClassificationType
-from encord.user_client import EncordUserClient
 
-user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
-    "<your_private_key>"
-)
-project_client: EncordClientProject = user_client.get_project_client(
-    "<project_hash>"
-)
+user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
+project_manager: ProjectManager = user_client.get_project_manager("<project_hash>")
 
-success: bool = project_client.add_classification(
+success: bool = project_manager.add_classification(
     "Animal",
     classification_type=ClassificationType.RADIO,
     required=True,

--- a/docs/source/code_examples/tutorials/projects/adding_datasets_to_projects.py
+++ b/docs/source/code_examples/tutorials/projects/adding_datasets_to_projects.py
@@ -1,14 +1,9 @@
-from encord.client import EncordClientProject
-from encord.user_client import EncordUserClient
+from encord import EncordUserClient, ProjectManager
 
-user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
-    "<your_private_key>"
-)
-project_client: EncordClientProject = user_client.get_project_client(
-    "<project_hash>"
-)
+user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
+project_manager: ProjectManager = user_client.get_project_manager("<project_hash>")
 
-success: bool = project_client.add_datasets(
+success: bool = project_manager.add_datasets(
     [
         "<dataset_hash1>",
         "<dataset_hash2>",

--- a/docs/source/code_examples/tutorials/projects/adding_objects_to_a_project_ontology.py
+++ b/docs/source/code_examples/tutorials/projects/adding_objects_to_a_project_ontology.py
@@ -1,13 +1,8 @@
-from encord.client import EncordClientProject
+from encord import EncordUserClient, ProjectManager
 from encord.project_ontology.object_type import ObjectShape
-from encord.user_client import EncordUserClient
 
-user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
-    "<your_private_key>"
-)
-project_client: EncordClientProject = user_client.get_project_client(
-    "<project_hash>"
-)
+user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
+project_manager: ProjectManager = user_client.get_project_manager("<project_hash>")
 
-success: bool = project_client.add_object("Dog", ObjectShape.BOUNDING_BOX)
+success: bool = project_manager.add_object("Dog", ObjectShape.BOUNDING_BOX)
 print(success)

--- a/docs/source/code_examples/tutorials/projects/adding_users_to_datasets.py
+++ b/docs/source/code_examples/tutorials/projects/adding_users_to_datasets.py
@@ -1,12 +1,10 @@
-from encord.user_client import EncordUserClient
+from encord import EncordUserClient, ProjectManager
 from encord.utilities.project_user import ProjectUserRole
 
-user_client = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
-project_client = user_client.get_project_client(
-    "<project_hash>",
-)
+user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
+project_manager: ProjectManager = user_client.get_project_manager("<project_hash>")
 
-added_users = project_client.add_users(
+added_users = project_manager.add_users(
     ["example1@encord.com", "example2@encord.com"],
     ProjectUserRole.ANNOTATOR,
 )

--- a/docs/source/code_examples/tutorials/projects/copying_a_project.py
+++ b/docs/source/code_examples/tutorials/projects/copying_a_project.py
@@ -1,14 +1,10 @@
-from encord.client import EncordClientProject
-from encord.user_client import EncordUserClient
+from encord import EncordUserClient, ProjectManager
 
-user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
-    "<your_private_key>"
-)
-project_client: EncordClientProject = user_client.get_project_client(
-    "<project_hash>"
-)
+user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
+project_manager: ProjectManager = user_client.get_project_manager("<project_hash>")
 
-project_hash: str = project_client.copy_project(
+
+project_hash: str = project_manager.copy_project(
     copy_datasets=True,
     copy_collaborators=True,
     copy_models=False,  # Not strictly needed

--- a/docs/source/code_examples/tutorials/projects/creating_a_project_manager.py
+++ b/docs/source/code_examples/tutorials/projects/creating_a_project_manager.py
@@ -1,0 +1,5 @@
+from encord import EncordUserClient, ProjectManager
+
+user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
+
+project_manager: ProjectManager = user_client.get_project_manager("<dataset_hash>")

--- a/docs/source/code_examples/tutorials/projects/fetching_project_ontology.py
+++ b/docs/source/code_examples/tutorials/projects/fetching_project_ontology.py
@@ -1,13 +1,9 @@
-from encord.client import EncordClientProject
+from encord import EncordUserClient, ProjectManager
 from encord.project_ontology.ontology import Ontology
-from encord.user_client import EncordUserClient
 
-user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
-    "<your_private_key>"
-)
-project_client: EncordClientProject = user_client.get_project_client(
-    "<project_hash>"
-)
+user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
+project_manager: ProjectManager = user_client.get_project_manager("<project_hash>")
 
-ontology: Ontology = project_client.get_project_ontology()
+
+ontology: Ontology = project_manager.get_project_ontology()
 print(ontology.to_dict())

--- a/docs/source/code_examples/tutorials/projects/removing_datasets_from_projects.py
+++ b/docs/source/code_examples/tutorials/projects/removing_datasets_from_projects.py
@@ -1,14 +1,10 @@
-from encord.client import EncordClientProject
-from encord.user_client import EncordUserClient
+from encord import EncordUserClient, ProjectManager
 
-user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
-    "<your_private_key>"
-)
-project_client: EncordClientProject = user_client.get_project_client(
-    "<project_hash>"
-)
+user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key("<your_private_key>")
+project_manager: ProjectManager = user_client.get_project_manager("<project_hash>")
 
-success: bool = project_client.remove_datasets(
+
+success: bool = project_manager.remove_datasets(
     [
         "<dataset_hash1>",
         "<dataset_hash2>",

--- a/docs/source/general_concepts.rst
+++ b/docs/source/general_concepts.rst
@@ -5,17 +5,26 @@ General Concepts
 ****************
 The |sdk| revolves around three major concepts:
 
-* **User**: the user authenticated to interact with the |company| platform.
-  The user has access to the resources and capabilities that are also available on the |platform|.
-  For a |platform| specific description of capabilities, please refer to the :xref:`docs_main_entry`
-* **Dataset**: the space where the data itself lives.
-  Datasets can be reused across multiple projects and contain no labels or annotations themselves.
-  For a |platform| specific introduction, please refer to the |platform| :xref:`dataset` page
-* **Project**: the space where ontology information, labels, annotations, and reviews live.
-  Projects can be linked to multiple datasets.
-  For a |platform| specific introduction, please refer to the |platform| :xref:`project` page
+User
+====
+The user authenticated to interact with the |company| platform.
+The user has access to the resources and capabilities that are also available on the |platform|.
+For a |platform| specific description of capabilities, please refer to the :xref:`docs_main_entry`.
 
-For each of the concepts, you find a client that allows you to interact with their specific attributes.
-For example, the *Project* has an associated :class:`.EncordClientProject` and the *Dataset* has an associated :class:`.EncordClientDataset`.
+Dataset
+=======
+The space where the data itself lives.
+Datasets can be reused across multiple projects and contain no labels or annotations themselves.
+For a |platform| specific introduction, please refer to the |platform| :xref:`dataset` page.
+
+Project
+=======
+The space where ontology information, labels, annotations, and reviews live.
+Projects can be linked to multiple datasets.
+For a |platform| specific introduction, please refer to the |platform| :xref:`project` page.
+
+For each of the concepts, you find a class that allows you to interact with their specific attributes.
+For example, the *Project* has an associated :class:`.ProjectManager` and the *Dataset* has an associated :class:`.DatasetManager`.
+
 
 If you haven't already, you can go ahead and install the SDK by following the :ref:`installation:Installation` guide or skip directly to the :ref:`authentication:Authentication` page to get started with the |sdk|.

--- a/docs/source/links.json
+++ b/docs/source/links.json
@@ -54,5 +54,9 @@
   "cvat": {
     "user_text": "CVAT",
     "url": "https://github.com/openvinotoolkit/cvat"
+  },
+  "ssh_public_key_authentication": {
+    "user_text": "SSH public key",
+    "url": "https://www.ssh.com/academy/ssh/public-key-authentication"
   }
 }

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -5,7 +5,7 @@ Tutorials
 The tutorials are separated into those that relate to *datasets* and those that relate to *projects*.
 
 .. note::
-    Throughout the tutorials, we use :class:`user_client <.EncordUserClient>`, :class:`dataset_client <.EncordClientDataset>` and :class:`project_client <.EncordClientProject>` extensively.
+    Throughout the tutorials, we use :class:`user_client <.EncordUserClient>`, :class:`dataset_manager <.DatasetManager>` and :class:`project_manager <.ProjectManager>` extensively.
     We refer to the :ref:`authentication:Authentication` page for examples of how to instantiate those.
 
 .. toctree::

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -2,7 +2,7 @@
 Tutorials
 *********
 
-The tutorials are separated into those that relate to *datasets*, those that relate to *projects* and those that give you end-to-end examples of common scenarios.
+The tutorials are separated into those that relate to *datasets* and those that relate to *projects*.
 
 .. note::
     Throughout the tutorials, we use :class:`user_client <.EncordUserClient>`, :class:`dataset_client <.EncordClientDataset>` and :class:`project_client <.EncordClientProject>` extensively.
@@ -14,4 +14,3 @@ The tutorials are separated into those that relate to *datasets*, those that rel
 
     ./tutorials/datasets
     ./tutorials/projects
-    ./tutorials/end-to-end/index

--- a/docs/source/tutorials/datasets.rst
+++ b/docs/source/tutorials/datasets.rst
@@ -108,6 +108,18 @@ In the example below, a user authenticates with |company| and then fetches all d
     Other keyword arguments such as :meth:`created_before  <.EncordUserClient.get_datasets>` or :meth:`edited_after <.EncordUserClient.get_datasets>` may also be of interest.
 
 
+Managing a dataset
+==================
+Your default choice for interacting with a dataset is via the :ref:`authentication:Public key authentication`.
+
+
+.. tabs::
+
+    .. tab:: Code
+
+        .. literalinclude:: /code_examples/tutorials/datasets/creating_a_dataset_manager.py
+            :language: python
+
 
 API keys
 ========
@@ -148,7 +160,7 @@ The following example show how to get hold of this key:
 Creating a dataset API key with specific rights
 -----------------------------------------------
 
-:ref:`authentication:Authenticate with Encord` using an API key allows you to control which capabilities the dataset client will have.
+:ref:`authentication:API key authentication` using an API key allows you to control which capabilities the dataset client will have.
 This can be useful if you, for example, want to share read-only access with some third-party.
 You need to provide the ``<dataset_hash>``, which uniquely identifies a dataset (see, for example, the :ref:`tutorials/datasets:Listing existing datasets` to get such hash).
 If you haven't created a dataset already, you can have a look at :ref:`tutorials/datasets:Creating a Dataset`.
@@ -240,7 +252,7 @@ You can add data to datasets in multiple ways.
 You can both use |company| storage, as described next, and you can :ref:`add data from a private cloud <tutorials/datasets:Adding data from a private cloud>` to integrate any pre-existing data.
 
 .. note::
-    The following examples assume that you have an :class:`.EncordClientDataset` initialised as variable ``dataset_client`` and :ref:`authenticated <authentication:Authenticate with Encord>`.
+    The following examples assume that you have an :class:`.DatasetManager` initialised as variable ``dataset_manager`` and :ref:`authenticated <authentication:API key authentication>`.
 
 Adding data to Encord-hosted storage
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -256,7 +268,7 @@ Use the method :meth:`upload_video() <.EncordClientDataset.upload_video>` to upl
             I suspect the issue is that, e.g., ``user_client.get_project_client`` returns a ``Union[EncordClientProject, EncordClientDataset]`` and not just an ``EncordClientProject``, so the extension doesn't know which one it is.
             As a consequence, it cannot find the correct link.
 
-            Adding, e.g., ``user_client.get_dataset_client("test")`` to one of the following code blocks yields links, so the preface it self works.
+            Adding, e.g., ``user_client.get_dataset_manager("test")`` to one of the following code blocks yields links, so the preface it self works.
 
             In turn, I suffice with linking to the proper places in the prose surrounding the code examples.
 
@@ -270,15 +282,15 @@ Use the method :meth:`upload_video() <.EncordClientDataset.upload_video>` to upl
 .. autolink-preface::
 
     from encord.client import EncordClientDataset
-    dataset_client = EncordClientDataset()  #  user_client.get_dataset_client("<dataset_hash>")
+    dataset_manager = EncordClientDataset()  #  user_client.get_dataset_manager("<dataset_hash>")
 
 
 .. code-block:: python
 
-    dataset_client.upload_video("path/to/your/video.mp4")
+    dataset_manager.upload_video("path/to/your/video.mp4")
 
 
-This will upload the given video file to the dataset associated with the :class:`dataset_client <.EncordClientDataset>`.
+This will upload the given video file to the dataset associated with the :class:`dataset_manager <.EncordClientDataset>`.
 
 Uploading images
 """"""""""""""""
@@ -290,18 +302,18 @@ Use the method :meth:`create_image_group() <.EncordClientDataset.create_image_gr
 .. autolink-preface::
 
     from encord.client import EncordClientDataset
-    dataset_client = EncordClientDataset()  #  user_client.get_dataset_client("<dataset_hash>")
+    dataset_manager = EncordClientDataset()  #  user_client.get_dataset_manager("<dataset_hash>")
 
 .. code-block:: python
 
-    dataset_client.create_image_group(
+    dataset_manager.create_image_group(
         [
             "path/to/your/img1.jpeg",
             "path/to/your/img2.jpeg",
         ]
     )
 
-This will upload the given list of images to the dataset associated with the :class:`dataset_client <.EncordClientDataset>` and create an image group.
+This will upload the given list of images to the dataset associated with the :class:`dataset_manager <.EncordClientDataset>` and create an image group.
 
 .. note::
 
@@ -318,7 +330,7 @@ Adding data from a private cloud
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 #.  Use :meth:`user_client.get_cloud_integrations() <.EncordUserClient.get_cloud_integrations>` method to retrieve a list of available Cloud Integrations
-#.  Grab the id from the integration of your choice and call :meth:`dataset_client.add_private_data_to_dataset() <.EncordClientDataset.add_private_data_to_dataset>` on the ``dataset_client`` with either the absolute path to a json file or a python dictionary in the format specified in the :xref:`private_cloud_section` of the |platform| datasets documentation
+#.  Grab the id from the integration of your choice and call :meth:`dataset_manager.add_private_data_to_dataset() <.EncordClientDataset.add_private_data_to_dataset>` on the ``dataset_manager`` with either the absolute path to a json file or a python dictionary in the format specified in the :xref:`private_cloud_section` of the |platform| datasets documentation
 
 .. tabs::
 
@@ -340,18 +352,18 @@ Deleting data
 -------------
 
 You can remove both videos and image group from datasets created using both the |platform| and the |sdk|.
-Use the method :meth:`dataset_client.delete_data() <.EncordClientDataset.delete_data>` to delete from a dataset.
+Use the method :meth:`dataset_manager.delete_data() <.EncordClientDataset.delete_data>` to delete from a dataset.
 
 .. autolink-concat:: section
 
 .. autolink-preface::
 
     from encord.client import EncordClientDataset
-    dataset_client = EncordClientDataset()
+    dataset_manager = EncordClientDataset()
 
 .. code-block:: python
 
-    dataset_client.delete_data(
+    dataset_manager.delete_data(
         [
             "<video1_data_hash>",
             "<image_group1_data_hash>",
@@ -361,7 +373,7 @@ Use the method :meth:`dataset_client.delete_data() <.EncordClientDataset.delete_
 
 In case the video or image group belongs to |company|-hosted storage, the corresponding file will be removed from the Encord-hosted storage.
 
-Please ensure that the list contains videos/image groups from the same dataset which is used to initialise the :class:`dataset_client <.EncordClientDataset>`.
+Please ensure that the list contains videos/image groups from the same dataset which is used to initialise the :class:`dataset_manager <.EncordClientDataset>`.
 Any videos or image groups which do not belong to the dataset used for initialisation will be ignored.
 
 
@@ -380,7 +392,7 @@ Trigger a re-encoding task
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You re-encode a list of videos by triggering a task for the same using the |sdk|.
-Use the method :meth:`dataset_client.re_encode_data() <.EncordClientDataset.re_encode_data>` to re-encode the list of videos specified
+Use the method :meth:`dataset_manager.re_encode_data() <.EncordClientDataset.re_encode_data>` to re-encode the list of videos specified
 
 .. tabs::
 
@@ -388,7 +400,7 @@ Use the method :meth:`dataset_client.re_encode_data() <.EncordClientDataset.re_e
 
         .. code-block:: python
 
-            task_id = dataset_client.re_encode_data(
+            task_id = dataset_manager.re_encode_data(
                 [
                     "video1_data_hash",
                     "video2_data_hash",
@@ -412,7 +424,7 @@ Any videos which do not belong to the dataset used for initialisation will be ig
 Check the status of a re-encoding task
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Use the method :meth:`dataset_client.re_encode_data_status(task_id) <.EncordClientDataset.re_encode_data_status>` to get the status of an existing re-encoding task.
+Use the method :meth:`dataset_manager.re_encode_data_status(task_id) <.EncordClientDataset.re_encode_data_status>` to get the status of an existing re-encoding task.
 
 .. tabs::
 
@@ -422,7 +434,7 @@ Use the method :meth:`dataset_client.re_encode_data_status(task_id) <.EncordClie
 
             from encord.orm.dataset import ReEncodeVideoTask
             task: ReEncodeVideoTask = (
-                dataset_client.re_encode_data_status(task_id)
+                dataset_manager.re_encode_data_status(task_id)
             )
             print(task)
 

--- a/docs/source/tutorials/datasets.rst
+++ b/docs/source/tutorials/datasets.rst
@@ -123,6 +123,8 @@ Your default choice for interacting with a dataset is via the :ref:`authenticati
 
 API keys
 ========
+We recommend using a :class:`.DatasetManager` as described in :ref:`tutorials/datasets:Managing a dataset`.
+This will be simpler than dealing with API keys which should only be used under specific circumstances as described in :ref:`authentication:API key authentication`.
 
 Creating a master API key with full rights
 ------------------------------------------
@@ -260,7 +262,7 @@ Adding data to Encord-hosted storage
 Uploading videos
 """"""""""""""""
 
-Use the method :meth:`upload_video() <.EncordClientDataset.upload_video>` to upload a video to a dataset using |company| storage.
+Use the method :meth:`upload_video() <.DatasetManager.upload_video>` to upload a video to a dataset using |company| storage.
 
 ..
     Note (FHV): Tried to add autolink section to enable links to, e.g., ``upload_video`` on code examples below without success.
@@ -281,8 +283,8 @@ Use the method :meth:`upload_video() <.EncordClientDataset.upload_video>` to upl
 
 .. autolink-preface::
 
-    from encord.client import EncordClientDataset
-    dataset_manager = EncordClientDataset()  #  user_client.get_dataset_manager("<dataset_hash>")
+    from encord.client import DatasetManager
+    dataset_manager = DatasetManager()  #  user_client.get_dataset_manager("<dataset_hash>")
 
 
 .. code-block:: python
@@ -290,19 +292,19 @@ Use the method :meth:`upload_video() <.EncordClientDataset.upload_video>` to upl
     dataset_manager.upload_video("path/to/your/video.mp4")
 
 
-This will upload the given video file to the dataset associated with the :class:`dataset_manager <.EncordClientDataset>`.
+This will upload the given video file to the dataset associated with the :class:`dataset_manager <.DatasetManager>`.
 
 Uploading images
 """"""""""""""""
 
-Use the method :meth:`create_image_group() <.EncordClientDataset.create_image_group>` to upload images and create an image group using |company| storage.
+Use the method :meth:`create_image_group() <.DatasetManager.create_image_group>` to upload images and create an image group using |company| storage.
 
 .. autolink-concat:: section
 
 .. autolink-preface::
 
-    from encord.client import EncordClientDataset
-    dataset_manager = EncordClientDataset()  #  user_client.get_dataset_manager("<dataset_hash>")
+    from encord.client import DatasetManager
+    dataset_manager = DatasetManager()  #  user_client.get_dataset_manager("<dataset_hash>")
 
 .. code-block:: python
 
@@ -313,7 +315,7 @@ Use the method :meth:`create_image_group() <.EncordClientDataset.create_image_gr
         ]
     )
 
-This will upload the given list of images to the dataset associated with the :class:`dataset_manager <.EncordClientDataset>` and create an image group.
+This will upload the given list of images to the dataset associated with the :class:`dataset_manager <.DatasetManager>` and create an image group.
 
 .. note::
 
@@ -322,7 +324,7 @@ This will upload the given list of images to the dataset associated with the :cl
 
 .. note::
 
-    Images in an image group will be assigned a ``data_sequence`` number, which is based on the order or the files listed in the argument to :meth:`create_image_group <.EncordClientDataset.create_image_group>` above.
+    Images in an image group will be assigned a ``data_sequence`` number, which is based on the order or the files listed in the argument to :meth:`create_image_group <.DatasetManager.create_image_group>` above.
     If the ordering is important, make sure to provide a list with filenames in the correct order.
 
 
@@ -330,7 +332,7 @@ Adding data from a private cloud
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 #.  Use :meth:`user_client.get_cloud_integrations() <.EncordUserClient.get_cloud_integrations>` method to retrieve a list of available Cloud Integrations
-#.  Grab the id from the integration of your choice and call :meth:`dataset_manager.add_private_data_to_dataset() <.EncordClientDataset.add_private_data_to_dataset>` on the ``dataset_manager`` with either the absolute path to a json file or a python dictionary in the format specified in the :xref:`private_cloud_section` of the |platform| datasets documentation
+#.  Grab the id from the integration of your choice and call :meth:`dataset_manager.add_private_data_to_dataset() <.DatasetManager.add_private_data_to_dataset>` on the ``dataset_manager`` with either the absolute path to a json file or a python dictionary in the format specified in the :xref:`private_cloud_section` of the |platform| datasets documentation
 
 .. tabs::
 
@@ -352,14 +354,14 @@ Deleting data
 -------------
 
 You can remove both videos and image group from datasets created using both the |platform| and the |sdk|.
-Use the method :meth:`dataset_manager.delete_data() <.EncordClientDataset.delete_data>` to delete from a dataset.
+Use the method :meth:`dataset_manager.delete_data() <.DatasetManager.delete_data>` to delete from a dataset.
 
 .. autolink-concat:: section
 
 .. autolink-preface::
 
-    from encord.client import EncordClientDataset
-    dataset_manager = EncordClientDataset()
+    from encord.client import DatasetManager
+    dataset_manager = DatasetManager()
 
 .. code-block:: python
 
@@ -373,7 +375,7 @@ Use the method :meth:`dataset_manager.delete_data() <.EncordClientDataset.delete
 
 In case the video or image group belongs to |company|-hosted storage, the corresponding file will be removed from the Encord-hosted storage.
 
-Please ensure that the list contains videos/image groups from the same dataset which is used to initialise the :class:`dataset_manager <.EncordClientDataset>`.
+Please ensure that the list contains videos/image groups from the same dataset which is used to initialise the :class:`dataset_manager <.DatasetManager>`.
 Any videos or image groups which do not belong to the dataset used for initialisation will be ignored.
 
 
@@ -392,7 +394,7 @@ Trigger a re-encoding task
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You re-encode a list of videos by triggering a task for the same using the |sdk|.
-Use the method :meth:`dataset_manager.re_encode_data() <.EncordClientDataset.re_encode_data>` to re-encode the list of videos specified
+Use the method :meth:`dataset_manager.re_encode_data() <.DatasetManager.re_encode_data>` to re-encode the list of videos specified
 
 .. tabs::
 
@@ -424,7 +426,7 @@ Any videos which do not belong to the dataset used for initialisation will be ig
 Check the status of a re-encoding task
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Use the method :meth:`dataset_manager.re_encode_data_status(task_id) <.EncordClientDataset.re_encode_data_status>` to get the status of an existing re-encoding task.
+Use the method :meth:`dataset_manager.re_encode_data_status(task_id) <.DatasetManager.re_encode_data_status>` to get the status of an existing re-encoding task.
 
 .. tabs::
 

--- a/docs/source/tutorials/projects.rst
+++ b/docs/source/tutorials/projects.rst
@@ -9,6 +9,7 @@ First, we show general concepts like creating a new project from the |sdk|.
 Afterwards, we go into more detail such as working with attributes (e.g. labels),
 and incorporating advanced features such as integrating our automation models and algorithms.
 Make sure that you have associated a :xref:`public-private_key_pair` with |company| before you start.
+If not you can do so by following the :ref:`authentication:Public key authentication` tutorial.
 
 Creating a Project
 ==================
@@ -21,7 +22,7 @@ You can create a new project using the :meth:`create_project() <.EncordUserClien
   For more details on creating datasets, see :ref:`tutorials/datasets:Creating a dataset`.
   This can be set to an empty list
 
-* :meth:`project_description <.EncordClientProject.create_project>`: the description of the project as a string.
+* :meth:`project_description <.EncordUserClient.create_project>`: the description of the project as a string.
   This parameter is optional
 
 :meth:`create_project() <.EncordUserClient.create_project>` will return the ``<project_hash>`` of the created project.
@@ -49,16 +50,16 @@ Copying a project
 Copying a project creates another project with the same ontology and settings [#F1]_.
 You can also decide to copy over the same users, datasets and models (which aren't copied over by default).
 
-The :meth:`copy_project() <.EncordClientProject>` method takes the following parameters, all of which are optional:
+The :meth:`copy_project() <.ProjectManager.copy_project>` method takes the following parameters, all of which are optional:
 
-* ``copy_datasets``: when set to ``True``, the datasets from the original project will be copied over and new tasks will be created from them
-* ``copy_collaborators``:  when set to ``True``, the collaborators from the original project will be copied over with their existing roles
-* ``copy_models``:  when set to ``True``, the models and their training data from the original project will be copied over
+* :meth:`copy_datasets <.ProjectManager.copy_project>`: when set to ``True``, the datasets from the original project will be copied over and new tasks will be created from them
+* :meth:`copy_collaborators <.ProjectManager.copy_project>`:  when set to ``True``, the collaborators from the original project will be copied over with their existing roles
+* :meth:`copy_models <.ProjectManager.copy_project>`:  when set to ``True``, the models and their training data from the original project will be copied over
 
 The parameters above are set to ``False`` by default, meaning you do not need to include any of them if you
 do not want to copy that feature into your new project.
 
-:meth:`copy_project <.EncordClientProject.copy_project>` returns the ``<project_hash>`` of the new project.
+:meth:`copy_project <.ProjectManager.copy_project>` returns the ``<project_hash>`` of the new project.
 
 Here is an example of copying a project:
 
@@ -116,10 +117,10 @@ In the example below, a user authenticates with |company| and then fetches all p
 
 .. note::
 
-    :meth:`.EncordUserClient.get_projects` has multiple optional arguments that allow you to query projects with specific characteristics.
+    :meth:`.EncordUserClient.get_projects` has multiple optional arguments that allow you to perform a filtered search when querying projects.
 
     For example, if you only want projects with titles starting with "Validation", you could use ``user_client.get_projects(title_like="Validation%")``.
-    Other keyword arguments such as :meth:`created_before  <.EncordUserClient.get_datasets>` or :meth:`edited_after <.EncordUserClient.get_datasets>` may also be of interest.
+    Other keyword arguments such as :meth:`created_before  <.EncordUserClient.get_projects>` or :meth:`edited_after <.EncordUserClient.get_projects>` may also be of interest.
 
 
 Adding users to projects
@@ -165,6 +166,18 @@ Note how all users get assigned the same role.
 The return value is a list of :class:`.ProjectUser`.
 Each :class:`.ProjectUser` contains information about email, :class:`.ProjectUserRole` and ``<project_hash>``.
 
+Managing a project
+==================
+Your default choice for interacting with a project is via the :ref:`authentication:Public key authentication`.
+
+
+.. tabs::
+
+    .. tab:: Code
+
+        .. literalinclude:: /code_examples/tutorials/projects/creating_a_project_manager.py
+            :language: python
+
 
 API keys
 ========
@@ -175,7 +188,7 @@ Creating a project API key
 Creating a project API key with specific rights
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can create a project API key through :meth:`create_project_api_key() <.EncordUserClient.create_project_api_key>`, which is required to interact with a project using the project client.
+You can create a project API key through :meth:`create_project_api_key() <.EncordUserClient.create_project_api_key>`, which is required to interact with a project using the :class:`.ProjectManager`.
 
 This method takes three arguments:
 
@@ -293,7 +306,7 @@ To add an existing dataset to a project, you use the ``<dataset_hash>`` as follo
     You need to be an admin of the datasets that you want to add.
 
 .. note::
-    :meth:`add_datasets() <.EncordClientProject.add_datasets>` will throw an error if it is unable to add a dataset to a project.
+    :meth:`add_datasets() <.ProjectManager.add_datasets>` will throw an error if it is unable to add a dataset to a project.
     See the doc-string documentation for further details.
 
 Removing datasets from a project
@@ -321,7 +334,7 @@ To get those hashes, you can follow the example in :ref:`tutorials/datasets:List
     You need to be an admin of the datasets that you want to remove.
 
 .. note::
-    :meth:`remove_datasets() <.EncordClientProject.remove_datasets>` will throw an error if it is unable to remove a dataset from a project.
+    :meth:`remove_datasets() <.ProjectManager.remove_datasets>` will throw an error if it is unable to remove a dataset from a project.
     See the doc-string documentation for further details.
 
 
@@ -433,9 +446,9 @@ Objects are located using a graphical annotation, such as a bounding box or a po
 Adding a classification to an ontology
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Here we are in the "cat vs. dog" scenario from above.
-Classifications for cats and dogs are added to an ontology using the :meth:`add_classification() <.EncordClientProject.add_classification>` method.
+Classifications for cats and dogs are added to an ontology using the :meth:`add_classification() <.ProjectManager.add_classification>` method.
 
-The :meth:`add_classification() <.EncordClientProject.add_classification>` method takes the following parameters:
+The :meth:`add_classification() <.ProjectManager.add_classification>` method takes the following parameters:
 
 * ``name``: the description of the classification as a string
 * ``classification_type``: a value from the :class:`.ClassificationType` enum.
@@ -461,9 +474,9 @@ The :meth:`add_classification() <.EncordClientProject.add_classification>` metho
 Adding an object to an ontology
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Here we are in the "where is the dog" scenario.
-Objects are added to an existing ontology using the :meth:`add_object() <.EncordClientProject.add_object>` method.
+Objects are added to an existing ontology using the :meth:`add_object() <.ProjectManager.add_object>` method.
 
-The :meth:`add_object() <.EncordClientProject.add_object>` method takes the following parameters:
+The :meth:`add_object() <.ProjectManager.add_object>` method takes the following parameters:
 
 * ``name``: the description of the object as a string
 * ``shape``: the shape of the object used to annotate it of type :class:`.ObjectShape` enum
@@ -510,19 +523,10 @@ A label row contains a single data unit or a collection of data units together w
 
 A data unit can have any number of vector labels (e.g. bounding box, polygon, polyline, keypoint) and classifications.
 
-Before you start, make sure that a project client is initialised with the appropriate project ID and API key.
-
-.. code-block::
-
-    from encord.client import EncordClient
-
-    client = EncordClient.initialise("<project_hash>", "<project_api_key>")
-
-
 Getting label rows
 ------------------
 
-A project's ``<label_hash>`` is found in the project information ``client.get_project()``, which also contain information about the ``data_title``, ``data_type`` and ``label_status``.
+A project's ``<label_hash>`` is found in the project information ``project_manager.get_project()``, which also contain information about the ``data_title``, ``data_type`` and ``label_status``.
 
 .. code-block::
 
@@ -543,21 +547,21 @@ A project's ``<label_hash>`` is found in the project information ``client.get_pr
     }
 
 
-Use the client to fetch individual label objects.
+Use the :class:`.ProjectManager` to fetch individual label objects.
 
 .. code-block::
 
-    label = client.get_label_row("<label_hash>")
+    label = project_manager.get_label_row("<label_hash>")
 
 Use the :meth:`project.get_labels_list() <encord.orm.project.Project.get_labels_list>` method to get a list of label hashes (``<label_hash>``) in a project and fetch all project labels.
 
 .. code-block::
 
-    project = client.get_project()
+    project = project_manager.get_project()
 
     label_rows = []
     for label_hash in project.get_labels_list():
-        lb = client.get_label_row(label_hash)
+        lb = project_manager.get_label_row(label_hash)
         label_rows.append(lb)
 
 The label row object contains data units with signed URLs (``<data_link>``) to the labeled data asset.
@@ -651,7 +655,7 @@ To save labels for the data which was not labeled before, follow the steps under
 
 .. code-block::
 
-    client.save_label_row('<label_hash>', sample_label)
+    project_manager.save_label_row('<label_hash>', sample_label)
 
 Label rows have to be saved in the same format as fetched.
 The function :meth:`construct_answer_dictionaries() <encord.utilities.label_utilities.construct_answer_dictionaries>` helps construct answer dictionaries for all objects and classifications in the label row if they do not exist, returning a label row object with updated object and classification answer dictionaries.
@@ -660,9 +664,9 @@ The function :meth:`construct_answer_dictionaries() <encord.utilities.label_util
 
     from encord.utilities.label_utilities import construct_answer_dictionaries
 
-    sample_label = client.get_label_row("sample_label_uid")
+    sample_label = project_manager.get_label_row("sample_label_uid")
     updated_label = label_utilities.construct_answer_dictionaries(sample_label)
-    client.save_label_row(sample_label["label_hash"], updated_label)
+    project_manager.save_label_row(sample_label["label_hash"], updated_label)
 
 
 Creating a label row
@@ -675,7 +679,7 @@ If you want to save labels to a unit of data (``video``, ``img_group``) for whic
 
    .. code-block:: python
 
-       project = client.get_project()
+       project = project_manager.get_project()
        print(project.label_rows)
 
    In this example project, we have two videos.
@@ -709,7 +713,7 @@ If you want to save labels to a unit of data (``video``, ``img_group``) for whic
     .. code-block:: python
 
         data_hash = label_row["data_hash"]
-        my_label_row = client.create_label_row(data_hash)
+        my_label_row = project_manager.create_label_row(data_hash)
 
 
     The label row will have the expected structure and can be updated as needed.
@@ -722,7 +726,7 @@ The following method can be used to submit a label row for review.
 
 .. code-block::
 
-    client.submit_label_row_for_review("<label_hash>")
+    project_manager.submit_label_row_for_review("<label_hash>")
 
 The above method will submit the annotation task corresponding to the label row and create the review tasks corresponding to it based on the sampling rate in the project settings.
 
@@ -743,27 +747,24 @@ A data row contains a data unit, or a collection of data units, and has attribut
 #. A data row with a data asset of type ``video`` contains a single data unit in the form of a video
 #. A data row with a data asset of type ``img_group`` contains as many data units as there are images in the group
 
-Before you start, make sure that a project client is initialised with the appropriate project ID and API key.
 
 .. code-block:: python
+
     # type: Tuple[Optional[dict], Optional[List[dict]]
-    video, images = client.get_data("<data_hash>", generate_signed_url=True)
+    video, images = project_manager.get_data("<data_hash>", generate_signed_url=True)
 
 You can optionally return signed URLs for timed public access to that resource (default is False).
 
 Reviewing label logs
 --------------------
 
-You can query information about a project's labels by using the :meth:`get_label_logs() <.EncordClientProject.get_label_logs>` method of a client initialised for that project.
+You can query information about a project's labels by using the :meth:`get_label_logs() <.ProjectManager.get_label_logs>` method of a corresponding :class:`ProjectManager <.ProjectManager>`.
 You will need an API key with the ``label_logs.read`` permission.
-The :meth:`get_label_logs() <.EncordClientProject.get_label_logs>` method takes a number of optional parameters to narrow down the retrieved logs:
+The :meth:`get_label_logs() <.ProjectManager.get_label_logs>` method takes a number of optional parameters to narrow down the retrieved logs:
 
 .. code-block::
 
-    from encord.client import EncordClient
-
-    client = EncordClient.initialise("<project_id>", "<project_api_key>")
-    logs = client.get_label_logs(user_hash=<user_hash>)
+    logs = project_manager.get_label_logs(user_hash=<user_hash>)
     for log in logs:
         print(log)
 
@@ -801,16 +802,9 @@ Click on the *Model API details* button to toggle a code snippet with create mod
 
 .. code-block:: python
 
-    from encord.client import EncordClient
     from encord.constants.model import FASTER_RCNN
 
-    # Initialize project client
-    client = EncordClient.initialise(
-      "<project_id>",  # Project ID
-      "<project_api_key>"  # API key
-    )
-
-    model_row_hash = client.create_model_row(
+    model_row_hash = project_manager.create_model_row(
         title="Sample title",
         description="Sample description",  # Optional
         #  List of feature feature uid's (hashes) to be included in the model.
@@ -860,17 +854,10 @@ Click on the *Training API details* button to toggle a code snippet with model t
 
 .. code-block::
 
-    from encord.client import EncordClient
     from encord.constants.model_weights import *
 
-    # Initialize project client
-    client = EncordClient.initialise(
-      "<project_id>",  # Project ID
-      "<project_api_key>"  # API key with model.train access
-    )
-
     # Run training and print resulting model iteration object
-    model_iteration = client.model_train(
+    model_iteration = project_manager.model_train(
       <model_uid>,
       label_rows=["<label_row_1>", "<label_row_2>", ...], # Label row uid's
       epochs=500, # Number of passes through training dataset.
@@ -930,16 +917,8 @@ Click the 'Inference API details' icon next to the download button to toggle a c
 
 .. code-block::
 
-    from encord.client import EncordClient
-
-    # Initialize project client
-    client = EncordClient.initialise(
-      "<project_id>",  # Project ID
-      "<project_api_key>"  # API key with model.inference access
-    )
-
     # Run inference and print inference result
-    inference_result = client.model_inference(
+    inference_result = project_manager.model_inference(
       "<model_iteration_id>",  # Model iteration ID
       data_hashes=["video1_data_hash", "video2_data_hash"],  # List of data_hash values for videos/image groups
       detection_frame_range=[0, 100],  # Run detection on frames 0 to 100
@@ -955,7 +934,7 @@ The default confidence threshold is set to ``0.6``, the default IoU threshold is
 
 .. code-block::
 
-    inference_result = client.model_inference(
+    inference_result = project_manager.model_inference(
       "<model_iteration_id>",  # Model iteration ID
       data_hashes=["video1_data_hash", "video2_data_hash"],  # List of data_hash values for videos/image groups
       detection_frame_range=[0, 100],  # Run detection on frames 0 to 100
@@ -971,7 +950,7 @@ In case of locally stored images only JPEG and PNG file types are supported for 
 
 .. code-block::
 
-    inference_result = client.model_inference(
+    inference_result = project_manager.model_inference(
       "<model_iteration_id>",  # Model iteration ID
       file_paths=["path/to/file/1.jpg", "path/to/file/2.jpg"],  # Local file paths to images
       detection_frame_range=[1,1],
@@ -983,7 +962,7 @@ For running inference on locally stored videos, only ``mp4`` and ``webm`` video 
 
 .. code-block::
 
-    inference_result = client.model_inference(
+    inference_result = project_manager.model_inference(
       "<model_iteration_id>",  # Model iteration ID
       file_paths=["path/to/file/1.mp4", "path/to/file/2.mp4"],  # Local file paths to videos
       detection_frame_range=[0, 100],  # Run detection on frames 0 to 100
@@ -995,7 +974,7 @@ The model inference API also accepts a list of base64 encoded strings.
 
 .. code-block::
 
-    inference_result = client.model_inference(
+    inference_result = project_manager.model_inference(
       "<model_iteration_id>",  # Model iteration ID
       base64_strings=[base64_str_1, base_64_str_2],  # Base 64 encoded strings of images/videos
       detection_frame_range=[1,1],
@@ -1021,19 +1000,11 @@ Algorithms
 The |sdk| allows you to interact with Encord's algorithmic automation features.
 Our library includes sampling, augmentation, transformation and labeling algorithms.
 
-To get started with our algorithmic automation features, make you have created an API key with ``algo.library`` added to access scopes and initialised a project client with the appropriate project ID and API key.
-
-.. code-block::
-
-    from encord.client import EncordClient
-    client = EncordClient.initialise("<resource_id>", "<resource_api_key>")
-
-
 
 Object interpolation
 --------------------
 
-The client object interpolator allows you to run interpolation algorithms on project labels (requires a project ontology).
+The :class:`.ProjectManager` object interpolator allows you to run interpolation algorithms on project labels (requires a project ontology).
 
 Interpolation is supported for the following annotation types:
 
@@ -1041,7 +1012,7 @@ Interpolation is supported for the following annotation types:
 #. Polygon
 #. Keypoint
 
-Use the :meth:`.EncordClientProject.object_interpolation` method to run object interpolation.
+Use the :meth:`.ProjectManager.object_interpolation` method to run object interpolation.
 
 Key frames, between which interpolation is run, can be obtained from label rows containing videos.
 The objects to interpolate between key frames is a list of ``<object_hash>`` values obtained from the ``label_row["labels"]["<frame_number>"]["objects"]`` entry in the label row.
@@ -1056,14 +1027,14 @@ The interpolation algorithm can be run on multiple objects with different ontolo
         .. code-block:: python
 
             # Fetch label row
-            sample_label = client.get_label_row("sample_label_uid")
+            sample_label = project_manager.get_label_row("sample_label_uid")
 
             # Prepare interpolation
             key_frames = sample_label["data_units"]["sample_data_hash"]["labels"]
             objects_to_interpolate = ["sample_object_uid"]
 
             # Run interpolation
-            interpolation_result = client.object_interpolation(key_frames, objects_to_interpolate)
+            interpolation_result = project_manager.object_interpolation(key_frames, objects_to_interpolate)
             print(interpolation_result)
 
     .. tab:: Example output
@@ -1103,7 +1074,7 @@ The interpolation algorithm can be run on multiple objects with different ontolo
             }
 
 
-The interpolation algorithm can also be run from sample frames kept locally, with ``key_frames`` passed in a simple JSON structure (see :meth:`doc-strings <.EncordClientProject.object_interpolation>`).
+The interpolation algorithm can also be run from sample frames kept locally, with ``key_frames`` passed in a simple JSON structure (see :meth:`doc-strings <.ProjectManager.object_interpolation>`).
 
 All that is required is a ``<feature_hash>`` and ``object_hash`` for each object in your set of key frames.
 

--- a/docs/source/tutorials/projects.rst
+++ b/docs/source/tutorials/projects.rst
@@ -181,6 +181,8 @@ Your default choice for interacting with a project is via the :ref:`authenticati
 
 API keys
 ========
+We recommend using a :class:`.ProjectManager` as described in :ref:`tutorials/projects:Managing a project`.
+This will be simpler than dealing with API keys which should only be used under specific circumstances as described in :ref:`authentication:API key authentication`.
 
 Creating a project API key
 --------------------------

--- a/docs/source/tutorials/projects.rst
+++ b/docs/source/tutorials/projects.rst
@@ -166,7 +166,7 @@ The return value is a list of :class:`.ProjectUser`.
 Each :class:`.ProjectUser` contains information about email, :class:`.ProjectUserRole` and ``<project_hash>``.
 
 
-API Keys
+API keys
 ========
 
 Creating a project API key

--- a/encord/__init__.py
+++ b/encord/__init__.py
@@ -1,0 +1,2 @@
+# from client import DatasetManager, ProjectManager
+# from user_client import EncordUserClient

--- a/encord/__init__.py
+++ b/encord/__init__.py
@@ -1,2 +1,2 @@
-# from client import DatasetManager, ProjectManager
-# from user_client import EncordUserClient
+from encord.client import DatasetManager, ProjectManager
+from encord.user_client import EncordUserClient

--- a/encord/__init__.py
+++ b/encord/__init__.py
@@ -1,2 +1,3 @@
-from encord.client import DatasetManager, ProjectManager
+from encord.dataset import Dataset
+from encord.project import Project
 from encord.user_client import EncordUserClient

--- a/encord/client.py
+++ b/encord/client.py
@@ -186,7 +186,8 @@ class EncordClient(object):
 CordClient = EncordClient
 
 
-class DatasetManager(EncordClient):
+# DENIS: could make this a base and add the `get_dataset` into the impl if we don't want to expose it
+class EncordClientDataset(EncordClient):
     def get_dataset(self) -> Dataset:
         """
         Retrieve dataset info (pointers to data, labels).
@@ -378,11 +379,11 @@ class DatasetManager(EncordClient):
         return response
 
 
-EncordClientDataset = DatasetManager
+# EncordClientDataset = DatasetManager
 CordClientDataset = EncordClientDataset
 
 
-class ProjectManager(EncordClient):
+class EncordClientProject(EncordClient):
     def get_project(self):
         """
         Retrieve project info (pointers to data, labels).
@@ -1109,6 +1110,6 @@ class ProjectManager(EncordClient):
         return self._querier.basic_setter(Project, uid=None, payload=payload)
 
 
-EncordClientProject = ProjectManager
+# EncordClientProject = ProjectManager
 
 CordClientProject = EncordClientProject

--- a/encord/client.py
+++ b/encord/client.py
@@ -1073,6 +1073,7 @@ class Project(EncordClient):
         return video, images
 
     def get_websocket_url(self) -> str:
+        return self._config.get_websocket_url()
         return (
             f"{self._config.websocket_endpoint}?"
             f"client_type={2}&"

--- a/encord/client.py
+++ b/encord/client.py
@@ -27,7 +27,7 @@ and obtaining project info:
     client.get_project()
 
     Returns:
-        ProjectManager: A project record instance. See Project ORM for details.
+        Project: A project record instance. See Project ORM for details.
 
 """
 

--- a/encord/client.py
+++ b/encord/client.py
@@ -19,8 +19,6 @@ to query project resources through the Encord API.
 Here is a simple example for instantiating the client for a project
 and obtaining project info:
 
-.. test_blurb2.py code::
-
     from encord.client import EncordClient
 
     client = EncordClient.initialize('YourProjectID', 'YourAPIKey')

--- a/encord/constants/string_constants.py
+++ b/encord/constants/string_constants.py
@@ -32,3 +32,4 @@ FITTED_BOUNDING_BOX = "fitted_bounding_box"
 # Type of Cord API key
 TYPE_PROJECT = "project"
 TYPE_DATASET = "dataset"
+ALL_RESOURCE_TYPES = [TYPE_PROJECT, TYPE_DATASET]

--- a/encord/dataset.py
+++ b/encord/dataset.py
@@ -1,0 +1,61 @@
+from typing import List
+
+from encord.client import EncordClientDataset
+from encord.configs import Config
+from encord.http.querier import Querier
+from encord.orm.dataset import DataRow
+from encord.orm.dataset import Dataset as OrmDataset
+from encord.orm.dataset import StorageLocation
+
+
+class Dataset(EncordClientDataset):
+    def __init__(self, querier: Querier, config: Config):
+        super().__init__(querier, config)
+        self._dataset_instance = None
+
+    def _get_dataset_instance(self):
+        if self._dataset_instance is None:
+            self._dataset_instance = self.get_dataset()
+        return self._dataset_instance
+
+    @property
+    def title(self) -> str:
+        """
+        Get the title of the dataset
+        Returns: title
+        """
+        dataset_instance = self._get_dataset_instance()
+        return dataset_instance.title
+
+    @property
+    def description(self) -> str:
+        """
+        Get the description of the dataset
+        """
+        dataset_instance = self._get_dataset_instance()
+        return dataset_instance.description
+
+    @property
+    def storage_location(self) -> StorageLocation:
+        """..."""
+        dataset_instance = self._get_dataset_instance()
+        return dataset_instance.storage_location
+
+    @property
+    def data_rows(self) -> List[DataRow]:
+        """..."""
+        dataset_instance = self._get_dataset_instance()
+        return dataset_instance.data_rows
+
+    def refetch_data(self) -> None:
+        """
+        The Dataset class will only fetch its properties once. Use this function if you suspect the state of those
+        properties to be dirty.
+        """
+        self._dataset_instance = self.get_dataset()
+
+    def get_dataset(self) -> OrmDataset:
+        """
+        This function is exposed for convenience. You are encouraged to use the property accessors instead.
+        """
+        return super().get_dataset()

--- a/encord/encord_objects/ontology.py
+++ b/encord/encord_objects/ontology.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import List, Optional, Union
+
+from encord.orm.project import StringEnum
+
+NestedID = List[int]
+
+
+class PropertyType(StringEnum):
+    RADIO = "radio"
+    TEXT = "text"
+    CHECKLIST = "checklist"
+
+
+class Shape(StringEnum):
+    BOUNDING_BOX = "bounding_box"
+    POLYGON = "polygon"
+    POINT = "point"
+    SKELETON = "skeleton"
+
+
+def _decode_nested_uid(nested_uid: list) -> str:
+    return ".".join([str(uid) for uid in nested_uid])
+
+
+def _attribute_id_from_json_str(attribute_id: str) -> NestedID:
+    nested_ids = attribute_id.split(".")
+    return [int(x) for x in nested_ids]
+
+
+@dataclass
+class _AttributeBase(ABC):
+    """
+    Just a trick to forward declare the Attribute dataclass for better typing support.
+    Do not instantiate this dataclass directly.
+    """
+
+    uid: NestedID
+    feature_node_hash: str
+    name: str
+    required: bool
+
+    @abstractmethod
+    def get_property_type(self) -> PropertyType:
+        pass
+
+    @abstractmethod
+    def has_options_field(self) -> bool:
+        pass
+
+    def to_dict(self) -> dict:
+        ret = self._encode_base()
+
+        options = self._encode_options()
+        if options is not None:
+            ret["options"] = options
+
+        return ret
+
+    @classmethod
+    def from_dict(cls, d: dict) -> Attribute:
+        property_type = d["type"]
+        common_attribute_fields = cls._decode_common_attribute_fields(d)
+        if property_type == "radio":
+            options_ret: List[NestableOption] = list()
+            if "options" in d:
+                for options_dict in d["options"]:
+                    options_ret.append(NestableOption.from_dict(options_dict))
+
+            return RadioAttribute(
+                **common_attribute_fields,
+                options=options_ret,
+            )
+
+        elif property_type == "checklist":
+            options_ret: List[FlatOption] = list()
+            if "options" in d:
+                for options_dict in d["options"]:
+                    options_ret.append(FlatOption.from_dict(options_dict))
+
+            return ChecklistAttribute(
+                **common_attribute_fields,
+                options=options_ret,
+            )
+
+        elif property_type == "text":
+            return TextAttribute(
+                **common_attribute_fields,
+            )
+
+        raise TypeError(
+            f"Attribute is ill-formed: '{d}'. Expected to see either "
+            f"attribute specific fields or option specific fields. Got both or none of them."
+        )
+
+    def _encode_base(self) -> dict:
+        ret = dict()
+        ret["id"] = _decode_nested_uid(self.uid)
+        ret["name"] = self.name
+        ret["type"] = self.get_property_type().value
+        ret["featureNodeHash"] = self.feature_node_hash
+        ret["required"] = self.required
+
+        return ret
+
+    def _encode_options(self) -> Optional[list]:
+        if not self.has_options_field() or not self.options:
+            return None
+
+        self: OptionAttribute
+
+        ret = list()
+        for option in self.options:
+            ret.append(option.to_dict())
+        return ret
+
+    @staticmethod
+    def _decode_common_attribute_fields(attribute_dict: dict) -> dict:
+        return {
+            "uid": _attribute_id_from_json_str(attribute_dict["id"]),
+            "feature_node_hash": attribute_dict["featureNodeHash"],
+            "name": attribute_dict["name"],
+            "required": attribute_dict["required"],
+        }
+
+
+def attribute_from_dict(d: dict) -> Attribute:
+    """Convenience functions as you cannot call static member on union types."""
+    return _AttributeBase.from_dict(d)
+
+
+def attributes_to_list_dict(attributes: List[Attribute]) -> list:
+    attributes_list = list()
+    for attribute in attributes:
+        attributes_list.append(attribute.to_dict())
+
+    return attributes_list
+
+
+class OptionType(Enum):
+    FLAT = auto()
+    NESTABLE = auto()
+
+
+@dataclass
+class _OptionBase(ABC):
+    uid: NestedID
+    feature_node_hash: str
+    label: str
+    value: str
+
+    @abstractmethod
+    def get_option_type(self) -> OptionType:
+        pass
+
+    def to_dict(self) -> dict:
+        ret = dict()
+        ret["id"] = _decode_nested_uid(self.uid)
+        ret["label"] = self.label
+        ret["value"] = self.value
+        ret["featureNodeHash"] = self.feature_node_hash
+
+        nested_options = self._encode_nested_options()
+        if nested_options:
+            ret["options"] = nested_options
+
+        return ret
+
+    @abstractmethod
+    def _encode_nested_options(self) -> list:
+        pass
+
+    @staticmethod
+    def _decode_common_option_fields(option_dict: dict) -> dict:
+        return {
+            "uid": _attribute_id_from_json_str(option_dict["id"]),
+            "label": option_dict["label"],
+            "value": option_dict["value"],
+            "feature_node_hash": option_dict["featureNodeHash"],
+        }
+
+
+@dataclass
+class FlatOption(_OptionBase):
+    def get_option_type(self) -> OptionType:
+        return OptionType.FLAT
+
+    @classmethod
+    def from_dict(cls, d: dict) -> FlatOption:
+        return FlatOption(**cls._decode_common_option_fields(d))
+
+    def _encode_nested_options(self) -> list:
+        return []
+
+
+@dataclass
+class NestableOption(_OptionBase):
+    nested_options: List[Attribute] = field(default_factory=list)
+
+    def get_option_type(self) -> OptionType:
+        return OptionType.NESTABLE
+
+    def _encode_nested_options(self) -> list:
+        return attributes_to_list_dict(self.nested_options)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> NestableOption:
+        nested_options_ret: List[Attribute] = list()
+        if "options" in d:
+            for nested_option in d["options"]:
+                nested_options_ret.append(attribute_from_dict(nested_option))
+        return NestableOption(
+            **cls._decode_common_option_fields(d),
+            nested_options=nested_options_ret,
+        )
+
+
+Option = Union[FlatOption, NestableOption]
+
+
+@dataclass
+class RadioAttribute(_AttributeBase):
+    options: List[NestableOption] = field(default_factory=list)
+
+    def get_property_type(self) -> PropertyType:
+        return PropertyType.RADIO
+
+    def has_options_field(self) -> bool:
+        return True
+
+
+@dataclass
+class ChecklistAttribute(_AttributeBase):
+    options: List[FlatOption] = field(default_factory=list)
+
+    def get_property_type(self) -> PropertyType:
+        return PropertyType.CHECKLIST
+
+    def has_options_field(self) -> bool:
+        return True
+
+
+@dataclass
+class TextAttribute(_AttributeBase):
+    def get_property_type(self) -> PropertyType:
+        return PropertyType.TEXT
+
+    def has_options_field(self) -> bool:
+        return False
+
+
+Attribute = Union[RadioAttribute, ChecklistAttribute, TextAttribute]
+OptionAttribute = Union[RadioAttribute, ChecklistAttribute]
+
+
+@dataclass
+class Classification:
+    uid: int
+    feature_node_hash: str
+    attributes: List[Attribute]
+
+    @classmethod
+    def from_dict(cls, d: dict) -> Classification:
+        attributes_ret: List[Attribute] = list()
+        for attribute_dict in d["attributes"]:
+            attributes_ret.append(attribute_from_dict(attribute_dict))
+
+        return Classification(
+            uid=int(d["id"]),
+            feature_node_hash=d["featureNodeHash"],
+            attributes=attributes_ret,
+        )
+
+    def to_dict(self) -> dict:
+        ret = dict()
+        ret["id"] = str(self.uid)
+        ret["featureNodeHash"] = self.feature_node_hash
+
+        attributes_list = attributes_to_list_dict(self.attributes)
+        if attributes_list:
+            ret["attributes"] = attributes_list
+
+        return ret
+
+
+@dataclass
+class Object:
+    uid: int
+    name: str
+    color: str
+    shape: Shape
+    # DENIS: rename this?
+    feature_node_hash: str
+    attributes: List[Attribute] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> Object:
+        shape_opt = Shape.from_string(d["shape"])
+        if shape_opt is None:
+            raise TypeError(f"The shape '{d['shape']}' of the object '{d}' is not recognised")
+
+        attributes_ret: List[Attribute] = list()
+        if "attributes" in d:
+            for attribute_dict in d["attributes"]:
+                attributes_ret.append(attribute_from_dict(attribute_dict))
+
+        object_ret = Object(
+            uid=int(d["id"]),
+            name=d["name"],
+            color=d["color"],
+            shape=shape_opt,
+            feature_node_hash=d["featureNodeHash"],
+            attributes=attributes_ret,
+        )
+
+        return object_ret
+
+    def to_dict(self) -> dict:
+        ret = dict()
+        ret["id"] = str(self.uid)
+        ret["name"] = self.name
+        ret["color"] = self.color
+        ret["shape"] = self.shape.value
+        ret["featureNodeHash"] = self.feature_node_hash
+
+        attributes_list = attributes_to_list_dict(self.attributes)
+        if attributes_list:
+            ret["attributes"] = attributes_list
+
+        return ret
+
+
+@dataclass
+class Ontology:
+    # could add the project_uid here
+    objects: List[Object] = field(default_factory=list)
+    classifications: List[Classification] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> Ontology:
+        """
+        Args:
+            d: a JSON blob of an "editor
+
+        Raises:
+            KeyError: If the dict is missing a required field.
+        """
+        objects_ret: List[Object] = list()
+        for object_dict in d["objects"]:
+            objects_ret.append(Object.from_dict(object_dict))
+
+        classifications_ret: List[Classification] = list()
+        for classification_dict in d["classifications"]:
+            classifications_ret.append(Classification.from_dict(classification_dict))
+
+        return Ontology(objects=objects_ret, classifications=classifications_ret)
+
+    def to_dict(self) -> dict:
+        """
+        Args:
+            ontology_instance: an ontology.Ontology object
+
+        Returns:
+            The dict equivalent to the ontology which can be inserted as an `editor` row
+                within the `projects` table.
+
+        Raises:
+            KeyError: If the dict is missing a required field.
+        """
+        ret = dict()
+        ontology_objects = list()
+        ret["objects"] = ontology_objects
+        for ontology_object in self.objects:
+            ontology_objects.append(ontology_object.to_dict())
+
+        ontology_classifications = list()
+        ret["classifications"] = ontology_classifications
+        for ontology_classification in self.classifications:
+            ontology_classifications.append(ontology_classification.to_dict())
+
+        return ret

--- a/encord/encord_objects/tests/data/editor_blob.json
+++ b/encord/encord_objects/tests/data/editor_blob.json
@@ -1,0 +1,103 @@
+{
+  "objects": [
+    {
+      "id": "1",
+      "name": "Eye",
+      "color": "#D33115",
+      "shape": "bounding_box",
+      "featureNodeHash": "a55abbeb"
+    },
+    {
+      "id": "2",
+      "name": "Nose",
+      "color": "#E27300",
+      "shape": "polygon",
+      "featureNodeHash": "86648f32",
+      "attributes": [
+        {
+          "id": "2.1",
+          "name": "Additional details about the nose",
+          "type": "checklist",
+          "required": true,
+          "featureNodeHash": "1e3e5cad",
+          "options": [
+            {
+              "id": "2.1.1",
+              "label": "Is it a cute nose?",
+              "value": "is_it_a_cute_nose?",
+              "featureNodeHash": "2bc17c88"
+            },
+            {
+              "id": "2.1.2",
+              "label": "Is it a wet nose? ",
+              "value": "is_it_a_wet_nose?_",
+              "featureNodeHash": "86eaa4f2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "3",
+      "name": "Example",
+      "color": "#FE9200",
+      "shape": "bounding_box",
+      "featureNodeHash": "6eeba59b",
+      "attributes": [
+        {
+          "id": "4.1",
+          "name": "Radio with options",
+          "type": "radio",
+          "required": false,
+          "featureNodeHash": "cabfedb5",
+          "options": [
+            {
+              "id": "4.1.1",
+              "label": "Nested Option",
+              "value": "nested_option",
+              "featureNodeHash": "5d102ce6",
+              "options": [
+                {
+                  "id": "4.1.1.1",
+                  "name": "Leaf",
+                  "type": "radio",
+                  "required": false,
+                  "featureNodeHash": "59204845"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "classifications": [
+    {
+      "id": "1",
+      "featureNodeHash": "a39d81c0",
+      "attributes": [
+        {
+          "id": "1.1",
+          "name": "Is the cat standing?",
+          "type": "radio",
+          "required": true,
+          "featureNodeHash": "a6136d14",
+          "options": [
+            {
+              "id": "1.1.1",
+              "label": "Yes",
+              "value": "yes",
+              "featureNodeHash": "a3aeb48d"
+            },
+            {
+              "id": "1.1.2",
+              "label": "No",
+              "value": "no",
+              "featureNodeHash": "d0a4b373"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/encord/encord_objects/tests/test_ontology.py
+++ b/encord/encord_objects/tests/test_ontology.py
@@ -1,0 +1,134 @@
+import json
+import os
+
+from encord.encord_objects import ontology
+from encord.encord_objects.ontology import Shape
+
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(CURRENT_DIR, "data")
+
+EXPECTED_ONTOLOGY: ontology.Ontology = ontology.Ontology(
+    objects=[
+        ontology.Object(
+            uid=1,
+            name="Eye",
+            color="#D33115",
+            shape=Shape.BOUNDING_BOX,
+            feature_node_hash="a55abbeb",
+        ),
+        ontology.Object(
+            uid=2,
+            name="Nose",
+            color="#E27300",
+            shape=Shape.POLYGON,
+            feature_node_hash="86648f32",
+            attributes=[
+                ontology.ChecklistAttribute(
+                    uid=[2, 1],
+                    feature_node_hash="1e3e5cad",
+                    name="Additional details about the nose",
+                    required=True,
+                    options=[
+                        ontology.FlatOption(
+                            uid=[2, 1, 1],
+                            feature_node_hash="2bc17c88",
+                            label="Is it a cute nose?",
+                            value="is_it_a_cute_nose?",
+                        ),
+                        ontology.FlatOption(
+                            uid=[2, 1, 2],
+                            feature_node_hash="86eaa4f2",
+                            label="Is it a wet nose? ",
+                            value="is_it_a_wet_nose?_",
+                        ),
+                    ],
+                )
+            ],
+        ),
+        ontology.Object(
+            uid=3,
+            name="Example",
+            color="#FE9200",
+            shape=Shape.BOUNDING_BOX,
+            feature_node_hash="6eeba59b",
+            attributes=[
+                ontology.RadioAttribute(
+                    uid=[4, 1],
+                    feature_node_hash="cabfedb5",
+                    name="Radio with options",
+                    required=False,
+                    options=[
+                        ontology.NestableOption(
+                            uid=[4, 1, 1],
+                            feature_node_hash="5d102ce6",
+                            label="Nested Option",
+                            value="nested_option",
+                            nested_options=[
+                                ontology.RadioAttribute(
+                                    uid=[4, 1, 1, 1],
+                                    feature_node_hash="59204845",
+                                    name="Leaf",
+                                    required=False,
+                                )
+                            ],
+                        )
+                    ],
+                )
+            ],
+        ),
+    ],
+    classifications=[
+        ontology.Classification(
+            uid=1,
+            feature_node_hash="a39d81c0",
+            attributes=[
+                ontology.RadioAttribute(
+                    uid=[1, 1],
+                    feature_node_hash="a6136d14",
+                    name="Is the cat standing?",
+                    required=True,
+                    options=[
+                        ontology.NestableOption(
+                            uid=[1, 1, 1],
+                            feature_node_hash="a3aeb48d",
+                            label="Yes",
+                            value="yes",
+                        ),
+                        ontology.NestableOption(
+                            uid=[1, 1, 2],
+                            feature_node_hash="d0a4b373",
+                            label="No",
+                            value="no",
+                        ),
+                    ],
+                )
+            ],
+        )
+    ],
+)
+
+
+def test_json_to_ontology():
+    # GIVEN
+    file_path = os.path.join(DATA_DIR, "editor_blob.json")
+    with open(file_path, "r", encoding="utf8") as f:
+        editor_dict = json.load(f)
+
+    # WHEN
+    actual = ontology.Ontology.from_dict(editor_dict)
+
+    # THEN
+    assert EXPECTED_ONTOLOGY == actual
+
+
+def test_ontology_to_json():
+    # GIVEN
+    file_path = os.path.join(DATA_DIR, "editor_blob.json")
+    with open(file_path, "r", encoding="utf8") as f:
+        editor_dict = json.load(f)
+
+    # WHEN
+    actual = EXPECTED_ONTOLOGY.to_dict()
+
+    # THEN
+    assert editor_dict == actual

--- a/encord/http/querier.py
+++ b/encord/http/querier.py
@@ -84,7 +84,7 @@ class Querier:
             db_object_type,
             uid,
             self._config.write_timeout,
-            payload=payload,
+            payloadØ=payload,
         )
 
         res = self.execute(request)

--- a/encord/http/querier.py
+++ b/encord/http/querier.py
@@ -84,7 +84,7 @@ class Querier:
             db_object_type,
             uid,
             self._config.write_timeout,
-            payloadØ=payload,
+            payload=payload,
         )
 
         res = self.execute(request)

--- a/encord/orm/label_row.py
+++ b/encord/orm/label_row.py
@@ -16,7 +16,7 @@ import json
 from collections import OrderedDict
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict
+from typing import Dict, List
 
 from encord.orm import base_orm
 from encord.orm.formatter import Formatter
@@ -223,7 +223,7 @@ class LabelRowMetadata(Formatter):
     annotation_task_status: AnnotationTaskStatus
 
     @classmethod
-    def from_dict(cls, json_dict: Dict):
+    def from_dict(cls, json_dict: Dict) -> "LabelRowMetadata":
         return LabelRowMetadata(
             json_dict["label_hash"],
             json_dict["data_hash"],
@@ -233,3 +233,10 @@ class LabelRowMetadata(Formatter):
             LabelStatus(json_dict["label_status"]),
             AnnotationTaskStatus(json_dict["annotation_task_status"]),
         )
+
+    @classmethod
+    def from_list(cls, json_list: list) -> List["LabelRowMetadata"]:
+        ret = []
+        for i in json_list:
+            ret.append(cls.from_dict(i))
+        return ret

--- a/encord/project.py
+++ b/encord/project.py
@@ -1,0 +1,129 @@
+import datetime
+from dataclasses import dataclass
+from typing import List, Optional
+
+from encord.client import EncordClientProject
+from encord.configs import Config
+from encord.encord_objects.ontology import Ontology
+from encord.http.querier import Querier
+from encord.orm.label_row import LabelRowMetadata
+from encord.orm.project import Project as OrmProject
+from encord.project_ontology.ontology import Ontology as LegacyOntology
+
+
+@dataclass
+class ProjectDataset:
+    dataset_hash: str
+    title: str
+    description: str
+
+    @staticmethod
+    def from_dict(d: dict) -> "ProjectDataset":
+        return ProjectDataset(
+            dataset_hash=d["dataset_hash"],
+            title=d["title"],
+            description=d["description"],
+        )
+
+    @classmethod
+    def from_list(cls, l: list) -> List["ProjectDataset"]:
+        ret = []
+        for i in l:
+            ret.append(cls.from_dict(i))
+        return ret
+
+
+class Project(EncordClientProject):
+    def __init__(self, querier: Querier, config: Config):
+        super().__init__(querier, config)
+        #  DENIS: possibly keep a parsed `ProjectDataclass` here instead of parsing every time on access.
+        self._project_instance: Optional[OrmProject] = None
+
+    def _get_project_instance(self):
+        if self._project_instance is None:
+            self._project_instance = self.get_project()
+        return self._project_instance
+
+    @property
+    def project_hash(self) -> str:
+        """
+        ...
+        """
+        project_instance = self._get_project_instance()
+        return project_instance.project_hash
+
+    @property
+    def title(self) -> str:
+        """
+        ...
+        """
+        project_instance = self._get_project_instance()
+        return project_instance.title
+
+    @property
+    def description(self) -> str:
+        """
+        ...
+        """
+        project_instance = self._get_project_instance()
+        return project_instance.description
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        """
+        ...
+        """
+        project_instance = self._get_project_instance()
+        return project_instance.created_at
+
+    @property
+    def last_edited_at(self) -> datetime.datetime:
+        """
+        ...
+        """
+        project_instance = self._get_project_instance()
+        return project_instance.last_edited_at
+
+    @property
+    def editor_ontology(self) -> Ontology:
+        """
+        ...
+        """
+        project_instance = self._get_project_instance()
+        return Ontology.from_dict(project_instance.editor_ontology)
+
+    @property
+    def datasets(self) -> List[ProjectDataset]:
+        """
+        ...
+        """
+        project_instance = self._get_project_instance()
+        return ProjectDataset.from_list(project_instance.datasets)
+
+    @property
+    def label_rows(self) -> List[LabelRowMetadata]:
+        """
+        ...
+        """
+        project_instance = self._get_project_instance()
+        return LabelRowMetadata.from_list(project_instance.label_rows)
+
+    def refetch_data(self) -> None:
+        """
+        The Project class will only fetch its properties once. Use this function if you suspect the state of those
+        properties to be dirty.
+        """
+        self._project_instance = self.get_project()
+
+    def get_project(self) -> OrmProject:
+        """
+        This function is exposed for convenience. You are encouraged to use the property accessors instead.
+        """
+        return super().get_project()
+
+    def get_project_ontology(self) -> LegacyOntology:
+        """
+        This function is exposed for convenience. You are encouraged to use the editor_ontology() property accessors
+        instead. The editor_ontology() property accessor returns a more complete ontology object.
+        """
+        return super().get_project_ontology()

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -25,7 +25,7 @@ from encord.constants.string_constants import TYPE_DATASET, TYPE_PROJECT
 from encord.http.querier import Querier
 from encord.http.utils import upload_to_signed_url_list
 from encord.orm.cloud_integration import CloudIntegration
-from encord.orm.dataset import (  # Dataset,
+from encord.orm.dataset import (
     CreateDatasetResponse,
     Dataset,
     DatasetAPIKey,
@@ -37,7 +37,7 @@ from encord.orm.dataset import (  # Dataset,
     StorageLocation,
 )
 from encord.orm.dataset_with_user_role import DatasetWithUserRole
-from encord.orm.project import (  # Project,
+from encord.orm.project import (
     CvatExportType,
     Project,
     ProjectImporter,
@@ -103,12 +103,12 @@ class EncordUserClient:
         result = self.querier.basic_setter(Dataset, uid=None, payload=dataset)
         return CreateDatasetResponse.from_dict(result)
 
-    def get_dataset_manager(self, dataset_hash: str):
+    def get_dataset_manager(self, dataset_hash: str) -> DatasetManager:
         config = SshConfig(self.user_config, resource_type=TYPE_DATASET, resource_id=dataset_hash)
         querier = Querier(config)
         return DatasetManager(querier=querier, config=config)
 
-    def get_project_manager(self, project_hash: str):
+    def get_project_manager(self, project_hash: str) -> ProjectManager:
         config = SshConfig(self.user_config, resource_type=TYPE_PROJECT, resource_id=project_hash)
         querier = Querier(config)
         return ProjectManager(querier=querier, config=config)

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -104,11 +104,30 @@ class EncordUserClient:
         return CreateDatasetResponse.from_dict(result)
 
     def get_dataset_manager(self, dataset_hash: str) -> DatasetManager:
+        """
+        Get a `DatasetManager` to interact with a specific project. This DatasetManager will be authenticated for all
+        operations if
+            * You are a dataset admin or
+            * You are an organisation admin of the organisation that holds the project
+
+        Args:
+            dataset_hash: The hash value under the Dataset ID
+        """
         config = SshConfig(self.user_config, resource_type=TYPE_DATASET, resource_id=dataset_hash)
         querier = Querier(config)
         return DatasetManager(querier=querier, config=config)
 
     def get_project_manager(self, project_hash: str) -> ProjectManager:
+        """
+        Get a `ProjectManager` to interact with a specific project. This ProjectManager will be authenticated for all
+        operations if
+            * You are a project admin or
+            * You are a project team manager or
+            * You are an organisation admin of the organisation that holds the project
+
+        Args:
+            project_hash: The hash value under the Project ID
+        """
         config = SshConfig(self.user_config, resource_type=TYPE_PROJECT, resource_id=project_hash)
         querier = Querier(config)
         return ProjectManager(querier=querier, config=config)
@@ -244,12 +263,16 @@ class EncordUserClient:
         return self.querier.basic_put(ProjectAPIKey, uid=project_hash, payload={})
 
     def get_dataset_client(self, dataset_hash: str, **kwargs) -> Union[EncordClientProject, EncordClientDataset]:
-        """Deprecated??"""
+        """
+        DEPRECATED - prefer using `get_dataset_manager()` instead.
+        """
         dataset_api_key: DatasetAPIKey = self.get_or_create_dataset_api_key(dataset_hash)
         return EncordClient.initialise(dataset_hash, dataset_api_key.api_key, **kwargs)
 
     def get_project_client(self, project_hash: str, **kwargs) -> Union[EncordClientProject, EncordClientDataset]:
-        """Deprecated??"""
+        """
+        DEPRECATED - prefer using `get_project_manager()` instead.
+        """
         project_api_key: str = self.get_or_create_project_api_key(project_hash)
         return EncordClient.initialise(project_hash, project_api_key, **kwargs)
 

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -107,7 +107,9 @@ class EncordUserClient:
         """
         Get a `DatasetManager` to interact with a specific project. This DatasetManager will be authenticated for all
         operations if
+
             * You are a dataset admin or
+
             * You are an organisation admin of the organisation that holds the project
 
         Args:
@@ -121,8 +123,11 @@ class EncordUserClient:
         """
         Get a `ProjectManager` to interact with a specific project. This ProjectManager will be authenticated for all
         operations if
+
             * You are a project admin or
+
             * You are a project team manager or
+
             * You are an organisation admin of the organisation that holds the project
 
         Args:

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -13,15 +13,14 @@ import dateutil
 
 # add this for backward compatible class comparisons
 from cord.utilities.client_utilities import LocalImport as CordLocalImport
-from encord.client import (
-    DatasetManager,
+from encord.client import (  # DatasetManager,; ProjectManager,
     EncordClient,
     EncordClientDataset,
     EncordClientProject,
-    ProjectManager,
 )
 from encord.configs import SshConfig, UserConfig, get_env_ssh_key
 from encord.constants.string_constants import TYPE_DATASET, TYPE_PROJECT
+from encord.dataset import Dataset as DatasetClass
 from encord.http.querier import Querier
 from encord.http.utils import upload_to_signed_url_list
 from encord.orm.cloud_integration import CloudIntegration
@@ -103,39 +102,45 @@ class EncordUserClient:
         result = self.querier.basic_setter(Dataset, uid=None, payload=dataset)
         return CreateDatasetResponse.from_dict(result)
 
-    def get_dataset_manager(self, dataset_hash: str) -> DatasetManager:
-        """
-        Get a `DatasetManager` to interact with a specific project. This DatasetManager will be authenticated for all
-        operations if
-
-            * You are a dataset admin or
-
-            * You are an organisation admin of the organisation that holds the project
-
-        Args:
-            dataset_hash: The hash value under the Dataset ID
-        """
+    def get_dataset(self, dataset_hash: str) -> DatasetClass:
         config = SshConfig(self.user_config, resource_type=TYPE_DATASET, resource_id=dataset_hash)
         querier = Querier(config)
-        return DatasetManager(querier=querier, config=config)
+        client = EncordClientDataset(querier=querier, config=config)
+        return DatasetClass(client)
 
-    def get_project_manager(self, project_hash: str) -> ProjectManager:
-        """
-        Get a `ProjectManager` to interact with a specific project. This ProjectManager will be authenticated for all
-        operations if
-
-            * You are a project admin or
-
-            * You are a project team manager or
-
-            * You are an organisation admin of the organisation that holds the project
-
-        Args:
-            project_hash: The hash value under the Project ID
-        """
-        config = SshConfig(self.user_config, resource_type=TYPE_PROJECT, resource_id=project_hash)
-        querier = Querier(config)
-        return ProjectManager(querier=querier, config=config)
+    # def get_dataset_manager(self, dataset_hash: str) -> DatasetManager:
+    #     """
+    #     Get a `DatasetManager` to interact with a specific project. This DatasetManager will be authenticated for all
+    #     operations if
+    #
+    #         * You are a dataset admin or
+    #
+    #         * You are an organisation admin of the organisation that holds the project
+    #
+    #     Args:
+    #         dataset_hash: The hash value under the Dataset ID
+    #     """
+    #     config = SshConfig(self.user_config, resource_type=TYPE_DATASET, resource_id=dataset_hash)
+    #     querier = Querier(config)
+    #     return DatasetManager(querier=querier, config=config)
+    #
+    # def get_project_manager(self, project_hash: str) -> ProjectManager:
+    #     """
+    #     Get a `ProjectManager` to interact with a specific project. This ProjectManager will be authenticated for all
+    #     operations if
+    #
+    #         * You are a project admin or
+    #
+    #         * You are a project team manager or
+    #
+    #         * You are an organisation admin of the organisation that holds the project
+    #
+    #     Args:
+    #         project_hash: The hash value under the Project ID
+    #     """
+    #     config = SshConfig(self.user_config, resource_type=TYPE_PROJECT, resource_id=project_hash)
+    #     querier = Querier(config)
+    #     return ProjectManager(querier=querier, config=config)
 
     def create_dataset_api_key(
         self, dataset_hash: str, api_key_title: str, dataset_scopes: List[DatasetScope]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encord"
-version = "0.1.36"
+version = "0.1.37"
 description = "Encord Python SDK Client"
 authors = ["Cord Technologies Limited <hello@encord.com>"]
 license = "Apache Software License"


### PR DESCRIPTION
# Introduction and Explanation
Essentially I have added another SshConfig which will allows the new `DatasetManager` and `ProjectManager` to use the reference of the `UserConfig` for SSH authentication. 

Notes:
* The new classes are called `DatasetManager` and `ProjectManager`. Calling them `Dataset` would lead to name clashes with the ORM class (also leading to potential backwards compatibility concerns) and would also be a bit of a confusing name if you think about operations like `Dataset.get_dataset()`. `DatasetManager` makes this more clear.
* We now have the functionally equivalent `EncordClientDataset` and `DatasetManager`. We just have an alias and use one class in conjunction with the API keys and one with just getting the `DatasetManager` directly from the `EncordUserClient`. I personally find this a little bit confusing and would not mind keeping one `EncordClientDataset` around, but seems like @rad-cord and @justin-cord prefer the rename so please let confirm this change in this PR.
* I have updated the docs - please check them out to see if it is as expected. I have left the docs for API keys but have made it very obvious that we encourage using the new `DatasetManager` and `user_client.get_dataset_manager()` etc. 
* You can now include the `DatasetManager`, `ProjectManager`, and `EncordUserClient` directly from the `encord` package.

# JIRA

DEV-1181


# Documentation
I need to update the SDK documentation.

# Tests
I will update the SDK integration tests. 

# Known issues

Backwards compatibility constraints