### PR TITLE
DEV-1326 - Adapt the type of the re-encode poll

### DIFF
--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -437,7 +437,8 @@ class ImageGroupOCR:
 @dataclasses.dataclass(frozen=True)
 class ReEncodeVideoTaskResult:
     data_hash: str
-    signed_url: str
+    # The signed url is only present when using StorageLocation.CORD_STORAGE
+    signed_url: Optional[str]
     bucket_path: str
 
 


### PR DESCRIPTION
This is technically an API change, however, for the cases where the `signed_url` would be `None` we are currently failing and throwing. So no one can realistically depend on this being a string with non cord storage anyway.