### PR TITLE
docs: add missing explanation of features

### DIFF
--- a/docs/source/code_examples/tutorials/end-to-end/labels_v2.py
+++ b/docs/source/code_examples/tutorials/end-to-end/labels_v2.py
@@ -241,8 +241,8 @@ for label_row_frame_view in first_label_row.get_frame_views():
 #
 # You can read more about classification instances here: https://docs.encord.com/ontologies/use/#classifications
 #
-# Get the ontology object
-# ^^^^^^^^^^^^^^^^^^^^^^^^
+# Get the ontology classification
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 # Assume that the following text classification exists in the ontology.
 text_ontology_classification: Classification = (
@@ -259,6 +259,9 @@ text_classification_instance = text_ontology_classification.create_instance()
 
 # First set the value of the classification instance
 text_classification_instance.set_answer(answer="This is a text classification.")
+
+# Second, select the frames where the classification instance is present
+text_classification_instance.set_for_frames(frames=0)
 
 # Then add it to the label row
 first_label_row.add_classification_instance(text_classification_instance)

--- a/docs/source/tutorials/datasets.rst
+++ b/docs/source/tutorials/datasets.rst
@@ -172,7 +172,13 @@ Use the method :meth:`create_image_group() <encord.dataset.Dataset.create_image_
         ]
     )
 
-This will upload the given list of images to the dataset associated with the :class:`dataset <encord.dataset.Dataset>` and create an image group.
+This method will upload the given list of images to the dataset associated with the :class:`dataset <encord.dataset.Dataset>` and create an image group.
+
+You can also upload individual images to a dataset using Encord storage with the method :meth:`upload_image() <encord.dataset.Dataset.upload_image>`.
+
+.. code-block:: python
+
+    dataset.upload_image("path/to/your/img1.jpeg")
 
 .. note::
 


### PR DESCRIPTION
# Introduction and Explanation
When exploring the tutorials I found that the docs were missing:
1. How to upload individual images in Encord storage.
2. Select a frame range when setting a classification instance in a label row v2.

I made changes in the docs to handle both issues.