### PR TITLE
feat(querier): adds a poolsize config

### DIFF
--- a/encord/http/constants.py
+++ b/encord/http/constants.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+from requests.adapters import DEFAULT_POOLSIZE
+
 DEFAULT_MAX_RETRIES = 0
 DEFAULT_BACKOFF_FACTOR = 0.1
 
@@ -15,6 +17,9 @@ class RequestsSettings:
 
     backoff_factor: float = DEFAULT_BACKOFF_FACTOR
     """With each retry, there will be a sleep of backoff_factor * (2 ** retry_number)"""
+
+    pool_maxsize: int = DEFAULT_POOLSIZE
+    """The maximum number of connections to save in the pool."""
 
 
 DEFAULT_REQUESTS_SETTINGS = RequestsSettings()


### PR DESCRIPTION
# Introduction and Explanation
Since we don't yet support bulk fetch of label rows, multiple threads fetching individual rows is the next best thing.
The default connection pool size for `urllib3`  is 10 and we should allow customising it if you want to use more than 10 workers. 


The default number of workers for `ThreadPoolExecutor` is `min(32, os.cpu_count() + 4)` which would be more than 10 if you have more than 6 CPU cores. 

<img width="854" alt="image" src="https://user-images.githubusercontent.com/115489098/204015203-9b732bd1-5e1a-44d4-a644-addf93dcab4e.png">
