### PR TITLE
Add project cache invalidation for project object on ontology changes

### DIFF
--- a/encord/project.py
+++ b/encord/project.py
@@ -340,7 +340,11 @@ class Project:
             OperationNotAllowed: If the operation is not allowed by the API key.
             ValueError: If invalid arguments are supplied in the function call
         """
-        return self._client.add_object(name, shape)
+        res = self._client.add_object(name, shape)
+        if res:
+            self._invalidate_project_instance()
+
+        return res
 
     def add_classification(
         self,
@@ -367,7 +371,11 @@ class Project:
             OperationNotAllowed: If the operation is not allowed by the API key.
             ValueError: If invalid arguments are supplied in the function call
         """
-        return self._client.add_classification(name, classification_type, required, options)
+        res = self._client.add_classification(name, classification_type, required, options)
+        if res:
+            self._invalidate_project_instance()
+
+        return res
 
     def list_models(self) -> List[ModelConfiguration]:
         """

--- a/encord/project.py
+++ b/encord/project.py
@@ -288,8 +288,7 @@ class Project:
             OperationNotAllowed: If the write operation is not allowed by the API key.
         """
         res = self._client.add_datasets(dataset_hashes)
-        if res:
-            self._invalidate_project_instance()
+        self._invalidate_project_instance()
         return res
 
     def remove_datasets(self, dataset_hashes: List[str]) -> bool:
@@ -310,8 +309,7 @@ class Project:
             OperationNotAllowed: If the operation is not allowed by the API key.
         """
         res = self._client.remove_datasets(dataset_hashes)
-        if res:
-            self._invalidate_project_instance()
+        self._invalidate_project_instance()
         return res
 
     def get_project_ontology(self) -> LegacyOntology:
@@ -341,9 +339,7 @@ class Project:
             ValueError: If invalid arguments are supplied in the function call
         """
         res = self._client.add_object(name, shape)
-        if res:
-            self._invalidate_project_instance()
-
+        self._invalidate_project_instance()
         return res
 
     def add_classification(
@@ -372,9 +368,7 @@ class Project:
             ValueError: If invalid arguments are supplied in the function call
         """
         res = self._client.add_classification(name, classification_type, required, options)
-        if res:
-            self._invalidate_project_instance()
-
+        self._invalidate_project_instance()
         return res
 
     def list_models(self) -> List[ModelConfiguration]:


### PR DESCRIPTION
# Introduction and Explanation
Invalidates project data cache once project ontology is modified, to avoid state inconsistencies between SDK and the backend
