### PR TITLE
Set default of annotation.last_edited_at to None when not passed from backend

### DIFF
--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -2478,7 +2478,7 @@ class ObjectInstance:
         created_at: datetime = datetime.now()
         created_by: Optional[str] = None
         """None defaults to the user of the SDK once uploaded to the server."""
-        last_edited_at: datetime = datetime.now()
+        last_edited_at: datetime = None
         last_edited_by: Optional[str] = None
         """None defaults to the user of the SDK once uploaded to the server."""
         confidence: float = DEFAULT_CONFIDENCE


### PR DESCRIPTION
# Introduction and Explanation
Annotation object currently sets last_edited_at to the current time if backend doesn't pass actual value. This is confusing our customers, so changing default to None as we have in other cases

# JIRA
Related to https://cord-team.atlassian.net/browse/CS-65
