### PR TITLE
ClassificationInstance: add missing properties

### DIFF
--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -2815,7 +2815,7 @@ class ObjectInstance:
     def __repr__(self):
         return (
             f"ObjectInstance(object_hash={self._object_hash}, object_name={self._ontology_object.name}, "
-            f"object_feature_hash={self._ontology_object.feature_node_hash})"
+            f"feature_hash={self._ontology_object.feature_node_hash})"
         )
 
     def __hash__(self) -> int:


### PR DESCRIPTION
Add properties `classification_name` and `object_feature_hash` of ClassificationInstance.
These properties were printed as part of an object representation, but not exposed as properties, which is confusing for the interface users.