### PR TITLE
Add to_dict() in LabelRowMetadata class

### DIFF
--- a/encord/orm/label_row.py
+++ b/encord/orm/label_row.py
@@ -254,3 +254,19 @@ class LabelRowMetadata(Formatter):
         for i in json_list:
             ret.append(cls.from_dict(i))
         return ret
+
+    def to_dict(self) -> dict:
+        """
+        Returns:
+            The dict equivalent of LabelRowMetadata.
+        """
+        return dict(
+            label_hash=self.label_hash,
+            label_status=self.label_status.value,
+            data_hash=self.data_hash,
+            dataset_hash=self.dataset_hash,
+            data_title=self.data_title,
+            data_type=self.data_type,
+            is_shadow_data=self.is_shadow_data,
+            annotation_task_status=self.annotation_task_status.value,
+        )


### PR DESCRIPTION
# Introduction and Explanation
`LabelRowMetadata` class was missing `to_dict()` equivalent as in `OntologyStructure`. This method will come handy when saving Encord Active cache.