### PR TITLE
Changing "is not" to "!=" in query_payload function to silence syntax…

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -1019,7 +1019,7 @@ class EncordClientProject(EncordClient):
 
         function_arguments = locals()
 
-        query_payload = {k: v for (k, v) in function_arguments.items() if k is not "self" and v is not None}
+        query_payload = {k: v for (k, v) in function_arguments.items() if k != "self" and v is not None}
 
         return self._querier.get_multiple(LabelLog, payload=query_payload)
 


### PR DESCRIPTION
Changing "is not" to "!=" in query_payload function to silence syntax warnings.

pre-commit tests passed:
![Screenshot 2023-01-11 at 11 49 34](https://user-images.githubusercontent.com/119512483/211799122-c73a5dbc-792f-414b-9582-5c9597e9614a.png)
