### PR TITLE
Skip downloading label rows metadata when querying project using UserClient

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -703,9 +703,12 @@ class EncordClientProject(EncordClient):
     DEPRECATED - prefer using the :class:`encord.project.Project` instead
     """
 
-    def get_project(self):
+    def get_project(self, include_labels_metadata=True):
         """
         Retrieve project info (pointers to data, labels).
+
+        Args:
+            include_labels_metadata: if false, label row metadata information will not be returned.
 
         Returns:
             OrmProject: A project record instance.
@@ -715,7 +718,7 @@ class EncordClientProject(EncordClient):
             ResourceNotFoundError: If no project exists by the specified project EntityId.
             UnknownError: If an error occurs while retrieving the project.
         """
-        return self._querier.basic_getter(OrmProject)
+        return self._querier.basic_getter(OrmProject, payload={"include_labels_metadata": include_labels_metadata})
 
     def list_label_rows(
         self,

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -114,7 +114,7 @@ class EncordUserClient:
         querier = Querier(config)
         client = EncordClientProject(querier=querier, config=config)
 
-        orm_project = client.get_project()
+        orm_project = client.get_project(include_labels_metadata=False)
 
         # Querying ontology using project querier to avoid permission error,
         # as there might be only read-only ontology structure access in scope of the project,


### PR DESCRIPTION
`UserClient.get_project` method currently receives all the rows metadata info when reads project information, and then immediately discards it. And this will cause significant unneeded delays, especially for big projects. 
With explicitly opting out of receiving metadata along with the project this method will complete many times faster.