### PR TITLE
Fix an error on setting dynamic answer

### DIFF
--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -2277,7 +2277,7 @@ class ObjectInstance:
             attribute = self._ontology_object.attributes[0]
         elif not self._is_attribute_valid_child_of_object_instance(attribute):
             raise LabelRowError("The attribute is not a valid child of the classification.")
-        elif not self._is_selectable_child_attribute(attribute):
+        elif not attribute.dynamic and not self._is_selectable_child_attribute(attribute):
             return None
 
         if is_dynamic is not None and is_dynamic is not attribute.dynamic:

--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -2769,6 +2769,9 @@ class ObjectInstance:
         # I have the ontology classification, so I can build the tree from that. Basically do a DFS.
         ontology_object = self._ontology_object
         for search_attribute in ontology_object.attributes:
+            if search_attribute.dynamic:
+                continue
+
             if _search_child_attributes(attribute, search_attribute, self._static_answer_map):
                 return True
         return False

--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -2326,7 +2326,7 @@ class ObjectInstance:
             attribute = _infer_attribute_from_answer(self._ontology_object.attributes, answer)
         if not self._is_attribute_valid_child_of_object_instance(attribute):
             raise LabelRowError("The attribute is not a valid child of the object.")
-        elif not self._is_selectable_child_attribute(attribute):
+        elif not attribute.dynamic and not self._is_selectable_child_attribute(attribute):
             raise LabelRowError(
                 "Setting a nested attribute is only possible if all parent attributes have been selected."
             )

--- a/tests/objects/test_label_structure.py
+++ b/tests/objects/test_label_structure.py
@@ -60,9 +60,9 @@ dynamic_text: TextAttribute = all_types_structure.get_child_by_hash("OTkxMjU1")
 dynamic_checklist = all_types_structure.get_child_by_hash("ODcxMDAy")
 dynamic_checklist_option_1 = all_types_structure.get_child_by_hash("MTE5MjQ3")
 dynamic_checklist_option_2 = all_types_structure.get_child_by_hash("Nzg3MDE3")
-dynamic_radio = all_types_structure.get_child_by_hash("MTExM9I3")
-dynamic_radio_option_1 = all_types_structure.get_child_by_hash("MT9xNDQ5")  # This is dynamic and deeply nested.
-dynamic_radio_option_2 = all_types_structure.get_child_by_hash("9TcxMjAy")  # This is dynamic and deeply nested.
+dynamic_radio = all_types_structure.get_child_by_hash("MTExM9I3", type_=RadioAttribute)
+dynamic_radio_option_1 = all_types_structure.get_child_by_hash("MT9xNDQ5", type_=Option)  # Dynamic and deeply nested.
+dynamic_radio_option_2 = all_types_structure.get_child_by_hash("9TcxMjAy", type_=Option)  # Dynamic and deeply nested.
 
 text_classification = all_types_structure.get_child_by_hash("jPOcEsbw", Classification)
 text_classification_attribute: TextAttribute = all_types_structure.get_child_by_hash("OxrtEM+v", TextAttribute)
@@ -752,6 +752,18 @@ def test_object_instance_answer_dynamic_attributes():
     # Overwriting frames
     object_instance.set_answer("Poseidon", attribute=dynamic_text, frames=1)
     assert object_instance.get_answer(dynamic_text) == [AnswerForFrames(answer="Poseidon", ranges=[Range(1, 1)])]
+
+
+def test_object_instance_answer_dynamic_classification():
+    object_instance = keypoint_dynamic.create_instance()
+
+    assert object_instance.get_answer(dynamic_radio) == []
+
+    object_instance.set_answer(answer=dynamic_radio_option_1, frames=1)
+
+    assert object_instance.get_answer(dynamic_radio) == [
+        AnswerForFrames(answer=dynamic_radio_option_1, ranges=[Range(1, 1)])
+    ]
 
 
 def test_object_instance_answer_dynamic_no_frames_argument():


### PR DESCRIPTION
ObjectInstance.set_answer throws an error when user tries to set an answer for dynamic attribute. This happens due to erroneous attempt to find dynamic attribute in the static answer map. Skipping this check for dynamic answers