### PR TITLE
Add frame indices updates on when classification instance is updated

### DIFF
--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -462,6 +462,10 @@ class ClassificationInstance:
                 reviews=reviews,
             )
 
+        if self.is_assigned_to_label_row():
+            self._parent._add_frames_to_classification(self.ontology_item, frames_list)
+            self._parent._add_to_frame_to_hashes_map(self)
+
     def get_annotation(self, frame: Union[int, str] = 0) -> Annotation:
         """
         Args:
@@ -1764,6 +1768,9 @@ class LabelRowV2:
             if frame in present_frames:
                 return frame
         return None
+
+    def _add_frames_to_classification(self, classification: Classification, frames: Iterable[int]) -> None:
+        self._classifications_to_frames[classification].update(set(frames))
 
     def _remove_frames_from_classification(self, classification: Classification, frames: Iterable[int]) -> None:
         present_frames = self._classifications_to_frames.get(classification, set())

--- a/tests/objects/test_label_structure.py
+++ b/tests/objects/test_label_structure.py
@@ -949,3 +949,26 @@ def test_frame_view(ontology):
 
     assert frame_view.get_object_instances() == [object_instance]
     assert frame_view.get_classification_instances() == [classification_instance]
+
+
+def test_classification_can_be_added_edited_and_removed(ontology):
+    label_row_metadata_dict = asdict(FAKE_LABEL_ROW_METADATA)
+    label_row_metadata_dict["frames_per_second"] = 25
+    label_row_metadata_dict["duration"] = 0.2
+    label_row_metadata_dict["number_of_frames"] = 2
+    label_row_metadata = LabelRowMetadata(**label_row_metadata_dict)
+
+    label_row = LabelRowV2(label_row_metadata, Mock(), ontology)
+    label_row.from_labels_dict(empty_image_group_labels)  # initialise the labels.
+
+    classification_instance = ClassificationInstance(checklist_classification)
+    classification_instance.set_for_frames(0)
+
+    label_row.add_classification_instance(classification_instance)
+    assert len(label_row.get_classification_instances()) == 1
+
+    classification_instance.set_for_frames(1)
+
+    label_row.remove_classification(classification_instance)
+
+    assert len(label_row.get_classification_instances()) == 0


### PR DESCRIPTION
Fixes an issue with parsing multi-frame classification that makes it impossible to remove frames from the classification using SDK

Root cause is that ClassificationInstance.set_for_frames() method did not update frames indices in the LabelRow it belongs to, so they would eventually diverge.