### PR TITLE
Fix remove_classifications method in labelrowv2.

### DIFF
--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -1236,10 +1236,7 @@ class LabelRowV2:
 
         classification_hash = classification_instance.classification_hash
         self._classifications_map.pop(classification_hash)
-        all_frames = self._classifications_to_frames[classification_instance.ontology_item]
-        actual_frames = _frame_views_to_frame_numbers(classification_instance.get_annotations())
-        for actual_frame in actual_frames:
-            all_frames.remove(actual_frame)
+        self._classifications_to_frames[classification_instance.ontology_item] = set()
 
     def add_to_single_frame_to_hashes_map(
         self, label_item: Union[ObjectInstance, ClassificationInstance], frame: int


### PR DESCRIPTION
Placeholder PR for the issue raised by GUSI to delete classifications.
They attached a notebook to their bug report: https://encord-global.slack.com/archives/C04J9HSUC58/p1681176352614909