### PR TITLE
LabelRowV2: skip querying for ontology for each object

### DIFF
--- a/encord/project.py
+++ b/encord/project.py
@@ -33,7 +33,6 @@ class Project:
         self._client = client
         self._project_instance = project_instance
         self._ontology = ontology
-        self._project_instance: Optional[OrmProject] = None
 
     @property
     def project_hash(self) -> str:

--- a/encord/project.py
+++ b/encord/project.py
@@ -21,6 +21,7 @@ from encord.project_ontology.classification_type import ClassificationType
 from encord.project_ontology.object_type import ObjectShape
 from encord.project_ontology.ontology import Ontology as LegacyOntology
 from encord.utilities.project_user import ProjectUser, ProjectUserRole
+from encord.ontology import Ontology
 
 
 class Project:
@@ -28,8 +29,10 @@ class Project:
     Access project related data and manipulate the project.
     """
 
-    def __init__(self, client: EncordClientProject):
+    def __init__(self, client: EncordClientProject, project_instance: OrmProject, ontology: Ontology):
         self._client = client
+        self._project_instance = project_instance
+        self._ontology = ontology
         self._project_instance: Optional[OrmProject] = None
 
     @property
@@ -173,7 +176,9 @@ class Project:
             include_uninitialised_labels=True,
         )
 
-        label_rows = [LabelRowV2(label_row_metadata, self._client) for label_row_metadata in label_row_metadatas]
+        label_rows = [
+            LabelRowV2(label_row_metadata, self._client, self._ontology) for label_row_metadata in label_row_metadatas
+        ]
         return label_rows
 
     def add_users(self, user_emails: List[str], user_role: ProjectUserRole) -> List[ProjectUser]:

--- a/encord/project.py
+++ b/encord/project.py
@@ -138,6 +138,12 @@ class Project:
         """
         self._project_instance = self.get_project()
 
+    def refetch_ontology(self) -> None:
+        """
+        Update the ontology for the project to reflect changes on the backend
+        """
+        self._ontology.refetch_data()
+
     def get_project(self) -> OrmProject:
         """
         This function is exposed for convenience. You are encouraged to use the property accessors instead.

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -113,7 +113,10 @@ class EncordUserClient:
         config = SshConfig(self.user_config, resource_type=TYPE_PROJECT, resource_id=project_hash)
         querier = Querier(config)
         client = EncordClientProject(querier=querier, config=config)
-        return Project(client)
+
+        orm_project = client.get_project()
+        project_ontology = self.get_ontology(orm_project["ontology_hash"])
+        return Project(client, orm_project, project_ontology)
 
     def get_ontology(self, ontology_hash: str) -> Ontology:
         config = SshConfig(self.user_config, resource_type=TYPE_ONTOLOGY, resource_id=ontology_hash)

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -116,7 +116,9 @@ class EncordUserClient:
 
         orm_project = client.get_project()
 
-        # TODO: it seems like client.get_ontology should be used here, but this leads to the permission errors
+        # Querying ontology using project querier to avoid permission error,
+        # as there might be only read-only ontology structure access in scope of the project,
+        # not full access, that is implied by get_ontology method
         ontology_hash = orm_project["ontology_hash"]
         config = SshConfig(self.user_config, resource_type=TYPE_ONTOLOGY, resource_id=ontology_hash)
         project_ontology = Ontology(querier, config)

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -115,7 +115,12 @@ class EncordUserClient:
         client = EncordClientProject(querier=querier, config=config)
 
         orm_project = client.get_project()
-        project_ontology = self.get_ontology(orm_project["ontology_hash"])
+
+        # TODO: it seems like client.get_ontology should be used here, but this leads to the permission errors
+        ontology_hash = orm_project["ontology_hash"]
+        config = SshConfig(self.user_config, resource_type=TYPE_ONTOLOGY, resource_id=ontology_hash)
+        project_ontology = Ontology(querier, config)
+
         return Project(client, orm_project, project_ontology)
 
     def get_ontology(self, ontology_hash: str) -> Ontology:

--- a/tests/objects/test_label_structure.py
+++ b/tests/objects/test_label_structure.py
@@ -1,6 +1,6 @@
 import datetime
 from dataclasses import asdict
-from unittest.mock import Mock
+from unittest.mock import Mock, PropertyMock
 
 import pytest
 
@@ -93,6 +93,13 @@ POLYGON_COORDINATES = PolygonCoordinates(
 KEYPOINT_COORDINATES = PointCoordinate(x=0.2, y=0.1)
 
 
+@pytest.fixture
+def ontology():
+    ontology_structure = PropertyMock(return_value=all_types_structure)
+    ontology = Mock(structure=ontology_structure)
+    yield ontology
+
+
 def test_create_object_instance_one_coordinate():
     object_instance = box_ontology_item.create_instance()
 
@@ -127,21 +134,21 @@ def test_create_object_instance_one_coordinate_multiframe():
     assert annotated_frames == [6, 8, 12]
 
 
-def test_create_a_label_row_from_empty_image_group_label_row_dict():
-    label_row = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock())
+def test_create_a_label_row_from_empty_image_group_label_row_dict(ontology):
+    label_row = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock(), ontology)
 
     with pytest.raises(LabelRowError):
         label_row.get_classification_instances()
 
-    label_row.from_labels_dict(empty_image_group_labels, all_types_structure)
+    label_row.from_labels_dict(empty_image_group_labels)
     assert label_row.get_classification_instances() == []
     assert label_row.get_object_instances() == []
     # TODO: do more assertions
 
 
-def test_add_object_instance_to_label_row():
-    label_row = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock())
-    label_row.from_labels_dict(empty_image_group_labels, all_types_structure)
+def test_add_object_instance_to_label_row(ontology):
+    label_row = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock(), ontology)
+    label_row.from_labels_dict(empty_image_group_labels)
 
     object_instance = ObjectInstance(box_ontology_item)
 
@@ -157,9 +164,9 @@ def test_add_object_instance_to_label_row():
     assert label_row.get_object_instances()[0].object_hash == object_instance.object_hash
 
 
-def test_add_remove_access_object_instances_in_label_row():
-    label_row = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock())
-    label_row.from_labels_dict(empty_image_group_labels, all_types_structure)
+def test_add_remove_access_object_instances_in_label_row(ontology):
+    label_row = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock(), ontology)
+    label_row.from_labels_dict(empty_image_group_labels)
 
     object_instance_1 = ObjectInstance(box_ontology_item)
     object_instance_2 = ObjectInstance(box_ontology_item)
@@ -195,9 +202,9 @@ def test_add_remove_access_object_instances_in_label_row():
     assert objects[0].object_hash == object_instance_2.object_hash
 
 
-def test_filter_for_objects():
-    label_row = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock())
-    label_row.from_labels_dict(empty_image_group_labels, all_types_structure)
+def test_filter_for_objects(ontology):
+    label_row = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock(), ontology)
+    label_row.from_labels_dict(empty_image_group_labels)
 
     label_box = ObjectInstance(box_ontology_item)
     label_polygon = ObjectInstance(polygon_ontology_item)
@@ -246,9 +253,9 @@ def test_add_wrong_coordinates():
         label_box.set_for_frames(POLYGON_COORDINATES, frames=1)
 
 
-def test_get_object_instances_by_frames():
-    label_row = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock())
-    label_row.from_labels_dict(empty_image_group_labels, all_types_structure)
+def test_get_object_instances_by_frames(ontology):
+    label_row = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock(), ontology)
+    label_row.from_labels_dict(empty_image_group_labels)
 
     label_box = ObjectInstance(box_ontology_item)
     label_polygon = ObjectInstance(polygon_ontology_item)
@@ -285,12 +292,12 @@ def test_get_object_instances_by_frames():
     assert objects[0].object_hash == label_polygon.object_hash
 
 
-def test_adding_object_instance_to_multiple_frames_fails():
-    label_row_1 = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock())
-    label_row_1.from_labels_dict(empty_image_group_labels, all_types_structure)
+def test_adding_object_instance_to_multiple_frames_fails(ontology):
+    label_row_1 = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock(), ontology)
+    label_row_1.from_labels_dict(empty_image_group_labels)
 
-    label_row_2 = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock())
-    label_row_2.from_labels_dict(empty_image_group_labels, all_types_structure)
+    label_row_2 = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock(), ontology)
+    label_row_2.from_labels_dict(empty_image_group_labels)
 
     label_box = ObjectInstance(box_ontology_item)
 
@@ -398,9 +405,9 @@ def test_update_remove_object_instance_coordinates():
     assert frame_4_view.manual_annotation == manual_annotation
 
 
-def test_removing_coordinates_from_object_removes_it_from_parent():
-    label_row = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock())
-    label_row.from_labels_dict(empty_image_group_labels, all_types_structure)
+def test_removing_coordinates_from_object_removes_it_from_parent(ontology):
+    label_row = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock(), ontology)
+    label_row.from_labels_dict(empty_image_group_labels)
 
     label_box = ObjectInstance(box_ontology_item)
     label_box.set_for_frames(BOX_COORDINATES, 1)
@@ -587,9 +594,9 @@ def test_classification_instances_frame_view():
         frame_view_1.created_by = "aphrodite@gmail.com"
 
 
-def test_add_and_get_classification_instances_to_label_row():
-    label_row = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock())
-    label_row.from_labels_dict(empty_image_group_labels, all_types_structure)
+def test_add_and_get_classification_instances_to_label_row(ontology):
+    label_row = LabelRowV2(FAKE_LABEL_ROW_METADATA, Mock(), ontology)
+    label_row.from_labels_dict(empty_image_group_labels)
 
     classification_instance_1 = ClassificationInstance(text_classification)
     classification_instance_2 = ClassificationInstance(text_classification)
@@ -899,21 +906,21 @@ def test_label_status_forwards_compatibility():
     assert LabelStatus("new-unknown-status").value == "_MISSING_LABEL_STATUS_"
 
 
-def test_frame_view():
+def test_frame_view(ontology):
     label_row_metadata_dict = asdict(FAKE_LABEL_ROW_METADATA)
     label_row_metadata_dict["frames_per_second"] = 25
     label_row_metadata_dict["duration"] = 0.2
     label_row_metadata_dict["number_of_frames"] = 5
     label_row_metadata = LabelRowMetadata(**label_row_metadata_dict)
 
-    label_row = LabelRowV2(label_row_metadata, Mock())
+    label_row = LabelRowV2(label_row_metadata, Mock(), ontology)
 
     assert label_row.number_of_frames == label_row_metadata.number_of_frames
 
     with pytest.raises(LabelRowError):
         frames = label_row.get_frame_views()
 
-    label_row.from_labels_dict(empty_image_group_labels, all_types_structure)  # initialise the labels.
+    label_row.from_labels_dict(empty_image_group_labels)  # initialise the labels.
 
     frame_view: LabelRowV2.FrameView = label_row.get_frame_view(1)
     assert frame_view.get_object_instances() == []

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -12,6 +12,7 @@ from encord.constants.model_weights import faster_rcnn_R_101_C4_3x
 from encord.exceptions import EncordException
 from encord.project import Project
 from encord.user_client import EncordUserClient
+from encord.client import EncordClientProject
 
 PRIVATE_KEY = (
     Ed25519PrivateKey.generate()
@@ -36,7 +37,10 @@ def teardown_function():
 
 
 @pytest.fixture
-def project(ssh_key_file_path):
+@patch.object(EncordClientProject, "get_project")
+def project(project_client_mock, ssh_key_file_path):
+    project_client_mock.get_project.return_value = MagicMock()
+
     os.environ[_ENCORD_SSH_KEY_FILE] = ssh_key_file_path
     user_client = EncordUserClient.create_with_ssh_private_key()
     assert isinstance(user_client, EncordUserClient)


### PR DESCRIPTION
# Introduction and Explanation
Make LabelRowV2 instances from same project to share same ontology object

# JIRA

None


# Documentation

Observed behaviour doesn't change so no documentation changes required

# Tests

Observed behaviour doesn't change so no additional tests added

# Known issues

None