### PR TITLE
Add the GenericServerError for forwards compatibility.

### DIFF
--- a/encord/exceptions.py
+++ b/encord/exceptions.py
@@ -187,3 +187,12 @@ class ResourceExistsError(EncordException):
     """
 
     pass
+
+
+class GenericServerError(EncordException):
+    """
+    The server has reported an error which is not recognised by this SDK version. Try upgrading the SDK version to
+    see the precise error that is reported.
+    """
+
+    pass

--- a/encord/http/error_utils.py
+++ b/encord/http/error_utils.py
@@ -103,4 +103,7 @@ def check_error_response(response, payload=None):
             "Trying to create a resource that already exists. " "Payload for this failure is: " + str(payload)
         )
 
-    pass
+    raise GenericServerError(
+        "The Encord server has reported an error. Upgrade the SDK to the latest version to get the exact error."
+        f"The reported error is of type `{response}`."
+    )

--- a/encord/http/error_utils.py
+++ b/encord/http/error_utils.py
@@ -104,6 +104,6 @@ def check_error_response(response, payload=None):
         )
 
     raise GenericServerError(
-        "The Encord server has reported an error. Upgrade the SDK to the latest version to get the exact error."
-        f"The reported error is of type `{response}`."
+        f"The Encord server has reported an error of type `{response}`. Please do not parse this error "
+        "programmatically, instead please upgrade the SDK to the latest version to get the exact error."
     )


### PR DESCRIPTION
# Introduction and Explanation
This change will guarantee that if a new error class is created in the api-server, that it will still trigger an error response in the SDK. 

NOTE: do not release this before https://github.com/encord-team/cord-backend/pull/859

# Tests

I have done manual tests with requests. 
