### PR TITLE
Create the new Project and Dataset objects

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,6 +7,18 @@ User Client
     :members:
     :undoc-members:
 
+Project
+--------
+.. automodule:: encord.project
+    :members:
+    :undoc-members:
+
+Dataset
+--------
+.. automodule:: encord.dataset
+    :members:
+    :undoc-members:
+
 Client
 ------------
 .. automodule:: encord.client

--- a/encord/__init__.py
+++ b/encord/__init__.py
@@ -1,0 +1,3 @@
+from encord.dataset import Dataset
+from encord.project import Project
+from encord.user_client import EncordUserClient

--- a/encord/client.py
+++ b/encord/client.py
@@ -43,8 +43,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
-import dateutil
-
 import encord.exceptions
 from encord.configs import ENCORD_DOMAIN, ApiKeyConfig, Config, EncordConfig
 from encord.constants.model import AutomationModels
@@ -53,9 +51,9 @@ from encord.http.querier import Querier
 from encord.http.utils import upload_to_signed_url_list
 from encord.orm.api_key import ApiKeyMeta
 from encord.orm.cloud_integration import CloudIntegration
+from encord.orm.dataset import AddPrivateDataResponse
+from encord.orm.dataset import Dataset as OrmDataset
 from encord.orm.dataset import (
-    AddPrivateDataResponse,
-    Dataset,
     DatasetData,
     Image,
     ImageGroup,
@@ -85,8 +83,8 @@ from encord.orm.model import (
     ModelRow,
     ModelTrainingParams,
 )
+from encord.orm.project import Project as OrmProject
 from encord.orm.project import (
-    Project,
     ProjectCopy,
     ProjectCopyOptions,
     ProjectDataset,
@@ -196,7 +194,11 @@ CordClient = EncordClient
 
 
 class EncordClientDataset(EncordClient):
-    def get_dataset(self) -> Dataset:
+    """
+    DEPRECATED - prefer using the :class:`encord.dataset.Dataset` instead
+    """
+
+    def get_dataset(self) -> OrmDataset:
         """
         Retrieve dataset info (pointers to data, labels).
 
@@ -204,29 +206,18 @@ class EncordClientDataset(EncordClient):
             self: Encord client object.
 
         Returns:
-            Dataset: A dataset record instance.
+            OrmDataset: A dataset record instance.
 
         Raises:
             AuthorisationError: If the dataset API key is invalid.
             ResourceNotFoundError: If no dataset exists by the specified dataset EntityId.
             UnknownError: If an error occurs while retrieving the dataset.
         """
-        return self._querier.basic_getter(Dataset)
+        return self._querier.basic_getter(OrmDataset)
 
     def upload_video(self, file_path: str):
         """
-        Upload video to Encord storage.
-
-        Args:
-            self: Encord client object.
-            file_path: path to video e.g. '/home/user/data/video.mp4'
-
-        Returns:
-            Bool.
-
-        Raises:
-            UploadOperationNotSupportedError: If trying to upload to external
-                                              datasets (e.g. S3/GPC/Azure)
+        This function is documented in :meth:`encord.dataset.Dataset.upload_video`.
         """
         if os.path.exists(file_path):
             short_name = os.path.basename(file_path)
@@ -243,22 +234,7 @@ class EncordClientDataset(EncordClient):
 
     def create_image_group(self, file_paths: typing.Iterable[str], max_workers: Optional[int] = None):
         """
-        Create an image group in Encord storage.
-
-        Args:
-            self: Encord client object.
-            file_paths: a list of paths to images, e.g.
-                ['/home/user/data/img1.png', '/home/user/data/img2.png']
-            max_workers:
-                Number of workers for parallel image upload. If set to None, this will be the number of CPU cores
-                available on the machine.
-
-        Returns:
-            Bool.
-
-        Raises:
-            UploadOperationNotSupportedError: If trying to upload to external
-                                              datasets (e.g. S3/GPC/Azure)
+        This function is documented in :meth:`encord.dataset.Dataset.create_image_group`.
         """
         for file_path in file_paths:
             if not os.path.exists(file_path):
@@ -278,22 +254,13 @@ class EncordClientDataset(EncordClient):
 
     def delete_image_group(self, data_hash: str):
         """
-        Create an image group in Encord storage.
-
-        Args:
-            self: Encord client object.
-            data_hash: the hash of the image group you'd like to delete
+        This function is documented in :meth:`encord.dataset.Dataset.delete_image_group`.
         """
         self._querier.basic_delete(ImageGroup, uid=data_hash)
 
     def delete_data(self, data_hashes: List[str]):
         """
-        Delete a video/image group from a dataset.
-
-        Args:
-            self: Encord client object.
-            data_hashes: list of hash of the videos/image_groups you'd like to delete, all should belong to the same
-             dataset
+        This function is documented in :meth:`encord.dataset.Dataset.delete_data`.
         """
         self._querier.basic_delete(Video, uid=data_hashes)
 
@@ -304,18 +271,7 @@ class EncordClientDataset(EncordClient):
         ignore_errors: bool = False,
     ) -> AddPrivateDataResponse:
         """
-        Append data hosted on private clouds to existing dataset
-
-        Args:
-            integration_id: str
-                EntityId of the cloud integration to be used when accessing those files
-            private_files:
-                A str path or Path object to a json file, json str or python dictionary of the files you wish to add
-            ignore_errors: bool, optional
-                Ignore individual errors when trying to access the specified files
-        Returns:
-            add_private_data_response List of DatasetDataInfo objects containing data_hash and title
-
+        This function is documented in :meth:`encord.dataset.Dataset.AddPrivateDataResponse`.
         """
         if isinstance(private_files, dict):
             files = private_files
@@ -342,42 +298,20 @@ class EncordClientDataset(EncordClient):
 
     def re_encode_data(self, data_hashes: List[str]):
         """
-        Launches an async task that can re-encode a list of videos.
-
-        Args:
-            self: Encord client object.
-            data_hashes: list of hash of the videos you'd like to re_encode, all should belong to the same
-             dataset
-        Returns:
-            EntityId(integer) of the async task launched.
-
+        This function is documented in :meth:`encord.dataset.Dataset.re_encode_data`.
         """
         payload = {"data_hash": data_hashes}
         return self._querier.basic_put(ReEncodeVideoTask, uid=None, payload=payload)
 
     def re_encode_data_status(self, job_id: int):
         """
-        Returns the status of an existing async task which is aimed at re-encoding videos.
-
-        Args:
-            self: Encord client object.
-            job_id: id of the async task that was launched to re-encode the videos
-
-        Returns:
-            ReEncodeVideoTask: Object containing the status of the task, along with info about the new encoded videos
-             in case the task has been completed
+        This function is documented in :meth:`encord.dataset.Dataset.re_encode_data_status`.
         """
         return self._querier.basic_getter(ReEncodeVideoTask, uid=job_id)
 
     def run_ocr(self, image_group_id: str) -> List[ImageGroupOCR]:
         """
-        Returns an optical character recognition result for a given image group
-        Args:
-            image_group_id: the id of the image group in this dataset to run OCR on
-
-        Returns:
-            Returns a list of ImageGroupOCR objects representing the text and corresponding coordinates
-            found in each frame of the image group
+        This function is documented in :meth:`encord.dataset.Dataset.run_ocr`.
         """
 
         payload = {"image_group_data_hash": image_group_id}
@@ -391,6 +325,10 @@ CordClientDataset = EncordClientDataset
 
 
 class EncordClientProject(EncordClient):
+    """
+    DEPRECATED - prefer using the :class:`encord.project.Project` instead
+    """
+
     def get_project(self):
         """
         Retrieve project info (pointers to data, labels).
@@ -399,14 +337,14 @@ class EncordClientProject(EncordClient):
             self: Encord client object.
 
         Returns:
-            Project: A project record instance.
+            OrmProject: A project record instance.
 
         Raises:
             AuthorisationError: If the project API key is invalid.
             ResourceNotFoundError: If no project exists by the specified project EntityId.
             UnknownError: If an error occurs while retrieving the project.
         """
-        return self._querier.basic_getter(Project)
+        return self._querier.basic_getter(OrmProject)
 
     def list_label_rows(
         self,
@@ -428,19 +366,7 @@ class EncordClientProject(EncordClient):
 
     def set_label_status(self, label_hash: str, label_status: LabelStatus) -> bool:
         """
-        Set the label status for a label row to a desired value.
-
-        Args:
-            self: Encord client object.
-            label_hash: unique identifier of the label row whose status is to be updated.
-            label_status: the new status that needs to be set.
-
-        Returns:
-            Bool.
-
-        Raises:
-            AuthorisationError: If the label_hash provided is invalid or not a member of the project.
-            UnknownError: If an error occurs while updating the status.
+        This function is documented in :meth:`encord.project.Project.set_label_status`.
         """
         payload = {
             "label_status": label_status.value,
@@ -449,19 +375,7 @@ class EncordClientProject(EncordClient):
 
     def add_users(self, user_emails: List[str], user_role: ProjectUserRole) -> List[ProjectUser]:
         """
-        Add users to project
-
-        Args:
-            user_emails: list of user emails to be added
-            user_role: the user role to assign to all users
-
-        Returns:
-            ProjectUser
-
-        Raises:
-            AuthorisationError: If the project API key is invalid.
-            ResourceNotFoundError: If no project exists by the specified project EntityId.
-            UnknownError: If an error occurs while adding the users to the project
+        This function is documented in :meth:`encord.project.Project.add_users`.
         """
 
         payload = {"user_emails": user_emails, "user_role": user_role}
@@ -472,24 +386,7 @@ class EncordClientProject(EncordClient):
 
     def copy_project(self, copy_datasets=False, copy_collaborators=False, copy_models=False) -> str:
         """
-        Copy the current project into a new one with copied contents including settings, datasets and users.
-        Labels and models are optional.
-
-        Args:
-            copy_datasets: if True, the datasets of the existing project are copied over, and new
-                           tasks are created from those datasets
-            copy_collaborators: if True, all users of the existing project are copied over with their current roles.
-                                If label and/or annotator reviewer mapping is set, this will also be copied over
-            copy_models: currently if True, all models with their training information will be copied into the new
-                         project
-
-        Returns:
-            the EntityId of the newly created project
-
-        Raises:
-            AuthorisationError: If the project API key is invalid.
-            ResourceNotFoundError: If no project exists by the specified project EntityId.
-            UnknownError: If an error occurs while copying the project.
+        This function is documented in :meth:`encord.project.Project.copy_project`.
         """
 
         payload = {"copy_project_options": []}
@@ -504,22 +401,7 @@ class EncordClientProject(EncordClient):
 
     def get_label_row(self, uid: str, get_signed_url: bool = True):
         """
-        Retrieve label row.
-
-        Args:
-            uid: A label_hash (uid) string.
-            get_signed_url: By default the operation returns a signed URL for the underlying data asset. This can be
-            expensive so it can optionally be turned off
-
-        Returns:
-            LabelRow: A label row instance.
-
-        Raises:
-            AuthenticationError: If the project API key is invalid.
-            AuthorisationError: If access to the specified resource is restricted.
-            ResourceNotFoundError: If no label exists by the specified label_hash (uid).
-            UnknownError: If an error occurs while retrieving the label.
-            OperationNotAllowed: If the read operation is not allowed by the API key.
+        This function is documented in :meth:`encord.project.Project.get_label_row`.
         """
         payload = {"get_signed_url": get_signed_url}
 
@@ -527,108 +409,33 @@ class EncordClientProject(EncordClient):
 
     def save_label_row(self, uid, label):
         """
-        Save existing label row.
-
-        If you have a series of frame labels and have not updated answer
-        dictionaries, call the construct_answer_dictionaries utilities function
-        to do so prior to saving labels.
-
-        Args:
-            uid: A label_hash (uid) string.
-            label: A label row instance.
-
-        Returns:
-            Bool.
-
-        Raises:
-            AuthenticationError: If the project API key is invalid.
-            AuthorisationError: If access to the specified resource is restricted.
-            ResourceNotFoundError: If no label exists by the specified label_hash (uid).
-            UnknownError: If an error occurs while saving the label.
-            OperationNotAllowed: If the write operation is not allowed by the API key.
-            AnswerDictionaryError: If an object or classification instance is missing in answer dictionaries.
-            CorruptedLabelError: If a blurb is corrupted (e.g. if the frame labels have more frames than the video).
+        This function is documented in :meth:`encord.project.Project.save_label_row`.
         """
         label = LabelRow(label)
         return self._querier.basic_setter(LabelRow, uid, payload=label)
 
     def create_label_row(self, uid):
         """
-        Create a label row (for data in a project not previously been labeled).
-
-        Args:
-            uid: the data_hash (uid) of the data unit being labeled.
-                Available in client.get_project().get('label_rows')
-                where label_status is NOT_LABELLED.
-
-        Returns:
-            LabelRow: A label row instance.
-
-        Raises:
-            AuthenticationError: If the project API key is invalid.
-            AuthorisationError: If access to the specified resource is restricted.
-            UnknownError: If an error occurs while saving the label.
-            OperationNotAllowed: If the write operation is not allowed by the API key.
-            AnswerDictionaryError: If an object or classification instance is missing in answer dictionaries.
-            CorruptedLabelError: If a blurb is corrupted (e.g. if the frame labels have more frames than the video).
-            ResourceExistsError: If a label row already exists for this project data. Avoids overriding existing work.
+        This function is documented in :meth:`encord.project.Project.create_label_row`.
         """
         return self._querier.basic_put(LabelRow, uid=uid, payload=None)
 
     def submit_label_row_for_review(self, uid):
         """
-        Submit a label row for review.
-
-        Args:
-            uid: A label_hash (uid) string.
-
-        Returns:
-            Bool.
-
-        Raises:
-            AuthenticationError: If the project API key is invalid.
-            AuthorisationError: If access to the specified resource is restricted.
-            UnknownError: If an error occurs while submitting for review.
-            OperationNotAllowed: If the write operation is not allowed by the API key.
+        This function is documented in :meth:`encord.project.Project.submit_label_row_for_review`.
         """
         return self._querier.basic_put(Review, uid=uid, payload=None)
 
     def add_datasets(self, dataset_hashes: List[str]) -> bool:
         """
-        Add a dataset to a project
-
-        Args:
-            dataset_hashes: List of dataset hashes of the datasets to be added
-
-        Returns:
-            Bool.
-
-        Raises:
-            AuthenticationError: If the project API key is invalid.
-            AuthorisationError: If access to the specified resource is restricted.
-            ResourceNotFoundError: If one or more datasets don't exist by the specified dataset_hashes.
-            UnknownError: If an error occurs while adding the datasets to the project.
-            OperationNotAllowed: If the write operation is not allowed by the API key.
+        This function is documented in :meth:`encord.project.Project.add_datasets`.
         """
         payload = {"dataset_hashes": dataset_hashes}
         return self._querier.basic_setter(ProjectDataset, uid=None, payload=payload)
 
     def remove_datasets(self, dataset_hashes: List[str]) -> bool:
         """
-        Remove datasets from project
-
-        Args:
-            dataset_hashes: List of dataset hashes of the datasets to be removed
-
-        Returns:
-            Bool.
-
-        Raises:
-            AuthenticationError: If the project API key is invalid.
-            AuthorisationError: If access to the specified resource is restricted.
-            ResourceNotFoundError: If no dataset exists by the specified dataset_hash (uid).
-            UnknownError: If an error occurs while removing the datasets from the project.
-            OperationNotAllowed: If the operation is not allowed by the API key.
+        This function is documented in :meth:`encord.project.Project.remove_datasets`.
         """
         return self._querier.basic_delete(ProjectDataset, uid=dataset_hashes)
 
@@ -639,21 +446,7 @@ class EncordClientProject(EncordClient):
 
     def add_object(self, name: str, shape: ObjectShape) -> bool:
         """
-        Add object to an ontology.
-
-        Args:
-            name: the name of the object
-            shape: the shape of the object. (BOUNDING_BOX, POLYGON, POLYLINE or KEY_POINT)
-
-        Returns:
-            True if the object was added successfully and False otherwise.
-
-        Raises:
-            AuthenticationError: If the project API key is invalid.
-            AuthorisationError: If access to the specified resource is restricted.
-            UnknownError: If an error occurs while add te object to the project ontology
-            OperationNotAllowed: If the operation is not allowed by the API key.
-            ValueError: If invalid arguments are supplied in the function call
+        This function is documented in :meth:`encord.project.Project.add_object`.
         """
         if len(name) == 0:
             raise ValueError("Ontology object name is empty")
@@ -670,19 +463,7 @@ class EncordClientProject(EncordClient):
         options: Optional[typing.Iterable[str]] = None,
     ):
         """
-
-        Args:
-            name: the name of the classification
-            classification_type: the classification type (RADIO, TEXT or CHECKLIST)
-            required (whether this classification is required by the annotator):
-            options: the list of options for the classification (to be set to None for texts)
-
-        Raises:
-            AuthenticationError: If the project API key is invalid.
-            AuthorisationError: If access to the specified resource is restricted.
-            UnknownError: If an error occurs while add te classification to the project ontology
-            OperationNotAllowed: If the operation is not allowed by the API key.
-            ValueError: If invalid arguments are supplied in the function call
+        This function is documented in :meth:`encord.project.Project.add_classification`.
         """
         if len(name) == 0:
             raise ValueError("Ontology classification name is empty")
@@ -699,25 +480,7 @@ class EncordClientProject(EncordClient):
         model: Union[AutomationModels, str],
     ) -> str:
         """
-        Create a model row.
-
-        Args:
-            title: Model title.
-            description: Model description.
-            features: List of <feature_node_hashes> which is id's of ontology objects
-                      or classifications to be included in the model.
-            model: the model type to be used.
-                   For backwards compatibility purposes, we continuously allow strings
-                   corresponding to the values of the :class:`.AutomationModels` Enum.
-
-        Returns:
-            The uid of the added model row.
-
-        Raises:
-            AuthenticationError: If the project API key is invalid.
-            AuthorisationError: If access to the specified resource is restricted.
-            ModelFeaturesInconsistentError: If a feature type is different than what is supported by the model (e.g. if
-                creating a classification model using a bounding box).
+        This function is documented in :meth:`encord.project.Project.create_model_row`.
         """
         if title is None:
             raise encord.exceptions.EncordException(message="You must set a title to create a model row.")
@@ -756,19 +519,7 @@ class EncordClientProject(EncordClient):
 
     def model_delete(self, uid: str) -> bool:
         """
-        Delete a model created on the platform.
-
-        Args:
-            uid: A model_hash (uid) string.
-
-        Returns:
-            bool
-
-        Raises:
-            AuthenticationError: If the project API key is invalid.
-            AuthorisationError: If access to the specified resource is restricted.
-            ResourceNotFoundError: If no model exists by the specified model_hash (uid).
-            UnknownError: If an error occurs during training.
+        This function is documented in :meth:`encord.project.Project.model_delete`.
         """
 
         return self._querier.basic_delete(Model, uid=uid)
@@ -787,32 +538,7 @@ class EncordClientProject(EncordClient):
         rdp_thresh=0.005,
     ):
         """
-        Run inference with model trained on the platform.
-
-        Args:
-            uid: A model_iteration_hash (uid) string.
-            file_paths: List of local file paths to image(s) or video(s) - if running inference on files.
-            base64_strings: List of base 64 strings of image(s) or video(s) - if running inference on base64 strings.
-            conf_thresh: Confidence threshold (default 0.6).
-            iou_thresh: Intersection over union threshold (default 0.3).
-            device: Device (CPU or CUDA, default is CUDA).
-            detection_frame_range: Detection frame range (for videos).
-            allocation_enabled: Object UID allocation (tracking) enabled (disabled by default).
-            data_hashes: list of hash of the videos/image_groups you'd like to run inference on.
-            rdp_thresh: parameter specifying the polygon coarseness to be used while running inference. The higher the
-                value, the less points in the segmented image
-
-        Returns:
-            Inference results: A dict of inference results.
-
-        Raises:
-            AuthenticationError: If the project API key is invalid.
-            AuthorisationError: If access to the specified resource is restricted.
-            ResourceNotFoundError: If no model exists by the specified model_iteration_hash (uid).
-            UnknownError: If an error occurs while running inference.
-            FileTypeNotSupportedError: If the file type is not supported for inference (has to be an image or video)
-            FileSizeNotSupportedError: If the file size is too big to be supported.
-            DetectionRangeInvalidError: If a detection range is invalid for video inference
+        This function is documented in :meth:`encord.project.Project.model_inference`.
         """
         if (file_paths is None and base64_strings is None and data_hashes is None) or (
             file_paths is not None
@@ -874,25 +600,7 @@ class EncordClientProject(EncordClient):
 
     def model_train(self, uid, label_rows=None, epochs=None, batch_size=24, weights=None, device="cuda"):
         """
-        Train a model created on the platform.
-
-        Args:
-            uid: A model_hash (uid) string.
-            label_rows: List of label row uid's (hashes) for training.
-            epochs: Number of passes through training dataset.
-            batch_size: Number of training examples utilized in one iteration.
-            weights: Model weights.
-            device: Device (CPU or CUDA, default is CUDA).
-
-        Returns:
-            A model iteration object.
-
-        Raises:
-            AuthenticationError: If the project API key is invalid.
-            AuthorisationError: If access to the specified resource is restricted.
-            ModelWeightsInconsistentError: If the passed model weights are incompatible with the selected model.
-            ResourceNotFoundError: If no model exists by the specified model_hash (uid).
-            UnknownError: If an error occurs during training.
+        This function is documented in :meth:`encord.project.Project.model_train`.
         """
         if label_rows is None:
             raise encord.exceptions.EncordException(
@@ -936,40 +644,7 @@ class EncordClientProject(EncordClient):
         objects_to_interpolate,
     ):
         """
-        Run object interpolation algorithm on project labels (requires an editor ontology and feature uid's).
-
-        Interpolation is supported for bounding box, polygon, and keypoint.
-
-        Args:
-            key_frames: Labels for frames to be interpolated. Key frames are consumed in the form::
-
-                {
-                    "<frame_number>": {
-                        "objects": [
-                            {
-                                "objectHash": "<object_hash>",
-                                "featureHash": "<feature_hash>",
-                                "polygon": {
-                                    "0": { "x": x1, "y": y1, },
-                                    "1": { "x": x2, "y": y2, },
-                                    # ...,
-                                }
-                            },
-                            # ...
-                        ]
-                    },
-                    # ...,
-                }
-
-            objects_to_interpolate: List of object uid's (hashes) of objects to interpolate.
-
-        Returns:
-            Interpolation results: Full set of filled frames including interpolated objects.
-
-        Raises:
-            AuthenticationError: If the project API key is invalid.
-            AuthorisationError: If access to the specified resource is restricted.
-            UnknownError: If an error occurs while running interpolation.
+        This function is documented in :meth:`encord.project.Project.object_interpolation`.
         """
         if len(key_frames) == 0 or len(objects_to_interpolate) == 0:
             raise encord.exceptions.EncordException(
@@ -998,43 +673,7 @@ class EncordClientProject(EncordClient):
         video: dict,
     ):
         """
-
-        Args:
-            frames: Labels for frames to be fitted. Frames are consumed in the form::
-
-                {
-                    "<frame_number>": {
-                        "objects": [
-                            {
-                                "objectHash": "<object_hash>",
-                                "featureHash": "<feature_hash>",
-                                "polygon": {
-                                    "0": { "x": x1, "y": y1, },
-                                    "1": { "x": x2, "y": y2, },
-                                    # ...,
-                                }
-                            },
-                            # ...
-                        ]
-                    },
-                    # ...,
-                }
-
-            video: Metadata of the video for which bounding box fitting needs to be
-                   run::
-
-                        {
-                            "width" : w,
-                            "height" : h,
-                        }
-
-        Returns:
-            Fitting results: Full set of filled frames including fitted objects.
-
-        Raises:
-            AuthenticationError: If the project API key is invalid.
-            AuthorisationError: If access to the specified resource is restricted.
-            UnknownError: If an error occurs while running interpolation.
+        This function is documented in :meth:`encord.project.Project.fitted_bounding_boxes`.
         """
         if len(frames) == 0 or len(video) == 0:
             raise encord.exceptions.EncordException(
@@ -1059,20 +698,7 @@ class EncordClientProject(EncordClient):
 
     def get_data(self, data_hash: str, get_signed_url: bool = False) -> Tuple[Optional[Video], Optional[List[Image]]]:
         """
-        Retrieve information about a video or image group.
-
-        Args:
-            data_hash: The uid of the data object
-            get_signed_url: Optionally return signed URLs for timed public access to that resource
-                (default False)
-
-        Returns:
-            A consisting of the video (if it exists) and a list of individual images (if they exist)
-
-        Raises:
-            AuthenticationError: If the project API key is invalid.
-            AuthorisationError: If access to the specified resource is restricted.
-            UnknownError: If an error occurs while retrieving the object.
+        This function is documented in :meth:`encord.project.Project.get_data`.
         """
         uid = {"data_hash": data_hash, "get_signed_url": get_signed_url}
 
@@ -1105,7 +731,6 @@ class EncordClientProject(EncordClient):
         return self._querier.get_multiple(LabelLog, payload=query_payload)
 
     def __set_project_ontology(self, ontology: Ontology) -> bool:
-
         """
         Save updated project ontology
         Args:
@@ -1115,7 +740,7 @@ class EncordClientProject(EncordClient):
             bool
         """
         payload = {"editor": ontology.to_dict()}
-        return self._querier.basic_setter(Project, uid=None, payload=payload)
+        return self._querier.basic_setter(OrmProject, uid=None, payload=payload)
 
 
 CordClientProject = EncordClientProject

--- a/encord/dataset.py
+++ b/encord/dataset.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional, TextIO, Union
 
 from encord.client import EncordClientDataset
+from encord.orm.cloud_integration import CloudIntegration
 from encord.orm.dataset import AddPrivateDataResponse, DataRow
 from encord.orm.dataset import Dataset as OrmDataset
 from encord.orm.dataset import ImageGroupOCR, StorageLocation
@@ -169,6 +170,9 @@ class Dataset:
             found in each frame of the image group
         """
         return self._client.run_ocr(image_group_id)
+
+    def get_cloud_integrations(self) -> List[CloudIntegration]:
+        return self._client.get_cloud_integrations()
 
     def _get_dataset_instance(self):
         if self._dataset_instance is None:

--- a/encord/dataset.py
+++ b/encord/dataset.py
@@ -1,0 +1,176 @@
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, TextIO, Union
+
+from encord.client import EncordClientDataset
+from encord.orm.dataset import AddPrivateDataResponse, DataRow
+from encord.orm.dataset import Dataset as OrmDataset
+from encord.orm.dataset import ImageGroupOCR, StorageLocation
+
+
+class Dataset:
+    """
+    Access dataset related data and manipulate the dataset.
+    """
+
+    def __init__(self, client: EncordClientDataset):
+        self._client = client
+        self._dataset_instance = None
+
+    @property
+    def title(self) -> str:
+        dataset_instance = self._get_dataset_instance()
+        return dataset_instance.title
+
+    @property
+    def description(self) -> str:
+        dataset_instance = self._get_dataset_instance()
+        return dataset_instance.description
+
+    @property
+    def storage_location(self) -> StorageLocation:
+        dataset_instance = self._get_dataset_instance()
+        return dataset_instance.storage_location
+
+    @property
+    def data_rows(self) -> List[DataRow]:
+        dataset_instance = self._get_dataset_instance()
+        return dataset_instance.data_rows
+
+    def refetch_data(self) -> None:
+        """
+        The Dataset class will only fetch its properties once. Use this function if you suspect the state of those
+        properties to be dirty.
+        """
+        self._dataset_instance = self.get_dataset()
+
+    def get_dataset(self) -> OrmDataset:
+        """
+        This function is exposed for convenience. You are encouraged to use the property accessors instead.
+        """
+        return self._client.get_dataset()
+
+    def upload_video(self, file_path: str):
+        """
+        Upload video to Encord storage.
+
+        Args:
+            self: Encord client object.
+            file_path: path to video e.g. '/home/user/data/video.mp4'
+
+        Returns:
+            Bool.
+
+        Raises:
+            UploadOperationNotSupportedError: If trying to upload to external
+                                              datasets (e.g. S3/GPC/Azure)
+        """
+        return self._client.upload_video(**{k: v for k, v in locals().items() if k != "self"})
+
+    def create_image_group(self, file_paths: Iterable[str], max_workers: Optional[int] = None):
+        """
+        Create an image group in Encord storage.
+
+        Args:
+            self: Encord client object.
+            file_paths: a list of paths to images, e.g.
+                ['/home/user/data/img1.png', '/home/user/data/img2.png']
+            max_workers:
+                Number of workers for parallel image upload. If set to None, this will be the number of CPU cores
+                available on the machine.
+
+        Returns:
+            Bool.
+
+        Raises:
+            UploadOperationNotSupportedError: If trying to upload to external
+                                              datasets (e.g. S3/GPC/Azure)
+        """
+        return self._client.create_image_group(**{k: v for k, v in locals().items() if k != "self"})
+
+    def delete_image_group(self, data_hash: str):
+        """
+        Create an image group in Encord storage.
+
+        Args:
+            self: Encord client object.
+            data_hash: the hash of the image group you'd like to delete
+        """
+        return self._client.delete_image_group(data_hash)
+
+    def delete_data(self, data_hashes: List[str]):
+        """
+        Delete a video/image group from a dataset.
+
+        Args:
+            self: Encord client object.
+            data_hashes: list of hash of the videos/image_groups you'd like to delete, all should belong to the same
+             dataset
+        """
+        return self._client.delete_data(**{k: v for k, v in locals().items() if k != "self"})
+
+    def add_private_data_to_dataset(
+        self,
+        integration_id: str,
+        private_files: Union[str, Dict, Path, TextIO],
+        ignore_errors: bool = False,
+    ) -> AddPrivateDataResponse:
+        """
+        Append data hosted on private clouds to existing dataset
+
+        Args:
+            integration_id: str
+                EntityId of the cloud integration to be used when accessing those files
+            private_files:
+                A str path or Path object to a json file, json str or python dictionary of the files you wish to add
+            ignore_errors: bool, optional
+                Ignore individual errors when trying to access the specified files
+        Returns:
+            add_private_data_response List of DatasetDataInfo objects containing data_hash and title
+
+        """
+        return self._client.add_private_data_to_dataset(**{k: v for k, v in locals().items() if k != "self"})
+
+    def re_encode_data(self, data_hashes: List[str]):
+        """
+        Launches an async task that can re-encode a list of videos.
+
+        Args:
+            self: Encord client object.
+            data_hashes: list of hash of the videos you'd like to re_encode, all should belong to the same
+             dataset
+        Returns:
+            EntityId(integer) of the async task launched.
+
+        """
+        return self._client.re_encode_data(**{k: v for k, v in locals().items() if k != "self"})
+
+    def re_encode_data_status(self, job_id: int):
+        """
+        Returns the status of an existing async task which is aimed at re-encoding videos.
+
+        Args:
+            self: Encord client object.
+            job_id: id of the async task that was launched to re-encode the videos
+
+        Returns:
+            ReEncodeVideoTask: Object containing the status of the task, along with info about the new encoded videos
+             in case the task has been completed
+        """
+        return self._client.re_encode_data_status(**{k: v for k, v in locals().items() if k != "self"})
+
+    def run_ocr(self, image_group_id: str) -> List[ImageGroupOCR]:
+        """
+        Returns an optical character recognition result for a given image group
+        Args:
+            image_group_id: the id of the image group in this dataset to run OCR on
+
+        Returns:
+            Returns a list of ImageGroupOCR objects representing the text and corresponding coordinates
+            found in each frame of the image group
+        """
+        return self._client.run_ocr(**{k: v for k, v in locals().items() if k != "self"})
+
+    def _get_dataset_instance(self):
+        if self._dataset_instance is None:
+            self._dataset_instance = self.get_dataset()
+        return self._dataset_instance

--- a/encord/dataset.py
+++ b/encord/dataset.py
@@ -64,7 +64,7 @@ class Dataset:
             UploadOperationNotSupportedError: If trying to upload to external
                                               datasets (e.g. S3/GPC/Azure)
         """
-        return self._client.upload_video(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.upload_video(file_path)
 
     def create_image_group(self, file_paths: Iterable[str], max_workers: Optional[int] = None):
         """
@@ -85,7 +85,7 @@ class Dataset:
             UploadOperationNotSupportedError: If trying to upload to external
                                               datasets (e.g. S3/GPC/Azure)
         """
-        return self._client.create_image_group(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.create_image_group(file_paths, max_workers)
 
     def delete_image_group(self, data_hash: str):
         """
@@ -106,7 +106,7 @@ class Dataset:
             data_hashes: list of hash of the videos/image_groups you'd like to delete, all should belong to the same
              dataset
         """
-        return self._client.delete_data(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.delete_data(data_hashes)
 
     def add_private_data_to_dataset(
         self,
@@ -128,7 +128,7 @@ class Dataset:
             add_private_data_response List of DatasetDataInfo objects containing data_hash and title
 
         """
-        return self._client.add_private_data_to_dataset(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.add_private_data_to_dataset(integration_id, private_files, ignore_errors)
 
     def re_encode_data(self, data_hashes: List[str]):
         """
@@ -142,7 +142,7 @@ class Dataset:
             EntityId(integer) of the async task launched.
 
         """
-        return self._client.re_encode_data(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.re_encode_data(data_hashes)
 
     def re_encode_data_status(self, job_id: int):
         """
@@ -156,7 +156,7 @@ class Dataset:
             ReEncodeVideoTask: Object containing the status of the task, along with info about the new encoded videos
              in case the task has been completed
         """
-        return self._client.re_encode_data_status(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.re_encode_data_status(job_id)
 
     def run_ocr(self, image_group_id: str) -> List[ImageGroupOCR]:
         """
@@ -168,7 +168,7 @@ class Dataset:
             Returns a list of ImageGroupOCR objects representing the text and corresponding coordinates
             found in each frame of the image group
         """
-        return self._client.run_ocr(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.run_ocr(image_group_id)
 
     def _get_dataset_instance(self):
         if self._dataset_instance is None:

--- a/encord/http/error_utils.py
+++ b/encord/http/error_utils.py
@@ -42,7 +42,7 @@ def check_error_response(response, payload=None):
     Called if HTTP response status code is an error response.
     """
     if response == AUTHENTICATION_ERROR:
-        raise AuthenticationError("Invalid API key.")
+        raise AuthenticationError("You are not authenticated to access the Encord platform.")
 
     if response == AUTHORISATION_ERROR:
         raise AuthorisationError("You are not authorised to access this asset.")

--- a/encord/objects/project.py
+++ b/encord/objects/project.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class ProjectDataset:
+    dataset_hash: str
+    title: str
+    description: str
+
+    @staticmethod
+    def from_dict(d: dict) -> "ProjectDataset":
+        return ProjectDataset(
+            dataset_hash=d["dataset_hash"],
+            title=d["title"],
+            description=d["description"],
+        )
+
+    @classmethod
+    def from_list(cls, l: list) -> List["ProjectDataset"]:
+        ret = []
+        for i in l:
+            ret.append(cls.from_dict(i))
+        return ret

--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -134,6 +134,8 @@ class Dataset(dict, Formatter):
         description: Optional[str] = None,
     ):
         """
+        DEPRECATED - prefer using the :class:`encord.dataset.Dataset` class instead.
+
         This class has dict-style accessors for backwards compatibility.
         Clients who are using this class for the first time are encouraged to use the property accessors and setters
         instead of the underlying dictionary.

--- a/encord/orm/label_row.py
+++ b/encord/orm/label_row.py
@@ -12,11 +12,12 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-import json
+from __future__ import annotations
+
 from collections import OrderedDict
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict
+from typing import Dict, List
 
 from encord.orm import base_orm
 from encord.orm.formatter import Formatter
@@ -223,7 +224,7 @@ class LabelRowMetadata(Formatter):
     annotation_task_status: AnnotationTaskStatus
 
     @classmethod
-    def from_dict(cls, json_dict: Dict):
+    def from_dict(cls, json_dict: Dict) -> LabelRowMetadata:
         return LabelRowMetadata(
             json_dict["label_hash"],
             json_dict["data_hash"],
@@ -233,3 +234,10 @@ class LabelRowMetadata(Formatter):
             LabelStatus(json_dict["label_status"]),
             AnnotationTaskStatus(json_dict["annotation_task_status"]),
         )
+
+    @classmethod
+    def from_list(cls, json_list: list) -> List[LabelRowMetadata]:
+        ret = []
+        for i in json_list:
+            ret.append(cls.from_dict(i))
+        return ret

--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -22,6 +22,8 @@ from encord.orm import base_orm
 
 class Project(base_orm.BaseORM):
     """
+    DEPRECATED - prefer using the `encord.project.Project` class instead.
+
     A project defines a label ontology and is a collection of datasets and label rows.
 
     ORM:

--- a/encord/project.py
+++ b/encord/project.py
@@ -3,6 +3,7 @@ from typing import Iterable, List, Optional, Tuple, Union
 
 from encord.client import EncordClientProject
 from encord.constants.model import AutomationModels
+from encord.orm.cloud_integration import CloudIntegration
 from encord.orm.dataset import Image, Video
 from encord.orm.label_log import LabelLog
 from encord.orm.label_row import AnnotationTaskStatus, LabelRowMetadata, LabelStatus
@@ -612,6 +613,9 @@ class Project:
         self, user_hash: str = None, data_hash: str = None, from_unix_seconds: int = None, to_unix_seconds: int = None
     ) -> List[LabelLog]:
         return self._client.get_label_logs(user_hash, data_hash, from_unix_seconds, to_unix_seconds)
+
+    def get_cloud_integrations(self) -> List[CloudIntegration]:
+        return self._client.get_cloud_integrations()
 
     def _get_project_instance(self):
         if self._project_instance is None:

--- a/encord/project.py
+++ b/encord/project.py
@@ -127,7 +127,7 @@ class Project:
         edited_after: Optional[Union[str, datetime.datetime]] = None,
         label_statuses: Optional[List[AnnotationTaskStatus]] = None,
     ) -> List[LabelRowMetadata]:
-        return self._client.list_label_rows(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.list_label_rows(edited_before, edited_after, label_statuses)
 
     def set_label_status(self, label_hash: str, label_status: LabelStatus) -> bool:
         """
@@ -145,7 +145,7 @@ class Project:
             AuthorisationError: If the label_hash provided is invalid or not a member of the project.
             UnknownError: If an error occurs while updating the status.
         """
-        return self._client.set_label_status(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.set_label_status(label_hash, label_status)
 
     def add_users(self, user_emails: List[str], user_role: ProjectUserRole) -> List[ProjectUser]:
         """
@@ -163,7 +163,7 @@ class Project:
             ResourceNotFoundError: If no project exists by the specified project EntityId.
             UnknownError: If an error occurs while adding the users to the project
         """
-        return self._client.add_users(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.add_users(user_emails, user_role)
 
     def copy_project(self, copy_datasets=False, copy_collaborators=False, copy_models=False) -> str:
         """
@@ -186,7 +186,7 @@ class Project:
             ResourceNotFoundError: If no project exists by the specified project EntityId.
             UnknownError: If an error occurs while copying the project.
         """
-        return self._client.copy_project(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.copy_project(copy_datasets, copy_collaborators, copy_models)
 
     def get_label_row(self, uid: str, get_signed_url: bool = True):
         """
@@ -207,7 +207,7 @@ class Project:
             UnknownError: If an error occurs while retrieving the label.
             OperationNotAllowed: If the read operation is not allowed by the API key.
         """
-        return self._client.get_label_row(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.get_label_row(uid, get_signed_url)
 
     def save_label_row(self, uid, label):
         """
@@ -233,7 +233,7 @@ class Project:
             AnswerDictionaryError: If an object or classification instance is missing in answer dictionaries.
             CorruptedLabelError: If a blurb is corrupted (e.g. if the frame labels have more frames than the video).
         """
-        return self._client.save_label_row(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.save_label_row(uid, label)
 
     def create_label_row(self, uid: str):
         """
@@ -256,7 +256,7 @@ class Project:
             CorruptedLabelError: If a blurb is corrupted (e.g. if the frame labels have more frames than the video).
             ResourceExistsError: If a label row already exists for this project data. Avoids overriding existing work.
         """
-        return self._client.create_label_row(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.create_label_row(uid)
 
     def submit_label_row_for_review(self, uid: str):
         """
@@ -274,7 +274,7 @@ class Project:
             UnknownError: If an error occurs while submitting for review.
             OperationNotAllowed: If the write operation is not allowed by the API key.
         """
-        return self._client.submit_label_row_for_review(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.submit_label_row_for_review(uid)
 
     def add_datasets(self, dataset_hashes: List[str]) -> bool:
         """
@@ -293,7 +293,7 @@ class Project:
             UnknownError: If an error occurs while adding the datasets to the project.
             OperationNotAllowed: If the write operation is not allowed by the API key.
         """
-        return self._client.add_datasets(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.add_datasets(dataset_hashes)
 
     def remove_datasets(self, dataset_hashes: List[str]) -> bool:
         """
@@ -312,7 +312,7 @@ class Project:
             UnknownError: If an error occurs while removing the datasets from the project.
             OperationNotAllowed: If the operation is not allowed by the API key.
         """
-        return self._client.remove_datasets(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.remove_datasets(dataset_hashes)
 
     def get_project_ontology(self) -> LegacyOntology:
         """
@@ -338,7 +338,7 @@ class Project:
             OperationNotAllowed: If the operation is not allowed by the API key.
             ValueError: If invalid arguments are supplied in the function call
         """
-        return self._client.add_object(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.add_object(name, shape)
 
     def add_classification(
         self,
@@ -361,7 +361,7 @@ class Project:
             OperationNotAllowed: If the operation is not allowed by the API key.
             ValueError: If invalid arguments are supplied in the function call
         """
-        return self._client.add_classification(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.add_classification(name, classification_type, required, options)
 
     def create_model_row(
         self,
@@ -391,7 +391,7 @@ class Project:
             ModelFeaturesInconsistentError: If a feature type is different than what is supported by the model (e.g. if
                 creating a classification model using a bounding box).
         """
-        return self._client.create_model_row(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.create_model_row(title, description, features, model)
 
     def model_delete(self, uid: str) -> bool:
         """
@@ -410,7 +410,7 @@ class Project:
             UnknownError: If an error occurs during training.
         """
 
-        return self._client.model_delete(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.model_delete(uid)
 
     def model_inference(
         self,
@@ -453,7 +453,18 @@ class Project:
             FileSizeNotSupportedError: If the file size is too big to be supported.
             DetectionRangeInvalidError: If a detection range is invalid for video inference
         """
-        return self._client.model_inference(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.model_inference(
+            uid,
+            file_paths,
+            base64_strings,
+            conf_thresh,
+            iou_thresh,
+            device,
+            detection_frame_range,
+            allocation_enabled,
+            data_hashes,
+            rdp_thresh,
+        )
 
     def model_train(self, uid, label_rows=None, epochs=None, batch_size=24, weights=None, device="cuda"):
         """
@@ -477,7 +488,14 @@ class Project:
             ResourceNotFoundError: If no model exists by the specified model_hash (uid).
             UnknownError: If an error occurs during training.
         """
-        return self._client.model_train(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.model_train(
+            uid,
+            label_rows,
+            epochs,
+            batch_size,
+            weights,
+            device,
+        )
 
     def object_interpolation(
         self,
@@ -520,7 +538,7 @@ class Project:
             AuthorisationError: If access to the specified resource is restricted.
             UnknownError: If an error occurs while running interpolation.
         """
-        return self._client.object_interpolation(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.object_interpolation(key_frames, objects_to_interpolate)
 
     def fitted_bounding_boxes(
         self,
@@ -566,7 +584,7 @@ class Project:
             AuthorisationError: If access to the specified resource is restricted.
             UnknownError: If an error occurs while running interpolation.
         """
-        return self._client.fitted_bounding_boxes(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.fitted_bounding_boxes(frames, video)
 
     def get_data(self, data_hash: str, get_signed_url: bool = False) -> Tuple[Optional[Video], Optional[List[Image]]]:
         """
@@ -585,7 +603,7 @@ class Project:
             AuthorisationError: If access to the specified resource is restricted.
             UnknownError: If an error occurs while retrieving the object.
         """
-        return self._client.get_data(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.get_data(data_hash, get_signed_url)
 
     def get_websocket_url(self) -> str:
         return self._client.get_websocket_url()
@@ -593,7 +611,7 @@ class Project:
     def get_label_logs(
         self, user_hash: str = None, data_hash: str = None, from_unix_seconds: int = None, to_unix_seconds: int = None
     ) -> List[LabelLog]:
-        return self._client.get_label_logs(**{k: v for k, v in locals().items() if k != "self"})
+        return self._client.get_label_logs(user_hash, data_hash, from_unix_seconds, to_unix_seconds)
 
     def _get_project_instance(self):
         if self._project_instance is None:

--- a/encord/project.py
+++ b/encord/project.py
@@ -1,0 +1,601 @@
+import datetime
+from typing import Iterable, List, Optional, Tuple, Union
+
+from encord.client import EncordClientProject
+from encord.constants.model import AutomationModels
+from encord.orm.dataset import Image, Video
+from encord.orm.label_log import LabelLog
+from encord.orm.label_row import AnnotationTaskStatus, LabelRowMetadata, LabelStatus
+from encord.orm.project import Project as OrmProject
+from encord.project_ontology.classification_type import ClassificationType
+from encord.project_ontology.object_type import ObjectShape
+from encord.project_ontology.ontology import Ontology as LegacyOntology
+from encord.utilities.project_user import ProjectUser, ProjectUserRole
+
+
+class Project:
+    """
+    Access project related data and manipulate the project.
+    """
+
+    def __init__(self, client: EncordClientProject):
+        self._client = client
+        self._project_instance: Optional[OrmProject] = None
+
+    @property
+    def project_hash(self) -> str:
+        """
+        Get the project hash (i.e. the Project ID).
+        """
+        project_instance = self._get_project_instance()
+        return project_instance.project_hash
+
+    @property
+    def title(self) -> str:
+        """
+        Get the title of the project.
+        """
+        project_instance = self._get_project_instance()
+        return project_instance.title
+
+    @property
+    def description(self) -> str:
+        """
+        Get the description of the project.
+        """
+        project_instance = self._get_project_instance()
+        return project_instance.description
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        """
+        Get the time the project was created at.
+        """
+        project_instance = self._get_project_instance()
+        return project_instance.created_at
+
+    @property
+    def last_edited_at(self) -> datetime.datetime:
+        """
+        Get the time the project was last edited at.
+        """
+        project_instance = self._get_project_instance()
+        return project_instance.last_edited_at
+
+    @property
+    def ontology(self) -> dict:
+        """
+        Get the ontology of the project.
+        """
+        project_instance = self._get_project_instance()
+        return project_instance.editor_ontology
+
+    @property
+    def datasets(self) -> list:
+        """
+        Get the associated datasets.
+
+        Prefer using the :meth:`encord.objects.project.ProjectDataset` class to work with the data.
+
+        .. code::
+
+            from encord.object.project import ProjectDataset
+
+            project = user_client.get_project("<project_hash>")
+
+            project_datasets = ProjectDataset.from_list(project.datasets)
+
+        """
+        project_instance = self._get_project_instance()
+        return project_instance.datasets
+
+    @property
+    def label_rows(self) -> dict:
+        """
+        Get the label rows.
+
+        Prefer using the :meth:`encord.orm.label_row.LabelRowMetadata` class to work with the data.
+
+        .. code::
+
+            from encord.orm.label_row import LabelRowMetadata
+
+            project = user_client.get_project("<project_hash>")
+
+            label_rows = LabelRowMetadata.from_list(project.label_rows)
+
+        """
+        project_instance = self._get_project_instance()
+        return project_instance.label_rows
+
+    def refetch_data(self) -> None:
+        """
+        The Project class will only fetch its properties once. Use this function if you suspect the state of those
+        properties to be dirty.
+        """
+        self._project_instance = self.get_project()
+
+    def get_project(self) -> OrmProject:
+        """
+        This function is exposed for convenience. You are encouraged to use the property accessors instead.
+        """
+        return self._client.get_project()
+
+    def list_label_rows(
+        self,
+        edited_before: Optional[Union[str, datetime.datetime]] = None,
+        edited_after: Optional[Union[str, datetime.datetime]] = None,
+        label_statuses: Optional[List[AnnotationTaskStatus]] = None,
+    ) -> List[LabelRowMetadata]:
+        return self._client.list_label_rows(**{k: v for k, v in locals().items() if k != "self"})
+
+    def set_label_status(self, label_hash: str, label_status: LabelStatus) -> bool:
+        """
+        Set the label status for a label row to a desired value.
+
+        Args:
+            self: Encord client object.
+            label_hash: unique identifier of the label row whose status is to be updated.
+            label_status: the new status that needs to be set.
+
+        Returns:
+            Bool.
+
+        Raises:
+            AuthorisationError: If the label_hash provided is invalid or not a member of the project.
+            UnknownError: If an error occurs while updating the status.
+        """
+        return self._client.set_label_status(**{k: v for k, v in locals().items() if k != "self"})
+
+    def add_users(self, user_emails: List[str], user_role: ProjectUserRole) -> List[ProjectUser]:
+        """
+        Add users to project
+
+        Args:
+            user_emails: list of user emails to be added
+            user_role: the user role to assign to all users
+
+        Returns:
+            ProjectUser
+
+        Raises:
+            AuthorisationError: If the project API key is invalid.
+            ResourceNotFoundError: If no project exists by the specified project EntityId.
+            UnknownError: If an error occurs while adding the users to the project
+        """
+        return self._client.add_users(**{k: v for k, v in locals().items() if k != "self"})
+
+    def copy_project(self, copy_datasets=False, copy_collaborators=False, copy_models=False) -> str:
+        """
+        Copy the current project into a new one with copied contents including settings, datasets and users.
+        Labels and models are optional.
+
+        Args:
+            copy_datasets: if True, the datasets of the existing project are copied over, and new
+                           tasks are created from those datasets
+            copy_collaborators: if True, all users of the existing project are copied over with their current roles.
+                                If label and/or annotator reviewer mapping is set, this will also be copied over
+            copy_models: currently if True, all models with their training information will be copied into the new
+                         project
+
+        Returns:
+            the EntityId of the newly created project
+
+        Raises:
+            AuthorisationError: If the project API key is invalid.
+            ResourceNotFoundError: If no project exists by the specified project EntityId.
+            UnknownError: If an error occurs while copying the project.
+        """
+        return self._client.copy_project(**{k: v for k, v in locals().items() if k != "self"})
+
+    def get_label_row(self, uid: str, get_signed_url: bool = True):
+        """
+        Retrieve label row.
+
+        Args:
+            uid: A label_hash   (uid) string.
+            get_signed_url: By default the operation returns a signed URL for the underlying data asset. This can be
+            expensive so it can optionally be turned off
+
+        Returns:
+            LabelRow: A label row instance.
+
+        Raises:
+            AuthenticationError: If the project API key is invalid.
+            AuthorisationError: If access to the specified resource is restricted.
+            ResourceNotFoundError: If no label exists by the specified label_hash (uid).
+            UnknownError: If an error occurs while retrieving the label.
+            OperationNotAllowed: If the read operation is not allowed by the API key.
+        """
+        return self._client.get_label_row(**{k: v for k, v in locals().items() if k != "self"})
+
+    def save_label_row(self, uid, label):
+        """
+        Save existing label row.
+
+        If you have a series of frame labels and have not updated answer
+        dictionaries, call the construct_answer_dictionaries utilities function
+        to do so prior to saving labels.
+
+        Args:
+            uid: A label_hash (uid) string.
+            label: A label row instance.
+
+        Returns:
+            Bool.
+
+        Raises:
+            AuthenticationError: If the project API key is invalid.
+            AuthorisationError: If access to the specified resource is restricted.
+            ResourceNotFoundError: If no label exists by the specified label_hash (uid).
+            UnknownError: If an error occurs while saving the label.
+            OperationNotAllowed: If the write operation is not allowed by the API key.
+            AnswerDictionaryError: If an object or classification instance is missing in answer dictionaries.
+            CorruptedLabelError: If a blurb is corrupted (e.g. if the frame labels have more frames than the video).
+        """
+        return self._client.save_label_row(**{k: v for k, v in locals().items() if k != "self"})
+
+    def create_label_row(self, uid: str):
+        """
+        Create a label row (for data in a project not previously been labeled).
+
+        Args:
+            uid: the data_hash (uid) of the data unit being labeled.
+                Available in client.get_project().get('label_rows')
+                where label_status is NOT_LABELLED.
+
+        Returns:
+            LabelRow: A label row instance.
+
+        Raises:
+            AuthenticationError: If the project API key is invalid.
+            AuthorisationError: If access to the specified resource is restricted.
+            UnknownError: If an error occurs while saving the label.
+            OperationNotAllowed: If the write operation is not allowed by the API key.
+            AnswerDictionaryError: If an object or classification instance is missing in answer dictionaries.
+            CorruptedLabelError: If a blurb is corrupted (e.g. if the frame labels have more frames than the video).
+            ResourceExistsError: If a label row already exists for this project data. Avoids overriding existing work.
+        """
+        return self._client.create_label_row(**{k: v for k, v in locals().items() if k != "self"})
+
+    def submit_label_row_for_review(self, uid: str):
+        """
+        Submit a label row for review.
+
+        Args:
+            uid: A label_hash (uid) string.
+
+        Returns:
+            Bool.
+
+        Raises:
+            AuthenticationError: If the project API key is invalid.
+            AuthorisationError: If access to the specified resource is restricted.
+            UnknownError: If an error occurs while submitting for review.
+            OperationNotAllowed: If the write operation is not allowed by the API key.
+        """
+        return self._client.submit_label_row_for_review(**{k: v for k, v in locals().items() if k != "self"})
+
+    def add_datasets(self, dataset_hashes: List[str]) -> bool:
+        """
+        Add a dataset to a project
+
+        Args:
+            dataset_hashes: List of dataset hashes of the datasets to be added
+
+        Returns:
+            Bool.
+
+        Raises:
+            AuthenticationError: If the project API key is invalid.
+            AuthorisationError: If access to the specified resource is restricted.
+            ResourceNotFoundError: If one or more datasets don't exist by the specified dataset_hashes.
+            UnknownError: If an error occurs while adding the datasets to the project.
+            OperationNotAllowed: If the write operation is not allowed by the API key.
+        """
+        return self._client.add_datasets(**{k: v for k, v in locals().items() if k != "self"})
+
+    def remove_datasets(self, dataset_hashes: List[str]) -> bool:
+        """
+        Remove datasets from project
+
+        Args:
+            dataset_hashes: List of dataset hashes of the datasets to be removed
+
+        Returns:
+            Bool.
+
+        Raises:
+            AuthenticationError: If the project API key is invalid.
+            AuthorisationError: If access to the specified resource is restricted.
+            ResourceNotFoundError: If no dataset exists by the specified dataset_hash (uid).
+            UnknownError: If an error occurs while removing the datasets from the project.
+            OperationNotAllowed: If the operation is not allowed by the API key.
+        """
+        return self._client.remove_datasets(**{k: v for k, v in locals().items() if k != "self"})
+
+    def get_project_ontology(self) -> LegacyOntology:
+        """
+        DEPRECATED - prefer using the `ontology` property accessor instead.
+        """
+        return self._client.get_project_ontology()
+
+    def add_object(self, name: str, shape: ObjectShape) -> bool:
+        """
+        Add object to an ontology.
+
+        Args:
+            name: the name of the object
+            shape: the shape of the object. (BOUNDING_BOX, POLYGON, POLYLINE or KEY_POINT)
+
+        Returns:
+            True if the object was added successfully and False otherwise.
+
+        Raises:
+            AuthenticationError: If the project API key is invalid.
+            AuthorisationError: If access to the specified resource is restricted.
+            UnknownError: If an error occurs while add te object to the project ontology
+            OperationNotAllowed: If the operation is not allowed by the API key.
+            ValueError: If invalid arguments are supplied in the function call
+        """
+        return self._client.add_object(**{k: v for k, v in locals().items() if k != "self"})
+
+    def add_classification(
+        self,
+        name: str,
+        classification_type: ClassificationType,
+        required: bool,
+        options: Optional[Iterable[str]] = None,
+    ):
+        """
+        Args:
+            name: the name of the classification
+            classification_type: the classification type (RADIO, TEXT or CHECKLIST)
+            required (whether this classification is required by the annotator):
+            options: the list of options for the classification (to be set to None for texts)
+
+        Raises:
+            AuthenticationError: If the project API key is invalid.
+            AuthorisationError: If access to the specified resource is restricted.
+            UnknownError: If an error occurs while add te classification to the project ontology
+            OperationNotAllowed: If the operation is not allowed by the API key.
+            ValueError: If invalid arguments are supplied in the function call
+        """
+        return self._client.add_classification(**{k: v for k, v in locals().items() if k != "self"})
+
+    def create_model_row(
+        self,
+        title: str,
+        description: str,
+        features: List[str],
+        model: Union[AutomationModels, str],
+    ) -> str:
+        """
+        Create a model row.
+
+        Args:
+            title: Model title.
+            description: Model description.
+            features: List of <feature_node_hashes> which is id's of ontology objects
+                      or classifications to be included in the model.
+            model: the model type to be used.
+                   For backwards compatibility purposes, we continuously allow strings
+                   corresponding to the values of the :class:`.AutomationModels` Enum.
+
+        Returns:
+            The uid of the added model row.
+
+        Raises:
+            AuthenticationError: If the project API key is invalid.
+            AuthorisationError: If access to the specified resource is restricted.
+            ModelFeaturesInconsistentError: If a feature type is different than what is supported by the model (e.g. if
+                creating a classification model using a bounding box).
+        """
+        return self._client.create_model_row(**{k: v for k, v in locals().items() if k != "self"})
+
+    def model_delete(self, uid: str) -> bool:
+        """
+        Delete a model created on the platform.
+
+        Args:
+            uid: A model_hash (uid) string.
+
+        Returns:
+            bool
+
+        Raises:
+            AuthenticationError: If the project API key is invalid.
+            AuthorisationError: If access to the specified resource is restricted.
+            ResourceNotFoundError: If no model exists by the specified model_hash (uid).
+            UnknownError: If an error occurs during training.
+        """
+
+        return self._client.model_delete(**{k: v for k, v in locals().items() if k != "self"})
+
+    def model_inference(
+        self,
+        uid,
+        file_paths=None,
+        base64_strings=None,
+        conf_thresh=0.6,
+        iou_thresh=0.3,
+        device="cuda",
+        detection_frame_range=None,
+        allocation_enabled=False,
+        data_hashes=None,
+        rdp_thresh=0.005,
+    ):
+        """
+        Run inference with model trained on the platform.
+
+        Args:
+            uid: A model_iteration_hash (uid) string.
+            file_paths: List of local file paths to image(s) or video(s) - if running inference on files.
+            base64_strings: List of base 64 strings of image(s) or video(s) - if running inference on base64 strings.
+            conf_thresh: Confidence threshold (default 0.6).
+            iou_thresh: Intersection over union threshold (default 0.3).
+            device: Device (CPU or CUDA, default is CUDA).
+            detection_frame_range: Detection frame range (for videos).
+            allocation_enabled: Object UID allocation (tracking) enabled (disabled by default).
+            data_hashes: list of hash of the videos/image_groups you'd like to run inference on.
+            rdp_thresh: parameter specifying the polygon coarseness to be used while running inference. The higher the
+                value, the less points in the segmented image
+
+        Returns:
+            Inference results: A dict of inference results.
+
+        Raises:
+            AuthenticationError: If the project API key is invalid.
+            AuthorisationError: If access to the specified resource is restricted.
+            ResourceNotFoundError: If no model exists by the specified model_iteration_hash (uid).
+            UnknownError: If an error occurs while running inference.
+            FileTypeNotSupportedError: If the file type is not supported for inference (has to be an image or video)
+            FileSizeNotSupportedError: If the file size is too big to be supported.
+            DetectionRangeInvalidError: If a detection range is invalid for video inference
+        """
+        return self._client.model_inference(**{k: v for k, v in locals().items() if k != "self"})
+
+    def model_train(self, uid, label_rows=None, epochs=None, batch_size=24, weights=None, device="cuda"):
+        """
+        Train a model created on the platform.
+
+        Args:
+            uid: A model_hash (uid) string.
+            label_rows: List of label row uid's (hashes) for training.
+            epochs: Number of passes through training dataset.
+            batch_size: Number of training examples utilized in one iteration.
+            weights: Model weights.
+            device: Device (CPU or CUDA, default is CUDA).
+
+        Returns:
+            A model iteration object.
+
+        Raises:
+            AuthenticationError: If the project API key is invalid.
+            AuthorisationError: If access to the specified resource is restricted.
+            ModelWeightsInconsistentError: If the passed model weights are incompatible with the selected model.
+            ResourceNotFoundError: If no model exists by the specified model_hash (uid).
+            UnknownError: If an error occurs during training.
+        """
+        return self._client.model_train(**{k: v for k, v in locals().items() if k != "self"})
+
+    def object_interpolation(
+        self,
+        key_frames,
+        objects_to_interpolate,
+    ):
+        """
+        Run object interpolation algorithm on project labels (requires an editor ontology and feature uid's).
+
+        Interpolation is supported for bounding box, polygon, and keypoint.
+
+        Args:
+            key_frames: Labels for frames to be interpolated. Key frames are consumed in the form::
+
+                {
+                    "<frame_number>": {
+                        "objects": [
+                            {
+                                "objectHash": "<object_hash>",
+                                "featureHash": "<feature_hash>",
+                                "polygon": {
+                                    "0": { "x": x1, "y": y1, },
+                                    "1": { "x": x2, "y": y2, },
+                                    # ...,
+                                }
+                            },
+                            # ...
+                        ]
+                    },
+                    # ...,
+                }
+
+            objects_to_interpolate: List of object uid's (hashes) of objects to interpolate.
+
+        Returns:
+            Interpolation results: Full set of filled frames including interpolated objects.
+
+        Raises:
+            AuthenticationError: If the project API key is invalid.
+            AuthorisationError: If access to the specified resource is restricted.
+            UnknownError: If an error occurs while running interpolation.
+        """
+        return self._client.object_interpolation(**{k: v for k, v in locals().items() if k != "self"})
+
+    def fitted_bounding_boxes(
+        self,
+        frames: dict,
+        video: dict,
+    ):
+        """
+
+        Args:
+            frames: Labels for frames to be fitted. Frames are consumed in the form::
+
+                {
+                    "<frame_number>": {
+                        "objects": [
+                            {
+                                "objectHash": "<object_hash>",
+                                "featureHash": "<feature_hash>",
+                                "polygon": {
+                                    "0": { "x": x1, "y": y1, },
+                                    "1": { "x": x2, "y": y2, },
+                                    # ...,
+                                }
+                            },
+                            # ...
+                        ]
+                    },
+                    # ...,
+                }
+
+            video: Metadata of the video for which bounding box fitting needs to be
+                   run::
+
+                        {
+                            "width" : w,
+                            "height" : h,
+                        }
+
+        Returns:
+            Fitting results: Full set of filled frames including fitted objects.
+
+        Raises:
+            AuthenticationError: If the project API key is invalid.
+            AuthorisationError: If access to the specified resource is restricted.
+            UnknownError: If an error occurs while running interpolation.
+        """
+        return self._client.fitted_bounding_boxes(**{k: v for k, v in locals().items() if k != "self"})
+
+    def get_data(self, data_hash: str, get_signed_url: bool = False) -> Tuple[Optional[Video], Optional[List[Image]]]:
+        """
+        Retrieve information about a video or image group.
+
+        Args:
+            data_hash: The uid of the data object
+            get_signed_url: Optionally return signed URLs for timed public access to that resource
+                (default False)
+
+        Returns:
+            A consisting of the video (if it exists) and a list of individual images (if they exist)
+
+        Raises:
+            AuthenticationError: If the project API key is invalid.
+            AuthorisationError: If access to the specified resource is restricted.
+            UnknownError: If an error occurs while retrieving the object.
+        """
+        return self._client.get_data(**{k: v for k, v in locals().items() if k != "self"})
+
+    def get_websocket_url(self) -> str:
+        return self._client.get_websocket_url()
+
+    def get_label_logs(
+        self, user_hash: str = None, data_hash: str = None, from_unix_seconds: int = None, to_unix_seconds: int = None
+    ) -> List[LabelLog]:
+        return self._client.get_label_logs(**{k: v for k, v in locals().items() if k != "self"})
+
+    def _get_project_instance(self):
+        if self._project_instance is None:
+            self._project_instance = self.get_project()
+        return self._project_instance

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -15,7 +15,7 @@ import dateutil
 from cord.utilities.client_utilities import LocalImport as CordLocalImport
 from encord.client import EncordClient, EncordClientDataset, EncordClientProject
 from encord.configs import SshConfig, UserConfig, get_env_ssh_key
-from encord.constants.string_constants import TYPE_DATASET
+from encord.constants.string_constants import TYPE_DATASET, TYPE_PROJECT
 from encord.dataset import Dataset
 from encord.http.querier import Querier
 from encord.http.utils import upload_to_signed_url_list
@@ -89,7 +89,7 @@ class EncordUserClient:
         Args:
             project_hash: The Project ID
         """
-        config = SshConfig(self.user_config, resource_type=TYPE_DATASET, resource_id=project_hash)
+        config = SshConfig(self.user_config, resource_type=TYPE_PROJECT, resource_id=project_hash)
         querier = Querier(config)
         client = EncordClientProject(querier=querier, config=config)
         return Project(client)


### PR DESCRIPTION
# Introduction and Explanation
Create a new `Dataset` and `Project` class. These will have accessors for their members, otherwise they will offload to the relevant `EncordClient`. 

The docstrings will warn about deprecation.

Note: For accessors such as `Project.label_rows` we will return the raw dict, but have a code example in our doc strings on how to create a meaningful dataclass from it. This is so we have a more composable workflow and have more flexibility in future changes without changing the api of this class.

# JIRA

[DEV-1181](https://cord-team.atlassian.net/browse/DEV-1181)


# Documentation
Will follow in a subsequent PR

# Tests
Will follow in sdk-integration-tests in the backend
