### PR TITLE
Add retry logic for image and video uploads

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -241,7 +241,7 @@ class EncordClientDataset(EncordClient):
         short_names = list(map(os.path.basename, file_paths))
         signed_urls = self._querier.basic_getter(SignedImagesURL, uid=short_names)
 
-        upload_to_signed_url_list(file_paths, signed_urls, self._querier, Image, max_workers)
+        upload_to_signed_url_list(file_paths, signed_urls, self._querier, Image)
         image_hash_list = list(map(lambda signed_url: signed_url.get("data_hash"), signed_urls))
         res = self._querier.basic_setter(ImageGroup, uid=image_hash_list, payload={})
 

--- a/encord/client.py
+++ b/encord/client.py
@@ -225,7 +225,6 @@ class EncordClientDataset(EncordClient):
             res = upload_to_signed_url_list([file_path], [signed_url], self._querier, Video)
             if res:
                 logger.info("Upload complete.")
-                logger.info("Please run client.get_dataset() to refresh.")
                 return res
             else:
                 raise encord.exceptions.EncordException(message="An error has occurred during video upload.")
@@ -241,9 +240,11 @@ class EncordClientDataset(EncordClient):
                 raise encord.exceptions.EncordException(message="{} does not point to a file.".format(file_path))
         short_names = list(map(os.path.basename, file_paths))
         signed_urls = self._querier.basic_getter(SignedImagesURL, uid=short_names)
+
         upload_to_signed_url_list(file_paths, signed_urls, self._querier, Image, max_workers)
         image_hash_list = list(map(lambda signed_url: signed_url.get("data_hash"), signed_urls))
         res = self._querier.basic_setter(ImageGroup, uid=image_hash_list, payload={})
+
         if res:
             titles = [video_data.get("title") for video_data in res]
             logger.info("Upload successful! {} created.".format(titles))

--- a/encord/client.py
+++ b/encord/client.py
@@ -260,7 +260,6 @@ class EncordClientDataset(EncordClient):
         if res:
             titles = [video_data.get("title") for video_data in res]
             logger.info("Upload successful! {} created.".format(titles))
-            logger.info("Please run client.get_dataset() to refresh.")
             return res
         else:
             raise encord.exceptions.EncordException(message="An error has occurred during image group creation.")

--- a/encord/client.py
+++ b/encord/client.py
@@ -251,6 +251,9 @@ class EncordClientDataset(EncordClient):
         uploaded_images = upload_to_signed_url_list(
             file_paths, signed_urls, self._querier, Image, cloud_upload_settings=cloud_upload_settings
         )
+        if not uploaded_images:
+            raise encord.exceptions.EncordException("All image uploads failed. Image group was not created.")
+
         image_hash_list = [uploaded_image.get("data_hash") for uploaded_image in uploaded_images]
         res = self._querier.basic_setter(ImageGroup, uid=image_hash_list, payload={})
 

--- a/encord/client.py
+++ b/encord/client.py
@@ -241,8 +241,8 @@ class EncordClientDataset(EncordClient):
         short_names = list(map(os.path.basename, file_paths))
         signed_urls = self._querier.basic_getter(SignedImagesURL, uid=short_names)
 
-        upload_to_signed_url_list(file_paths, signed_urls, self._querier, Image)
-        image_hash_list = list(map(lambda signed_url: signed_url.get("data_hash"), signed_urls))
+        uploaded_images = upload_to_signed_url_list(file_paths, signed_urls, self._querier, Image)
+        image_hash_list = [uploaded_image.get("data_hash") for uploaded_image in uploaded_images]
         res = self._querier.basic_setter(ImageGroup, uid=image_hash_list, payload={})
 
         if res:

--- a/encord/dataset.py
+++ b/encord/dataset.py
@@ -84,8 +84,7 @@ class Dataset:
             file_paths: a list of paths to images, e.g.
                 ['/home/user/data/img1.png', '/home/user/data/img2.png']
             max_workers:
-                Number of workers for parallel image upload. If set to None, this will be the number of CPU cores
-                available on the machine.
+                DEPRECATED: This argument will be ignored
 
         Returns:
             Bool.
@@ -94,7 +93,7 @@ class Dataset:
             UploadOperationNotSupportedError: If trying to upload to external
                                               datasets (e.g. S3/GPC/Azure)
         """
-        return self._client.create_image_group(file_paths, max_workers)
+        return self._client.create_image_group(file_paths)
 
     def delete_image_group(self, data_hash: str):
         """

--- a/encord/dataset.py
+++ b/encord/dataset.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional, TextIO, Union
 
 from encord.client import EncordClientDataset
+from encord.http.utils import CloudUploadSettings
 from encord.orm.cloud_integration import CloudIntegration
 from encord.orm.dataset import AddPrivateDataResponse, DataRow
 from encord.orm.dataset import Dataset as OrmDataset
@@ -58,13 +59,15 @@ class Dataset:
         """
         return self._client.get_dataset()
 
-    def upload_video(self, file_path: str):
+    def upload_video(self, file_path: str, cloud_upload_settings: CloudUploadSettings = CloudUploadSettings()):
         """
         Upload video to Encord storage.
 
         Args:
             self: Encord client object.
             file_path: path to video e.g. '/home/user/data/video.mp4'
+            cloud_upload_settings:
+                Settings for uploading data into the cloud. Change this object to overwrite the default values.
 
         Returns:
             Bool.
@@ -73,9 +76,14 @@ class Dataset:
             UploadOperationNotSupportedError: If trying to upload to external
                                               datasets (e.g. S3/GPC/Azure)
         """
-        return self._client.upload_video(file_path)
+        return self._client.upload_video(file_path, cloud_upload_settings=cloud_upload_settings)
 
-    def create_image_group(self, file_paths: Iterable[str], max_workers: Optional[int] = None):
+    def create_image_group(
+        self,
+        file_paths: Iterable[str],
+        max_workers: Optional[int] = None,
+        cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
+    ):
         """
         Create an image group in Encord storage.
 
@@ -85,6 +93,8 @@ class Dataset:
                 ['/home/user/data/img1.png', '/home/user/data/img2.png']
             max_workers:
                 DEPRECATED: This argument will be ignored
+            cloud_upload_settings:
+                Settings for uploading data into the cloud. Change this object to overwrite the default values.
 
         Returns:
             Bool.
@@ -93,7 +103,7 @@ class Dataset:
             UploadOperationNotSupportedError: If trying to upload to external
                                               datasets (e.g. S3/GPC/Azure)
         """
-        return self._client.create_image_group(file_paths)
+        return self._client.create_image_group(file_paths, cloud_upload_settings=cloud_upload_settings)
 
     def delete_image_group(self, data_hash: str):
         """

--- a/encord/exceptions.py
+++ b/encord/exceptions.py
@@ -216,3 +216,11 @@ class GenericServerError(EncordException):
     """
 
     pass
+
+
+class UploadError(EncordException):
+    """
+    The upload was not successful
+    """
+
+    pass

--- a/encord/exceptions.py
+++ b/encord/exceptions.py
@@ -218,9 +218,9 @@ class GenericServerError(EncordException):
     pass
 
 
-class UploadError(EncordException):
+class CloudUploadError(EncordException):
     """
-    The upload was not successful
+    The upload to the cloud was not successful
     """
 
     pass

--- a/encord/http/utils.py
+++ b/encord/http/utils.py
@@ -144,21 +144,25 @@ def _data_upload_with_retries(
     content_type = "application/octet-stream" if is_video else mimetypes.guess_type(file_path)[0]
 
     current_backoff = backoff_factor
-    for i in range(max_retries):
+    for i in range(max_retries + 1):
         try:
             return requests.put(
-                signed_url.get("signed_url"),
+                # signed_url.get("signed_url"),
+                "https://blabla.co.coc",
                 data=read_in_chunks(file_path, pbar),
                 headers={"Content-Type": content_type},
             )
         except Exception:
-            if i < max_retries - 1:
+            if i < max_retries:
                 logger.warning(
-                    "An exception occurred during the file upload. Retrying upload in %s seconds",
+                    "An exception occurred during uploading the file `%s`. Retrying upload in %s seconds",
+                    file_path,
                     current_backoff,
                     exc_info=True,
                 )
                 sleep(current_backoff)
                 current_backoff *= 2
+            else:
+                logger.exception("An exception occurred during uploading the file `%s`", file_path)
 
     raise UploadError("Could not upload a file. Please check the logs for details.")

--- a/encord/http/utils.py
+++ b/encord/http/utils.py
@@ -96,7 +96,7 @@ def upload_to_signed_url_list(
                 else:
                     raise e
 
-    if cloud_upload_settings:
+    if failed_uploads:
         logger.warning("The upload was incomplete for the following items: %s", failed_uploads)
 
     return orm_class_list

--- a/encord/http/utils.py
+++ b/encord/http/utils.py
@@ -124,8 +124,11 @@ def _upload_single_file(
             logger.info("Error uploading: %s", signed_url.get("title", ""))
 
     else:
+        res_content = res_upload.content
         error_string = (
-            f"Error uploading file '{signed_url.get('title', '')}' to signed url: " f"'{signed_url.get('signed_url')}'",
+            f"Error uploading file '{signed_url.get('title', '')}' to signed url: "
+            f"'{signed_url.get('signed_url')}'. "
+            f"Response content: '{res_content}'",
         )
         logger.error(error_string)
         raise RuntimeError(error_string)

--- a/encord/http/utils.py
+++ b/encord/http/utils.py
@@ -8,7 +8,7 @@ from typing import List, TypeVar
 import requests
 from tqdm import tqdm
 
-from encord.exceptions import UploadError
+from encord.exceptions import CloudUploadError
 from encord.http.querier import Querier
 from encord.orm.dataset import Image, Video
 
@@ -90,9 +90,9 @@ def upload_to_signed_url_list(
                     cloud_upload_settings.backoff_factor,
                 )
                 orm_class_list.append(res)
-            except UploadError as e:
+            except CloudUploadError as e:
                 if cloud_upload_settings.allow_failures:
-                    failed_uploads.append(file_path)  # DENIS: return this.
+                    failed_uploads.append(file_path)
                 else:
                     raise e
 
@@ -147,8 +147,7 @@ def _data_upload_with_retries(
     for i in range(max_retries + 1):
         try:
             return requests.put(
-                # signed_url.get("signed_url"),
-                "https://blabla.co.coc",
+                signed_url.get("signed_url"),
                 data=read_in_chunks(file_path, pbar),
                 headers={"Content-Type": content_type},
             )
@@ -165,4 +164,4 @@ def _data_upload_with_retries(
             else:
                 logger.exception("An exception occurred during uploading the file `%s`", file_path)
 
-    raise UploadError("Could not upload a file. Please check the logs for details.")
+    raise CloudUploadError("Could not upload a file. Please check the logs for details.")

--- a/encord/http/utils.py
+++ b/encord/http/utils.py
@@ -127,11 +127,12 @@ def _upload_single_file(
         status_code = res_upload.status_code
         headers = res_upload.headers
         res_text = res_upload.text
-        error_string = (
+        error_string = str(
             f"Error uploading file '{signed_url.get('title', '')}' to signed url: "
             f"'{signed_url.get('signed_url')}'.\n"
-            f"Response data: status code: '{status_code}', headers: '{headers}', content: '{res_text}'",
+            f"Response data:\n\tstatus code: '{status_code}'\n\theaders: '{headers}'\n\tcontent: '{res_text}'",
         )
+
         logger.error(error_string)
         raise RuntimeError(error_string)
 

--- a/encord/http/utils.py
+++ b/encord/http/utils.py
@@ -46,6 +46,10 @@ def read_in_chunks(file_path, pbar, blocksize=1024, chunks=-1):
             chunks -= 1
             step = round(blocksize / size * PROGRESS_BAR_FILE_FACTOR, 1)
             current = min(PROGRESS_BAR_FILE_FACTOR, current + step)
+            print(f"file factor {PROGRESS_BAR_FILE_FACTOR}")
+            print(f"current {current}")
+            print(f"step {step}")
+            print("pbar update", min(PROGRESS_BAR_FILE_FACTOR - current, step))
             pbar.update(min(PROGRESS_BAR_FILE_FACTOR - current, step))
 
 
@@ -124,11 +128,13 @@ def _upload_single_file(
             logger.info("Error uploading: %s", signed_url.get("title", ""))
 
     else:
-        res_content = res_upload.content
+        status_code = res_upload.status_code
+        headers = res_upload.headers
+        res_text = res_upload.text
         error_string = (
             f"Error uploading file '{signed_url.get('title', '')}' to signed url: "
-            f"'{signed_url.get('signed_url')}'. "
-            f"Response content: '{res_content}'",
+            f"'{signed_url.get('signed_url')}'.\n"
+            f"Response data: status code: '{status_code}', headers: '{headers}', content: '{res_text}'",
         )
         logger.error(error_string)
         raise RuntimeError(error_string)

--- a/encord/http/utils.py
+++ b/encord/http/utils.py
@@ -46,10 +46,6 @@ def read_in_chunks(file_path, pbar, blocksize=1024, chunks=-1):
             chunks -= 1
             step = round(blocksize / size * PROGRESS_BAR_FILE_FACTOR, 1)
             current = min(PROGRESS_BAR_FILE_FACTOR, current + step)
-            print(f"file factor {PROGRESS_BAR_FILE_FACTOR}")
-            print(f"current {current}")
-            print(f"step {step}")
-            print("pbar update", min(PROGRESS_BAR_FILE_FACTOR - current, step))
             pbar.update(min(PROGRESS_BAR_FILE_FACTOR - current, step))
 
 

--- a/encord/http/utils.py
+++ b/encord/http/utils.py
@@ -3,11 +3,15 @@ import mimetypes
 import multiprocessing
 import os.path
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from functools import partial
+from time import sleep
 from typing import List, Optional, TypeVar
 
 import requests
+from requests.adapters import HTTPAdapter, Retry
 from tqdm import tqdm
 
+from encord.exceptions import UploadError
 from encord.http.querier import Querier
 from encord.orm.dataset import Image, Video
 
@@ -34,7 +38,7 @@ def read_in_chunks(file_path, pbar, blocksize=1024, chunks=-1):
 
 OrmT = TypeVar("OrmT")
 
-
+# DENIS: deprecate max workers
 def upload_to_signed_url_list(
     file_paths: List[str], signed_urls, querier: Querier, orm_class: OrmT, max_workers: Optional[int] = None
 ) -> List[OrmT]:
@@ -47,39 +51,72 @@ def upload_to_signed_url_list(
 
     assert len(file_paths) == len(signed_urls), "Error getting the correct number of signed urls"
 
-    if max_workers is None:
-        max_workers = min(multiprocessing.cpu_count(), len(file_paths))
-    elif max_workers < 1:
-        raise ValueError(f"max_workers must be a positive integer. Received: {max_workers}")
-
+    failed_uploads = []
     orm_class_list = []
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        total = len(file_paths) * PROGRESS_BAR_FILE_FACTOR
-        with tqdm(total=total, desc="Files upload progress: ") as pbar:
-            futures = []
-            for i in range(len(file_paths)):
-                file_path = file_paths[i]
-                file_name = os.path.basename(file_path)
-                signed_url = signed_urls[i]
-                assert signed_url.get("title", "") == file_name, "Ordering issue"
+    total = len(file_paths) * PROGRESS_BAR_FILE_FACTOR
+    with tqdm(total=total, desc="Files upload progress: ") as pbar:
+        for i in range(len(file_paths)):
+            file_path = file_paths[i]
+            file_name = os.path.basename(file_path)
+            signed_url = signed_urls[i]
+            assert signed_url.get("title", "") == file_name, "Ordering issue"
 
-                future = executor.submit(_upload_single_file, file_path, signed_url, querier, orm_class, pbar, is_video)
-                futures.append(future)
-
-            for future in as_completed(futures):
-                res = future.result()
+            try:
+                res = _upload_single_file(file_path, signed_url, querier, orm_class, pbar, is_video)
                 orm_class_list.append(res)
+            except UploadError:
+                # DENIS: for special exceptions
+                failed_uploads.append(file_path)  # DENIS: return this.
 
     return orm_class_list
 
 
 def _upload_single_file(
-    file_path: str, signed_url: dict, querier: Querier, orm_class: OrmT, pbar, is_video: bool
+    file_path: str,
+    signed_url: dict,
+    querier: Querier,
+    orm_class: OrmT,
+    pbar,
+    is_video: bool,
 ) -> OrmT:
-    content_type = "application/octet-stream" if is_video else mimetypes.guess_type(file_path)[0]
-    res_upload = requests.put(
-        signed_url.get("signed_url"), data=read_in_chunks(file_path, pbar), headers={"Content-Type": content_type}
-    )
+    # s = requests.Session()
+    # retries = Retry(
+    #     total=5,
+    #     backoff_factor=2,
+    # )
+    # s.mount("https://", HTTPAdapter(max_retries=retries))
+
+    # content_type = "application/octet-stream" if is_video else mimetypes.guess_type(file_path)[0]
+    # res_upload = requests.put(
+    #     signed_url.get("signed_url"), data=read_in_chunks(file_path, pbar), headers={"Content-Type": content_type}
+    # )
+
+    # DENIS: these are arguments
+    # max_retries = 5
+    # backoff_factor = 0.1
+    #
+    # current_backoff = backoff_factor
+    # for i in range(max_retries):
+    #     try:
+    #         res_upload = requests.put(
+    #             # "https://blabla.cosdf",
+    #             signed_url.get("signed_url"),
+    #             data=read_in_chunks(file_path, pbar),
+    #             headers={"Content-Type": content_type},
+    #         )
+    #         break
+    #     except Exception as e:
+    #         if i < max_retries - 1:
+    #             logger.warning(
+    #                 "An exception occurred during the file upload. Will retry in %s seconds",
+    #                 current_backoff,
+    #                 exc_info=True,
+    #             )
+    #             sleep(current_backoff)
+    #             current_backoff *= 2
+    # else:
+    #     raise UploadError("")
+    res_upload = _data_upload_with_retries(file_path, signed_url, pbar, is_video)
 
     if res_upload.status_code == 200:
         data_hash = signed_url.get("data_hash")
@@ -97,3 +134,36 @@ def _upload_single_file(
         raise RuntimeError(error_string)
 
     return orm_class(res)
+
+
+def _data_upload_with_retries(
+    file_path: str,
+    signed_url: dict,
+    pbar,
+    is_video: bool,
+):
+    content_type = "application/octet-stream" if is_video else mimetypes.guess_type(file_path)[0]
+
+    max_retries = 5
+    backoff_factor = 0.1
+
+    current_backoff = backoff_factor
+    for i in range(max_retries):
+        try:
+            return requests.put(
+                # "https://blabla.cosdf",
+                signed_url.get("signed_url"),
+                data=read_in_chunks(file_path, pbar),
+                headers={"Content-Type": content_type},
+            )
+        except Exception as e:
+            if i < max_retries - 1:
+                logger.warning(
+                    "An exception occurred during the file upload. Retrying upload in %s seconds",
+                    current_backoff,
+                    exc_info=True,
+                )
+                sleep(current_backoff)
+                current_backoff *= 2
+
+    raise UploadError("")

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -313,8 +313,7 @@ class EncordUserClient:
                 Set how much interaction is needed from the labeler and from the reviewer for the CVAT labels.
                     See the `ReviewMode` documentation for more details.
             max_workers:
-                Number of workers for parallel image upload. If set to None, this will be the number of CPU cores
-                available on the machine.
+                DEPRECATED: This argument will be ignored
 
         Returns:
             CvatImporterSuccess: If the project was successfully imported.
@@ -344,7 +343,7 @@ class EncordUserClient:
         images_paths = self.__get_images_paths(annotations_base64, images_directory_path)
 
         log.info("Starting image upload.")
-        dataset_hash, image_title_to_image_hash_map = self.__upload_cvat_images(images_paths, dataset_name, max_workers)
+        dataset_hash, image_title_to_image_hash_map = self.__upload_cvat_images(images_paths, dataset_name)
         log.info("Image upload completed.")
 
         payload = {
@@ -397,9 +396,7 @@ class EncordUserClient:
             raise ValueError(f"No images found in the provided data folder.")
         return images
 
-    def __upload_cvat_images(
-        self, images_paths: List[Path], dataset_name: str, max_workers: int
-    ) -> Tuple[str, Dict[str, str]]:
+    def __upload_cvat_images(self, images_paths: List[Path], dataset_name: str) -> Tuple[str, Dict[str, str]]:
         """
         This function does not create any image groups yet.
         Returns:
@@ -424,7 +421,7 @@ class EncordUserClient:
         )
 
         signed_urls = client._querier.basic_getter(SignedImagesURL, uid=short_names)
-        upload_to_signed_url_list(file_path_strings, signed_urls, client._querier, Image, max_workers)
+        upload_to_signed_url_list(file_path_strings, signed_urls, client._querier, Image)
 
         image_title_to_image_hash_map = dict(map(lambda x: (x.title, x.data_hash), signed_urls))
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -888,7 +888,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "0592b7a2e025b39aa1d87a894aade887f19e2c6563d76fb9c544b8cd0595cbbb"
+content-hash = "bf9a07b826c2ee57eebbe284d7a859b012b59f1d3806278598a26374f647c37d"
 
 [metadata.files]
 alabaster = [
@@ -1028,10 +1028,7 @@ filelock = [
     {file = "filelock-3.4.2-py3-none-any.whl", hash = "sha256:cf0fc6a2f8d26bd900f19bf33915ca70ba4dd8c56903eeb14e1e7a2fd7590146"},
     {file = "filelock-3.4.2.tar.gz", hash = "sha256:38b4f4c989f9d06d44524df1b24bd19e167d851f19b50bf3e3559952dddc5b80"},
 ]
-fonttools = [
-    {file = "fonttools-4.33.3-py3-none-any.whl", hash = "sha256:f829c579a8678fa939a1d9e9894d01941db869de44390adb49ce67055a06cc2a"},
-    {file = "fonttools-4.33.3.zip", hash = "sha256:c0fdcfa8ceebd7c1b2021240bd46ef77aa8e7408cf10434be55df52384865f8e"},
-]
+fonttools = []
 identify = [
     {file = "identify-2.4.3-py2.py3-none-any.whl", hash = "sha256:ac9c919c8ac5b90d03f8e1bce6dedcbd8a3b2a59c46737c04ed852e2d307af29"},
     {file = "identify-2.4.3.tar.gz", hash = "sha256:8d80d877441073e7222ff272da45ca5ca1d901412790544b446e7d363ad5e9f0"},
@@ -1060,51 +1057,7 @@ jinja2 = [
     {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
     {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
 ]
-kiwisolver = [
-    {file = "kiwisolver-1.4.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6e395ece147f0692ca7cdb05a028d31b83b72c369f7b4a2c1798f4b96af1e3d8"},
-    {file = "kiwisolver-1.4.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0b7f50a1a25361da3440f07c58cd1d79957c2244209e4f166990e770256b6b0b"},
-    {file = "kiwisolver-1.4.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3c032c41ae4c3a321b43a3650e6ecc7406b99ff3e5279f24c9b310f41bc98479"},
-    {file = "kiwisolver-1.4.2-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1dcade8f6fe12a2bb4efe2cbe22116556e3b6899728d3b2a0d3b367db323eacc"},
-    {file = "kiwisolver-1.4.2-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0e45e780a74416ef2f173189ef4387e44b5494f45e290bcb1f03735faa6779bf"},
-    {file = "kiwisolver-1.4.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d2bb56309fb75a811d81ed55fbe2208aa77a3a09ff5f546ca95e7bb5fac6eff"},
-    {file = "kiwisolver-1.4.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:69b2d6c12f2ad5f55104a36a356192cfb680c049fe5e7c1f6620fc37f119cdc2"},
-    {file = "kiwisolver-1.4.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:262c248c60f22c2b547683ad521e8a3db5909c71f679b93876921549107a0c24"},
-    {file = "kiwisolver-1.4.2-cp310-cp310-win32.whl", hash = "sha256:1008346a7741620ab9cc6c96e8ad9b46f7a74ce839dbb8805ddf6b119d5fc6c2"},
-    {file = "kiwisolver-1.4.2-cp310-cp310-win_amd64.whl", hash = "sha256:6ece2e12e4b57bc5646b354f436416cd2a6f090c1dadcd92b0ca4542190d7190"},
-    {file = "kiwisolver-1.4.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b978afdb913ca953cf128d57181da2e8798e8b6153be866ae2a9c446c6162f40"},
-    {file = "kiwisolver-1.4.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f88c4b8e449908eeddb3bbd4242bd4dc2c7a15a7aa44bb33df893203f02dc2d"},
-    {file = "kiwisolver-1.4.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e348f1904a4fab4153407f7ccc27e43b2a139752e8acf12e6640ba683093dd96"},
-    {file = "kiwisolver-1.4.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c839bf28e45d7ddad4ae8f986928dbf5a6d42ff79760d54ec8ada8fb263e097c"},
-    {file = "kiwisolver-1.4.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8ae5a071185f1a93777c79a9a1e67ac46544d4607f18d07131eece08d415083a"},
-    {file = "kiwisolver-1.4.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c222f91a45da9e01a9bc4f760727ae49050f8e8345c4ff6525495f7a164c8973"},
-    {file = "kiwisolver-1.4.2-cp37-cp37m-win32.whl", hash = "sha256:a4e8f072db1d6fb7a7cc05a6dbef8442c93001f4bb604f1081d8c2db3ca97159"},
-    {file = "kiwisolver-1.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:be9a650890fb60393e60aacb65878c4a38bb334720aa5ecb1c13d0dac54dd73b"},
-    {file = "kiwisolver-1.4.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:8ec2e55bf31b43aabe32089125dca3b46fdfe9f50afbf0756ae11e14c97b80ca"},
-    {file = "kiwisolver-1.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1d1078ba770d6165abed3d9a1be1f9e79b61515de1dd00d942fa53bba79f01ae"},
-    {file = "kiwisolver-1.4.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:cbb5eb4a2ea1ffec26268d49766cafa8f957fe5c1b41ad00733763fae77f9436"},
-    {file = "kiwisolver-1.4.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e6cda72db409eefad6b021e8a4f964965a629f577812afc7860c69df7bdb84a"},
-    {file = "kiwisolver-1.4.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b1605c7c38cc6a85212dfd6a641f3905a33412e49f7c003f35f9ac6d71f67720"},
-    {file = "kiwisolver-1.4.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81237957b15469ea9151ec8ca08ce05656090ffabc476a752ef5ad7e2644c526"},
-    {file = "kiwisolver-1.4.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:240009fdf4fa87844f805e23f48995537a8cb8f8c361e35fda6b5ac97fcb906f"},
-    {file = "kiwisolver-1.4.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:240c2d51d098395c012ddbcb9bd7b3ba5de412a1d11840698859f51d0e643c4f"},
-    {file = "kiwisolver-1.4.2-cp38-cp38-win32.whl", hash = "sha256:8b6086aa6936865962b2cee0e7aaecf01ab6778ce099288354a7229b4d9f1408"},
-    {file = "kiwisolver-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:0d98dca86f77b851350c250f0149aa5852b36572514d20feeadd3c6b1efe38d0"},
-    {file = "kiwisolver-1.4.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:91eb4916271655dfe3a952249cb37a5c00b6ba68b4417ee15af9ba549b5ba61d"},
-    {file = "kiwisolver-1.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fa4d97d7d2b2c082e67907c0b8d9f31b85aa5d3ba0d33096b7116f03f8061261"},
-    {file = "kiwisolver-1.4.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:71469b5845b9876b8d3d252e201bef6f47bf7456804d2fbe9a1d6e19e78a1e65"},
-    {file = "kiwisolver-1.4.2-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8ff3033e43e7ca1389ee59fb7ecb8303abb8713c008a1da49b00869e92e3dd7c"},
-    {file = "kiwisolver-1.4.2-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:89b57c2984f4464840e4b768affeff6b6809c6150d1166938ade3e22fbe22db8"},
-    {file = "kiwisolver-1.4.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffbdb9a96c536f0405895b5e21ee39ec579cb0ed97bdbd169ae2b55f41d73219"},
-    {file = "kiwisolver-1.4.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8a830a03970c462d1a2311c90e05679da56d3bd8e78a4ba9985cb78ef7836c9f"},
-    {file = "kiwisolver-1.4.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f74f2a13af201559e3d32b9ddfc303c94ae63d63d7f4326d06ce6fe67e7a8255"},
-    {file = "kiwisolver-1.4.2-cp39-cp39-win32.whl", hash = "sha256:e677cc3626287f343de751e11b1e8a5b915a6ac897e8aecdbc996cd34de753a0"},
-    {file = "kiwisolver-1.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:b3e251e5c38ac623c5d786adb21477f018712f8c6fa54781bd38aa1c60b60fc2"},
-    {file = "kiwisolver-1.4.2-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0c380bb5ae20d829c1a5473cfcae64267b73aaa4060adc091f6df1743784aae0"},
-    {file = "kiwisolver-1.4.2-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:484f2a5f0307bc944bc79db235f41048bae4106ffa764168a068d88b644b305d"},
-    {file = "kiwisolver-1.4.2-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e8afdf533b613122e4bbaf3c1e42c2a5e9e2d1dd3a0a017749a7658757cb377"},
-    {file = "kiwisolver-1.4.2-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:42f6ef9b640deb6f7d438e0a371aedd8bef6ddfde30683491b2e6f568b4e884e"},
-    {file = "kiwisolver-1.4.2.tar.gz", hash = "sha256:7f606d91b8a8816be476513a77fd30abe66227039bd6f8b406c348cb0247dcc9"},
-]
+kiwisolver = []
 markupsafe = [
     {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
@@ -1176,43 +1129,7 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
 ]
-matplotlib = [
-    {file = "matplotlib-3.5.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:03bbb3f5f78836855e127b5dab228d99551ad0642918ccbf3067fcd52ac7ac5e"},
-    {file = "matplotlib-3.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:49a5938ed6ef9dda560f26ea930a2baae11ea99e1c2080c8714341ecfda72a89"},
-    {file = "matplotlib-3.5.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:77157be0fc4469cbfb901270c205e7d8adb3607af23cef8bd11419600647ceed"},
-    {file = "matplotlib-3.5.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5844cea45d804174bf0fac219b4ab50774e504bef477fc10f8f730ce2d623441"},
-    {file = "matplotlib-3.5.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c87973ddec10812bddc6c286b88fdd654a666080fbe846a1f7a3b4ba7b11ab78"},
-    {file = "matplotlib-3.5.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a05f2b37222319753a5d43c0a4fd97ed4ff15ab502113e3f2625c26728040cf"},
-    {file = "matplotlib-3.5.2-cp310-cp310-win32.whl", hash = "sha256:9776e1a10636ee5f06ca8efe0122c6de57ffe7e8c843e0fb6e001e9d9256ec95"},
-    {file = "matplotlib-3.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:b4fedaa5a9aa9ce14001541812849ed1713112651295fdddd640ea6620e6cf98"},
-    {file = "matplotlib-3.5.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ee175a571e692fc8ae8e41ac353c0e07259113f4cb063b0ec769eff9717e84bb"},
-    {file = "matplotlib-3.5.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e8bda1088b941ead50caabd682601bece983cadb2283cafff56e8fcddbf7d7f"},
-    {file = "matplotlib-3.5.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9480842d5aadb6e754f0b8f4ebeb73065ac8be1855baa93cd082e46e770591e9"},
-    {file = "matplotlib-3.5.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6c623b355d605a81c661546af7f24414165a8a2022cddbe7380a31a4170fa2e9"},
-    {file = "matplotlib-3.5.2-cp37-cp37m-win32.whl", hash = "sha256:a91426ae910819383d337ba0dc7971c7cefdaa38599868476d94389a329e599b"},
-    {file = "matplotlib-3.5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:c4b82c2ae6d305fcbeb0eb9c93df2602ebd2f174f6e8c8a5d92f9445baa0c1d3"},
-    {file = "matplotlib-3.5.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ebc27ad11df3c1661f4677a7762e57a8a91dd41b466c3605e90717c9a5f90c82"},
-    {file = "matplotlib-3.5.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5a32ea6e12e80dedaca2d4795d9ed40f97bfa56e6011e14f31502fdd528b9c89"},
-    {file = "matplotlib-3.5.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2a0967d4156adbd0d46db06bc1a877f0370bce28d10206a5071f9ecd6dc60b79"},
-    {file = "matplotlib-3.5.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2b696699386766ef171a259d72b203a3c75d99d03ec383b97fc2054f52e15cf"},
-    {file = "matplotlib-3.5.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7f409716119fa39b03da3d9602bd9b41142fab7a0568758cd136cd80b1bf36c8"},
-    {file = "matplotlib-3.5.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b8d3f4e71e26307e8c120b72c16671d70c5cd08ae412355c11254aa8254fb87f"},
-    {file = "matplotlib-3.5.2-cp38-cp38-win32.whl", hash = "sha256:b6c63cd01cad0ea8704f1fd586e9dc5777ccedcd42f63cbbaa3eae8dd41172a1"},
-    {file = "matplotlib-3.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:75c406c527a3aa07638689586343f4b344fcc7ab1f79c396699eb550cd2b91f7"},
-    {file = "matplotlib-3.5.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:4a44cdfdb9d1b2f18b1e7d315eb3843abb097869cd1ef89cfce6a488cd1b5182"},
-    {file = "matplotlib-3.5.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3d8e129af95b156b41cb3be0d9a7512cc6d73e2b2109f82108f566dbabdbf377"},
-    {file = "matplotlib-3.5.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:364e6bca34edc10a96aa3b1d7cd76eb2eea19a4097198c1b19e89bee47ed5781"},
-    {file = "matplotlib-3.5.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea75df8e567743207e2b479ba3d8843537be1c146d4b1e3e395319a4e1a77fe9"},
-    {file = "matplotlib-3.5.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:44c6436868186564450df8fd2fc20ed9daaef5caad699aa04069e87099f9b5a8"},
-    {file = "matplotlib-3.5.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7d7705022df2c42bb02937a2a824f4ec3cca915700dd80dc23916af47ff05f1a"},
-    {file = "matplotlib-3.5.2-cp39-cp39-win32.whl", hash = "sha256:ee0b8e586ac07f83bb2950717e66cb305e2859baf6f00a9c39cc576e0ce9629c"},
-    {file = "matplotlib-3.5.2-cp39-cp39-win_amd64.whl", hash = "sha256:c772264631e5ae61f0bd41313bbe48e1b9bcc95b974033e1118c9caa1a84d5c6"},
-    {file = "matplotlib-3.5.2-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:751d3815b555dcd6187ad35b21736dc12ce6925fc3fa363bbc6dc0f86f16484f"},
-    {file = "matplotlib-3.5.2-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:31fbc2af27ebb820763f077ec7adc79b5a031c2f3f7af446bd7909674cd59460"},
-    {file = "matplotlib-3.5.2-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4fa28ca76ac5c2b2d54bc058b3dad8e22ee85d26d1ee1b116a6fd4d2277b6a04"},
-    {file = "matplotlib-3.5.2-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:24173c23d1bcbaed5bf47b8785d27933a1ac26a5d772200a0f3e0e38f471b001"},
-    {file = "matplotlib-3.5.2.tar.gz", hash = "sha256:48cf850ce14fa18067f2d9e0d646763681948487a8080ec0af2686468b4607a2"},
-]
+matplotlib = []
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
@@ -1259,46 +1176,7 @@ pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
-pillow = [
-    {file = "Pillow-9.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:af79d3fde1fc2e33561166d62e3b63f0cc3e47b5a3a2e5fea40d4917754734ea"},
-    {file = "Pillow-9.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:55dd1cf09a1fd7c7b78425967aacae9b0d70125f7d3ab973fadc7b5abc3de652"},
-    {file = "Pillow-9.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:66822d01e82506a19407d1afc104c3fcea3b81d5eb11485e593ad6b8492f995a"},
-    {file = "Pillow-9.1.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a5eaf3b42df2bcda61c53a742ee2c6e63f777d0e085bbc6b2ab7ed57deb13db7"},
-    {file = "Pillow-9.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01ce45deec9df310cbbee11104bae1a2a43308dd9c317f99235b6d3080ddd66e"},
-    {file = "Pillow-9.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:aea7ce61328e15943d7b9eaca87e81f7c62ff90f669116f857262e9da4057ba3"},
-    {file = "Pillow-9.1.0-cp310-cp310-win32.whl", hash = "sha256:7a053bd4d65a3294b153bdd7724dce864a1d548416a5ef61f6d03bf149205160"},
-    {file = "Pillow-9.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:97bda660702a856c2c9e12ec26fc6d187631ddfd896ff685814ab21ef0597033"},
-    {file = "Pillow-9.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:21dee8466b42912335151d24c1665fcf44dc2ee47e021d233a40c3ca5adae59c"},
-    {file = "Pillow-9.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b6d4050b208c8ff886fd3db6690bf04f9a48749d78b41b7a5bf24c236ab0165"},
-    {file = "Pillow-9.1.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5cfca31ab4c13552a0f354c87fbd7f162a4fafd25e6b521bba93a57fe6a3700a"},
-    {file = "Pillow-9.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed742214068efa95e9844c2d9129e209ed63f61baa4d54dbf4cf8b5e2d30ccf2"},
-    {file = "Pillow-9.1.0-cp37-cp37m-win32.whl", hash = "sha256:c9efef876c21788366ea1f50ecb39d5d6f65febe25ad1d4c0b8dff98843ac244"},
-    {file = "Pillow-9.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:de344bcf6e2463bb25179d74d6e7989e375f906bcec8cb86edb8b12acbc7dfef"},
-    {file = "Pillow-9.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:17869489de2fce6c36690a0c721bd3db176194af5f39249c1ac56d0bb0fcc512"},
-    {file = "Pillow-9.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:25023a6209a4d7c42154073144608c9a71d3512b648a2f5d4465182cb93d3477"},
-    {file = "Pillow-9.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8782189c796eff29dbb37dd87afa4ad4d40fc90b2742704f94812851b725964b"},
-    {file = "Pillow-9.1.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:463acf531f5d0925ca55904fa668bb3461c3ef6bc779e1d6d8a488092bdee378"},
-    {file = "Pillow-9.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f42364485bfdab19c1373b5cd62f7c5ab7cc052e19644862ec8f15bb8af289e"},
-    {file = "Pillow-9.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:3fddcdb619ba04491e8f771636583a7cc5a5051cd193ff1aa1ee8616d2a692c5"},
-    {file = "Pillow-9.1.0-cp38-cp38-win32.whl", hash = "sha256:4fe29a070de394e449fd88ebe1624d1e2d7ddeed4c12e0b31624561b58948d9a"},
-    {file = "Pillow-9.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:c24f718f9dd73bb2b31a6201e6db5ea4a61fdd1d1c200f43ee585fc6dcd21b34"},
-    {file = "Pillow-9.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fb89397013cf302f282f0fc998bb7abf11d49dcff72c8ecb320f76ea6e2c5717"},
-    {file = "Pillow-9.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c870193cce4b76713a2b29be5d8327c8ccbe0d4a49bc22968aa1e680930f5581"},
-    {file = "Pillow-9.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69e5ddc609230d4408277af135c5b5c8fe7a54b2bdb8ad7c5100b86b3aab04c6"},
-    {file = "Pillow-9.1.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:35be4a9f65441d9982240e6966c1eaa1c654c4e5e931eaf580130409e31804d4"},
-    {file = "Pillow-9.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82283af99c1c3a5ba1da44c67296d5aad19f11c535b551a5ae55328a317ce331"},
-    {file = "Pillow-9.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a325ac71914c5c043fa50441b36606e64a10cd262de12f7a179620f579752ff8"},
-    {file = "Pillow-9.1.0-cp39-cp39-win32.whl", hash = "sha256:a598d8830f6ef5501002ae85c7dbfcd9c27cc4efc02a1989369303ba85573e58"},
-    {file = "Pillow-9.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:0c51cb9edac8a5abd069fd0758ac0a8bfe52c261ee0e330f363548aca6893595"},
-    {file = "Pillow-9.1.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a336a4f74baf67e26f3acc4d61c913e378e931817cd1e2ef4dfb79d3e051b481"},
-    {file = "Pillow-9.1.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb1b89b11256b5b6cad5e7593f9061ac4624f7651f7a8eb4dfa37caa1dfaa4d0"},
-    {file = "Pillow-9.1.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:255c9d69754a4c90b0ee484967fc8818c7ff8311c6dddcc43a4340e10cd1636a"},
-    {file = "Pillow-9.1.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:5a3ecc026ea0e14d0ad7cd990ea7f48bfcb3eb4271034657dc9d06933c6629a7"},
-    {file = "Pillow-9.1.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5b0ff59785d93b3437c3703e3c64c178aabada51dea2a7f2c5eccf1bcf565a3"},
-    {file = "Pillow-9.1.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7110ec1701b0bf8df569a7592a196c9d07c764a0a74f65471ea56816f10e2c8"},
-    {file = "Pillow-9.1.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:8d79c6f468215d1a8415aa53d9868a6b40c4682165b8cb62a221b1baa47db458"},
-    {file = "Pillow-9.1.0.tar.gz", hash = "sha256:f401ed2bbb155e1ade150ccc63db1a4f6c1909d3d378f7d1235a44e90d75fb97"},
-]
+pillow = []
 platformdirs = [
     {file = "platformdirs-2.4.1-py3-none-any.whl", hash = "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca"},
     {file = "platformdirs-2.4.1.tar.gz", hash = "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"},
@@ -1386,10 +1264,7 @@ requests = [
     {file = "requests-2.25.0-py2.py3-none-any.whl", hash = "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"},
     {file = "requests-2.25.0.tar.gz", hash = "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8"},
 ]
-setuptools-scm = [
-    {file = "setuptools_scm-6.4.2-py3-none-any.whl", hash = "sha256:acea13255093849de7ccb11af9e1fb8bde7067783450cee9ef7a93139bddf6d4"},
-    {file = "setuptools_scm-6.4.2.tar.gz", hash = "sha256:6833ac65c6ed9711a4d5d2266f8024cfa07c533a0e55f4c12f6eff280a5a9e30"},
-]
+setuptools-scm = []
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -1418,9 +1293,7 @@ sphinx-copybutton = [
     {file = "sphinx-copybutton-0.5.0.tar.gz", hash = "sha256:a0c059daadd03c27ba750da534a92a63e7a36a7736dcf684f26ee346199787f6"},
     {file = "sphinx_copybutton-0.5.0-py3-none-any.whl", hash = "sha256:9684dec7434bd73f0eea58dda93f9bb879d24bff2d8b187b1f2ec08dfe7b5f48"},
 ]
-sphinx-gallery = [
-    {file = "sphinx-gallery-0.10.1.tar.gz", hash = "sha256:953f32b0833b0a689ff33516d0866865fb8601c0626811b95d2e844286d207e4"},
-]
+sphinx-gallery = []
 sphinx-tabs = [
     {file = "sphinx-tabs-3.3.1.tar.gz", hash = "sha256:d10dd7fb2700329b8e5948ab9f8e3ef54fff30f79d2e42cfd1b0089ae26e8c5e"},
     {file = "sphinx_tabs-3.3.1-py3-none-any.whl", hash = "sha256:73209aa769246501f6de9e33051cfd2d54f5900e0cc28a63367d8e4af4c0db5d"},


### PR DESCRIPTION
This is for a fix for Veo as they seem to have issues uploading image groups with 1.8k images.

* Removes the `max_workers` and ditches parallel uploads.
* Allows for backoff logic with exposed parameters for GCP uploads. @justin-cord I chose slightly different default settings from what you suggested. This is more in line with what I have personally seen in practice. I am happy to adjust this.
* Allows image group upload with a mode where unsuccessfully uploaded images are skipped.
* Improves overall error reporting through logs