### PR TITLE
Add support for specifying lists of integer frame numbers when annotating.

### DIFF
--- a/encord/objects/frames.py
+++ b/encord/objects/frames.py
@@ -11,7 +11,8 @@ class Range:
 
 
 Ranges = List[Range]
-Frames = Union[int, Range, Ranges]
+FramesList = List[int]
+Frames = Union[int, FramesList, Range, Ranges]
 
 
 def frame_to_range(frame: int) -> Range:
@@ -121,6 +122,11 @@ def frames_class_to_frames_list(frames_class: Frames) -> List[int]:
     elif isinstance(frames_class, Range):
         return range_to_frames(frames_class)
     elif isinstance(frames_class, list):
-        return ranges_to_frames(frames_class)
+        if all([isinstance(x, int) for x in frames_class]):
+            return sorted(list(set(frames_class)))
+        elif all([isinstance(x, Range) for x in frames_class]):
+            return ranges_to_frames(frames_class)
+        else:
+            raise RuntimeError("Unexpected type for frames.")
     else:
         raise RuntimeError("Unexpected type for frames.")

--- a/tests/objects/test_frames.py
+++ b/tests/objects/test_frames.py
@@ -1,0 +1,33 @@
+import pytest
+
+from encord.objects.frames import frames_class_to_frames_list, Range
+
+
+def test_frames_class_to_frames_list():
+    # Single frame
+    assert frames_class_to_frames_list(1) == [1]
+    assert frames_class_to_frames_list(10) == [10]
+
+    # Range
+    assert frames_class_to_frames_list(Range(1, 4)) == [1, 2, 3, 4]
+    assert frames_class_to_frames_list(Range(0, 1)) == [0, 1]
+    assert frames_class_to_frames_list(Range(4, 4)) == [4]
+
+    # List of Range
+    list_of_range_1 = [Range(2, 3), Range(3, 5), Range(7, 7)]
+    assert frames_class_to_frames_list(list_of_range_1) == [2, 3, 4, 5, 7]
+    list_of_range_2 = [Range(10, 12), Range(3, 5), Range(8, 9), Range(8, 9)]
+    assert frames_class_to_frames_list(list_of_range_2) == [3, 4, 5, 8, 9, 10, 11, 12]
+
+    # List of integer frame numbers
+    list_of_integers_1 = [4, 5, 6, 24, 60]
+    assert frames_class_to_frames_list(list_of_integers_1) == list_of_integers_1
+    assert frames_class_to_frames_list([4]) == [4]
+    assert frames_class_to_frames_list([9, 8, 7]) == [7, 8, 9]
+    assert frames_class_to_frames_list([9, 2, 4, 4, 14]) == [2, 4, 9, 14]
+
+    # Exception
+    with pytest.raises(RuntimeError):
+        frames_class_to_frames_list([4, Range(4, 6)])
+    with pytest.raises(RuntimeError):
+        frames_class_to_frames_list({3, 5, 7})

--- a/tests/objects/test_frames.py
+++ b/tests/objects/test_frames.py
@@ -20,6 +20,8 @@ def test_frames_class_to_frames_list():
     assert frames_class_to_frames_list(list_of_range_2) == [3, 4, 5, 8, 9, 10, 11, 12]
 
     # List of integer frame numbers
+    # Empty List
+    assert frames_class_to_frames_list([]) == []
     list_of_integers_1 = [4, 5, 6, 24, 60]
     assert frames_class_to_frames_list(list_of_integers_1) == list_of_integers_1
     assert frames_class_to_frames_list([4]) == [4]

--- a/tests/objects/test_label_structure.py
+++ b/tests/objects/test_label_structure.py
@@ -107,6 +107,26 @@ def test_create_object_instance_one_coordinate():
     object_instance.is_valid()
 
 
+def test_create_object_instance_one_coordinate_multiframe():
+    object_instance = box_ontology_item.create_instance()
+
+    coordinates = BoundingBoxCoordinates(
+        height=0.1,
+        width=0.2,
+        top_left_x=0.3,
+        top_left_y=0.4,
+    )
+
+    object_instance.set_for_frames(coordinates=coordinates, frames=[12, 6, 8])
+    object_instance.is_valid()
+
+    annotations = object_instance.get_annotations()
+    annotated_frames = []
+    for a in annotations:
+        annotated_frames.append(a.frame)
+    assert annotated_frames == [6, 8, 12]
+
+
 def test_create_a_label_row_from_empty_image_group_label_row_dict():
     label_row = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock())
 


### PR DESCRIPTION
# Introduction and Explanation
Adding the ability for annotations to be set in a list of frames instead of a range or list of ranges of frames.
We can now do
`object_instance.set_for_frames([3, 6, 10, 12])`
instead of having to do
`object_instance.set_for_frames([Range(3, 6), Range(10, 12)])`

# Tests

- A test that uses this behaviour at the object instance level (`object_instance.set_for_frames`).
- A test that checks the behaviour of the `frames_class_to_frames_list` method.
