### PR TITLE
feat(project-copy): adds label copy options

### DIFF
--- a/docs/source/code_examples/tutorials/projects/copying_a_project.py
+++ b/docs/source/code_examples/tutorials/projects/copying_a_project.py
@@ -34,11 +34,11 @@ project.copy_project(
         dataset_title="baz",
         dataset_description="quz",
         datasets_to_data_hashes_map={
-            "<dataset_hash>": ["<data_unit_1", "<data_unit_2"]
+            "<dataset_hash>": ["<data_hash_1", "<data_hash_2"]
         },
     ),
     copy_labels=CopyLabelsOptions(
         accepted_label_statuses=[ReviewApprovalState.APPROVED],
-        accepted_label_hashes=["<label_hahs_1>", "<label_hahs_2>"],
+        accepted_label_hashes=["<label_hash_1>", "<label_hash_2>"],
     ),
 )

--- a/docs/source/code_examples/tutorials/projects/copying_a_project.py
+++ b/docs/source/code_examples/tutorials/projects/copying_a_project.py
@@ -6,9 +6,39 @@ user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
 project: Project = user_client.get_project("<project_hash>")
 
 
+# Basic copy
+
 new_project_hash: str = project.copy_project(
     copy_datasets=True,
     copy_collaborators=True,
     copy_models=False,  # Not strictly needed
 )
 print(new_project_hash)
+
+
+# Advanced copy
+
+from encord.orm.project import (
+    CopyDatasetAction,
+    CopyDatasetOptions,
+    CopyLabelsOptions,
+    ReviewApprovalState,
+)
+
+project.copy_project(
+    new_title="foo",
+    new_description="bar",
+    copy_collaborators=True,
+    copy_datasets=CopyDatasetOptions(
+        action=CopyDatasetAction.CLONE,  # This will also create a new dataset
+        dataset_title="baz",
+        dataset_description="quz",
+        datasets_to_data_hashes_map={
+            "<dataset_hash>": ["<data_unit_1", "<data_unit_2"]
+        },
+    ),
+    copy_labels=CopyLabelsOptions(
+        accepted_label_statuses=[ReviewApprovalState.APPROVED],
+        accepted_label_hashes=["<label_hahs_1>", "<label_hahs_2>"],
+    ),
+)

--- a/encord/client.py
+++ b/encord/client.py
@@ -625,7 +625,7 @@ class EncordClientProject(EncordClient):
         copy_models=False,
         *,
         copy_labels: Optional[CopyLabelsOptions] = None,
-        new_title: str,
+        new_title: Optional[str] = None,
         new_description: Optional[str] = None,
     ) -> str:
         """

--- a/encord/client.py
+++ b/encord/client.py
@@ -99,6 +99,7 @@ from encord.orm.model import (
     ModelTrainingWeights,
     TrainingMetadata,
 )
+from encord.orm.project import CopyLabelsOptions, CopyProjectPayload
 from encord.orm.project import Project as OrmProject
 from encord.orm.project import (
     ProjectCopy,
@@ -612,18 +613,29 @@ class EncordClientProject(EncordClient):
 
         return list(map(lambda user: ProjectUser.from_dict(user), users))
 
-    def copy_project(self, copy_datasets=False, copy_collaborators=False, copy_models=False) -> str:
+    def copy_project(
+        self,
+        copy_datasets=False,
+        copy_collaborators=False,
+        copy_models=False,
+        copy_labels=False,
+        copy_labels_options: Optional[CopyLabelsOptions] = None,
+    ) -> str:
         """
         This function is documented in :meth:`encord.project.Project.copy_project`.
         """
 
-        payload = {"copy_project_options": []}
+        copy_project_options: List[ProjectCopyOptions] = []
         if copy_datasets:
-            payload["copy_project_options"].append(ProjectCopyOptions.DATASETS.value)
+            copy_project_options.append(ProjectCopyOptions.DATASETS)
         if copy_models:
-            payload["copy_project_options"].append(ProjectCopyOptions.MODELS.value)
+            copy_project_options.append(ProjectCopyOptions.MODELS)
         if copy_collaborators:
-            payload["copy_project_options"].append(ProjectCopyOptions.COLLABORATORS.value)
+            copy_project_options.append(ProjectCopyOptions.COLLABORATORS)
+        if copy_labels:
+            copy_project_options.append(ProjectCopyOptions.LABELS)
+
+        payload = CopyProjectPayload(copy_project_options=copy_project_options, copy_labels_options=copy_labels_options)
 
         return self._querier.basic_setter(ProjectCopy, self._config.resource_id, payload=payload)
 

--- a/encord/client.py
+++ b/encord/client.py
@@ -637,7 +637,7 @@ class EncordClientProject(EncordClient):
 
         payload = CopyProjectPayload(copy_project_options=copy_project_options, copy_labels_options=copy_labels_options)
 
-        return self._querier.basic_setter(ProjectCopy, self._config.resource_id, payload=payload)
+        return self._querier.basic_setter(ProjectCopy, self._config.resource_id, payload=dataclasses.asdict(payload))
 
     def get_label_row(
         self,

--- a/encord/client.py
+++ b/encord/client.py
@@ -620,13 +620,13 @@ class EncordClientProject(EncordClient):
 
     def copy_project(
         self,
-        *,
-        new_title: str,
-        new_description: Optional[str] = None,
         copy_datasets: Union[bool, CopyDatasetOptions] = False,
         copy_collaborators=False,
         copy_models=False,
+        *,
         copy_labels: Optional[CopyLabelsOptions] = None,
+        new_title: str,
+        new_description: Optional[str] = None,
     ) -> str:
         """
         This function is documented in :meth:`encord.project.Project.copy_project`.

--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -165,6 +165,14 @@ class ReviewApprovalState(str, Enum):
 
 
 @dataclass
+class CopyProjectMetadata:
+    project_title: str
+    project_description: str
+    dataset_title: Optional[str] = None
+    dataset_description: Optional[str] = None
+
+
+@dataclass
 class CopyReviewTasksOptions:
     copy_review_tasks: bool = False
     review_status_list: List = field(default_factory=list)

--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -16,7 +16,7 @@ import datetime
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, List, Optional, TypedDict, Union
+from typing import Dict, List, Optional, Union
 
 from encord.orm import base_orm
 
@@ -164,22 +164,25 @@ class ReviewApprovalState(str, Enum):
     NOT_SELECTED_FOR_REVIEW = "NOT_SELECTED_FOR_REVIEW"
 
 
-class CopyReviewTasksOptions(TypedDict):
-    copy_review_tasks: bool
-    review_status_list: List
+@dataclass
+class CopyReviewTasksOptions:
+    copy_review_tasks: bool = False
+    review_status_list: List = field(default_factory=list)
 
 
-class CopyLabelsOptions(TypedDict):
-    datasets_to_data_hashes_map: Dict[str, List[str]]
-    accepted_label_statuses: Optional[List[ReviewApprovalState]]
-    accpeted_label_hashes: Optional[List[str]]
-    copy_review_tasks_options: Optional[CopyReviewTasksOptions]
-    create_new_dataset: Optional[bool]
+@dataclass
+class CopyLabelsOptions:
+    datasets_to_data_hashes_map: Dict[str, List[str]] = field(default_factory=dict)
+    copy_review_tasks_options: CopyReviewTasksOptions = CopyReviewTasksOptions()
+    accpeted_label_hashes: Optional[List[str]] = None
+    accepted_label_statuses: Optional[List[ReviewApprovalState]] = None
+    create_new_dataset: Optional[bool] = None
 
 
-class CopyProjectPayload(TypedDict):
-    copy_project_options: List[ProjectCopyOptions]
-    copy_labels_options: Optional[CopyLabelsOptions]
+@dataclass
+class CopyProjectPayload:
+    copy_project_options: List[ProjectCopyOptions] = field(default_factory=list)
+    copy_labels_options: Optional[CopyLabelsOptions] = None
 
 
 class ProjectWorkflowType(Enum):

--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -174,7 +174,7 @@ class CopyReviewTasksOptions:
 class CopyLabelsOptions:
     datasets_to_data_hashes_map: Dict[str, List[str]] = field(default_factory=dict)
     copy_review_tasks_options: CopyReviewTasksOptions = CopyReviewTasksOptions()
-    accpeted_label_hashes: Optional[List[str]] = None
+    accepted_label_hashes: Optional[List[str]] = None
     accepted_label_statuses: Optional[List[ReviewApprovalState]] = None
     create_new_dataset: Optional[bool] = None
 

--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -166,7 +166,9 @@ class ReviewApprovalState(str, Enum):
 
 class CopyDatasetAction(str, Enum):
     ATTACH = "ATTACH"
+    """ Attach the datasets associated with the original project to the copy project. """
     CLONE = "CLONE"
+    """ Clone the data units from the associated datasets into a new dataset an attach it to the copy project. """
 
 
 @dataclass
@@ -176,8 +178,6 @@ class CopyDatasetOptions:
     action: CopyDatasetAction = CopyDatasetAction.ATTACH
     """
     One of `CopyDatasetAction.ATTACH` or `CopyDatasetAction.CLONE`. (defaults to ATTACH)
-    ATTACH: Attach the datasets associated with the original project to the copy project.
-    CLONE: Clone the data units from the associated datasets into a new dataset an attach it to the copy project.
     """
     dataset_title: Optional[str] = None
     dataset_description: Optional[str] = None
@@ -211,8 +211,8 @@ class CopyProjectPayload:
 
     @dataclass
     class _ProjectCopyMetadata:
-        project_title: str
-        project_description: str = ""
+        project_title: Optional[str] = None
+        project_description: Optional[str] = None
         dataset_title: Optional[str] = None
         dataset_description: Optional[str] = None
 

--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -16,7 +16,7 @@ import datetime
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, TypedDict, Union
 
 from encord.orm import base_orm
 
@@ -149,10 +149,37 @@ class ProjectDataset:
     pass
 
 
-class ProjectCopyOptions(Enum):
+class ProjectCopyOptions(str, Enum):
     COLLABORATORS = "collaborators"
     DATASETS = "datasets"
     MODELS = "models"
+    LABELS = "labels"
+
+
+class ReviewApprovalState(str, Enum):
+    APPROVED = "APPROVED"
+    PENDING = "PENDING"
+    REJECTED = "REJECTED"
+    DELETED = "DELETED"
+    NOT_SELECTED_FOR_REVIEW = "NOT_SELECTED_FOR_REVIEW"
+
+
+class CopyReviewTasksOptions(TypedDict):
+    copy_review_tasks: bool
+    review_status_list: List
+
+
+class CopyLabelsOptions(TypedDict):
+    datasets_to_data_hashes_map: Dict[str, List[str]]
+    accepted_label_statuses: Optional[List[ReviewApprovalState]]
+    accpeted_label_hashes: Optional[List[str]]
+    copy_review_tasks_options: Optional[CopyReviewTasksOptions]
+    create_new_dataset: Optional[bool]
+
+
+class CopyProjectPayload(TypedDict):
+    copy_project_options: List[ProjectCopyOptions]
+    copy_labels_options: Optional[CopyLabelsOptions]
 
 
 class ProjectWorkflowType(Enum):

--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -164,33 +164,61 @@ class ReviewApprovalState(str, Enum):
     NOT_SELECTED_FOR_REVIEW = "NOT_SELECTED_FOR_REVIEW"
 
 
+class CopyDatasetAction(str, Enum):
+    ATTACH = "ATTACH"
+    CLONE = "CLONE"
+
+
 @dataclass
-class CopyProjectMetadata:
-    project_title: str
-    project_description: str
+class CopyDatasetOptions:
+    """Options for copying the datasets associated with a project."""
+
+    action: CopyDatasetAction = CopyDatasetAction.ATTACH
+    """
+    One of `CopyDatasetAction.ATTACH` or `CopyDatasetAction.CLONE`. (defaults to ATTACH)
+    ATTACH: Attach the datasets associated with the original project to the copy project.
+    CLONE: Clone the data units from the associated datasets into a new dataset an attach it to the copy project.
+    """
     dataset_title: Optional[str] = None
     dataset_description: Optional[str] = None
-
-
-@dataclass
-class CopyReviewTasksOptions:
-    copy_review_tasks: bool = False
-    review_status_list: List = field(default_factory=list)
+    datasets_to_data_hashes_map: Dict[str, List[str]] = field(default_factory=dict)
+    """ A dictionary of `{ <dataset_hash>: List[<data_unit_hash>]}`.
+    When provided with a CLONE action this will filter the copied data units.
+    When combined with `CopyLabelsOptions`, only labels from specific data units will be copied.
+    """
 
 
 @dataclass
 class CopyLabelsOptions:
-    datasets_to_data_hashes_map: Dict[str, List[str]] = field(default_factory=dict)
-    copy_review_tasks_options: CopyReviewTasksOptions = CopyReviewTasksOptions()
+    """Options for copying the labels associated with a project."""
+
     accepted_label_hashes: Optional[List[str]] = None
+    """ A list of label hashes that will be copied to the new project  """
     accepted_label_statuses: Optional[List[ReviewApprovalState]] = None
-    create_new_dataset: Optional[bool] = None
+    """ A list of label statuses to filter the labels copied to the new project, defined in `ReviewApprovalState`"""
 
 
 @dataclass
 class CopyProjectPayload:
+    """WARN: do not use, this is only for internal purpose."""
+
+    @dataclass
+    class _CopyLabelsOptions:
+        datasets_to_data_hashes_map: Dict[str, List[str]] = field(default_factory=dict)
+        accepted_label_hashes: Optional[List[str]] = None
+        accepted_label_statuses: Optional[List[ReviewApprovalState]] = None
+        create_new_dataset: Optional[bool] = None
+
+    @dataclass
+    class _ProjectCopyMetadata:
+        project_title: str
+        project_description: str = ""
+        dataset_title: Optional[str] = None
+        dataset_description: Optional[str] = None
+
     copy_project_options: List[ProjectCopyOptions] = field(default_factory=list)
-    copy_labels_options: Optional[CopyLabelsOptions] = None
+    copy_labels_options: Optional[_CopyLabelsOptions] = None
+    project_copy_metadata: Optional[_ProjectCopyMetadata] = None
 
 
 class ProjectWorkflowType(Enum):

--- a/encord/project.py
+++ b/encord/project.py
@@ -222,6 +222,9 @@ class Project:
                                 If label and/or annotator reviewer mapping is set, this will also be copied over
             copy_models: currently if True, all models with their training information will be copied into the new
                          project
+            copy_labels: options for copying labels, defined in `CopyLabelsOptions`
+            new_title: when provided, will be used as the title for the new project.
+            new_description: when provided, will be used as the title for the new project.
 
         Returns:
             the EntityId of the newly created project
@@ -232,7 +235,7 @@ class Project:
             UnknownError: If an error occurs while copying the project.
         """
         return self._client.copy_project(
-            new_title=new_title or f"Copy of {self.title}",
+            new_title=new_title,
             new_description=new_description,
             copy_datasets=copy_datasets,
             copy_collaborators=copy_collaborators,

--- a/encord/project.py
+++ b/encord/project.py
@@ -14,7 +14,7 @@ from encord.orm.label_row import (
     ShadowDataState,
 )
 from encord.orm.model import ModelConfiguration, ModelTrainingWeights, TrainingMetadata
-from encord.orm.project import CopyLabelsOptions, CopyProjectMetadata
+from encord.orm.project import CopyDatasetOptions, CopyLabelsOptions
 from encord.orm.project import Project as OrmProject
 from encord.project_ontology.classification_type import ClassificationType
 from encord.project_ontology.object_type import ObjectShape
@@ -203,12 +203,12 @@ class Project:
 
     def copy_project(
         self,
-        copy_datasets=False,
+        copy_datasets: Union[bool, CopyDatasetOptions] = False,
         copy_collaborators=False,
         copy_models=False,
-        copy_labels=False,
-        copy_labels_options: Optional[CopyLabelsOptions] = None,
-        copy_project_metadata: Optional[CopyProjectMetadata] = None,
+        copy_labels: Optional[CopyLabelsOptions] = None,
+        new_title: Optional[str] = None,
+        new_description: Optional[str] = None,
     ) -> str:
         """
         Copy the current project into a new one with copied contents including settings, datasets and users.
@@ -231,7 +231,12 @@ class Project:
             UnknownError: If an error occurs while copying the project.
         """
         return self._client.copy_project(
-            copy_datasets, copy_collaborators, copy_models, copy_labels, copy_labels_options
+            new_title=new_title or f"Copy of {self.title}",
+            new_description=new_description,
+            copy_datasets=copy_datasets,
+            copy_collaborators=copy_collaborators,
+            copy_models=copy_models,
+            copy_labels=copy_labels,
         )
 
     def get_label_row(

--- a/encord/project.py
+++ b/encord/project.py
@@ -206,6 +206,7 @@ class Project:
         copy_datasets: Union[bool, CopyDatasetOptions] = False,
         copy_collaborators=False,
         copy_models=False,
+        *,
         copy_labels: Optional[CopyLabelsOptions] = None,
         new_title: Optional[str] = None,
         new_description: Optional[str] = None,

--- a/encord/project.py
+++ b/encord/project.py
@@ -14,7 +14,7 @@ from encord.orm.label_row import (
     ShadowDataState,
 )
 from encord.orm.model import ModelConfiguration, ModelTrainingWeights, TrainingMetadata
-from encord.orm.project import CopyLabelsOptions
+from encord.orm.project import CopyLabelsOptions, CopyProjectMetadata
 from encord.orm.project import Project as OrmProject
 from encord.project_ontology.classification_type import ClassificationType
 from encord.project_ontology.object_type import ObjectShape
@@ -208,6 +208,7 @@ class Project:
         copy_models=False,
         copy_labels=False,
         copy_labels_options: Optional[CopyLabelsOptions] = None,
+        copy_project_metadata: Optional[CopyProjectMetadata] = None,
     ) -> str:
         """
         Copy the current project into a new one with copied contents including settings, datasets and users.

--- a/encord/project.py
+++ b/encord/project.py
@@ -14,6 +14,7 @@ from encord.orm.label_row import (
     ShadowDataState,
 )
 from encord.orm.model import ModelConfiguration, ModelTrainingWeights, TrainingMetadata
+from encord.orm.project import CopyLabelsOptions
 from encord.orm.project import Project as OrmProject
 from encord.project_ontology.classification_type import ClassificationType
 from encord.project_ontology.object_type import ObjectShape
@@ -200,7 +201,14 @@ class Project:
         """
         return self._client.add_users(user_emails, user_role)
 
-    def copy_project(self, copy_datasets=False, copy_collaborators=False, copy_models=False) -> str:
+    def copy_project(
+        self,
+        copy_datasets=False,
+        copy_collaborators=False,
+        copy_models=False,
+        copy_labels=False,
+        copy_labels_options: Optional[CopyLabelsOptions] = None,
+    ) -> str:
         """
         Copy the current project into a new one with copied contents including settings, datasets and users.
         Labels and models are optional.
@@ -221,7 +229,9 @@ class Project:
             ResourceNotFoundError: If no project exists by the specified project EntityId.
             UnknownError: If an error occurs while copying the project.
         """
-        return self._client.copy_project(copy_datasets, copy_collaborators, copy_models)
+        return self._client.copy_project(
+            copy_datasets, copy_collaborators, copy_models, copy_labels, copy_labels_options
+        )
 
     def get_label_row(
         self,


### PR DESCRIPTION
# Introduction and Explanation
At encord active, we want to copy projects with their labels and create a new dataset as well.

The backend has the code already, just need to update the SDK.