### PR TITLE
DEV-2004 Dataset description defaults to empty string

### DIFF
--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -109,7 +109,7 @@ class EncordUserClient:
         self,
         dataset_title: str,
         dataset_type: StorageLocation,
-        dataset_description: Optional[str] = None,
+        dataset_description: str = "",
     ) -> CreateDatasetResponse:
         """
         DEPRECATED - please use `create_dataset` instead.
@@ -120,7 +120,7 @@ class EncordUserClient:
         self,
         dataset_title: str,
         dataset_type: StorageLocation,
-        dataset_description: Optional[str] = None,
+        dataset_description: str = "",
     ) -> CreateDatasetResponse:
         """
         Args:
@@ -138,7 +138,7 @@ class EncordUserClient:
             "type": dataset_type,
         }
 
-        if dataset_description:
+        if dataset_description != "":
             dataset["description"] = dataset_description
 
         result = self.querier.basic_setter(OrmDataset, uid=None, payload=dataset)


### PR DESCRIPTION
# Introduction and Explanation
Dataset description defaults to empty string rather than null value to comply with FE type checks. 

# JIRA
[JIRA ticket](https://cord-team.atlassian.net/browse/DEV-2004?atlOrigin=eyJpIjoiMWM3YjBmZDliNzg2NDJlNzljOGYwZGI3ZmNmMzMxMTkiLCJwIjoiaiJ9)