### PR TITLE
Update answer dictinary construction for single images.

### DIFF
--- a/encord/utilities/label_utilities.py
+++ b/encord/utilities/label_utilities.py
@@ -41,11 +41,11 @@ def construct_answer_dictionaries(label_row):
         if LABELS in data_unit:
             labels = data_unit.get(LABELS)
 
-            if data_type == DataType.IMG_GROUP.value:  # Go through images
+            if data_type in {DataType.IMG_GROUP.value, DataType.IMAGE.value}:  # Go through images
                 items = labels.get(OBJECTS) + labels.get(CLASSIFICATIONS)
                 add_answers_to_items(items, classification_answers, object_answers)
 
-            elif data_type in [DataType.VIDEO.value, DataType.IMAGE.value]:
+            elif data_type == DataType.VIDEO.value:
                 for frame in labels:  # Go through frames
                     items = labels[frame].get(OBJECTS) + labels[frame].get(CLASSIFICATIONS)
                     add_answers_to_items(items, classification_answers, object_answers)


### PR DESCRIPTION
# Introduction and Explanation
At the bug bash yesterday, we decided to unnest the "frame" level of single images in the label row (on the backend). The `construct_answer_dictionaries` needs to conform with this change.