### PR TITLE
Fix non-backward compatible typing

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -1291,7 +1291,7 @@ class EncordClientProject(EncordClient):
         payload = {"editor": ontology.to_dict()}
         return self._querier.basic_setter(OrmProject, uid=None, payload=payload)
 
-    def workflow_reopen(self, label_hashes: list[str]) -> None:
+    def workflow_reopen(self, label_hashes: List[str]) -> None:
         """
         This function is documented in :meth:`encord.objects.LabelRowV2.workflow_reopen`.
         """

--- a/tests/test_workflow_actions.py
+++ b/tests/test_workflow_actions.py
@@ -1,0 +1,76 @@
+import json
+from copy import deepcopy
+from typing import Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from requests import Session
+
+from encord import EncordUserClient, Project
+from encord.client import EncordClientProject
+from encord.http.querier import Querier, RequestContext
+from encord.objects import LabelRowV2
+from encord.objects.ontology_labels_impl import Ontology as OrmOntology
+from encord.ontology import Ontology
+from encord.orm.label_row import LabelRow, LabelRowMetadata
+from encord.orm.project import Project as OrmProject
+from tests.test_data.label_rows_metadata_blurb import (
+    LABEL_ROW_BLURB,
+    LABEL_ROW_METADATA_BLURB,
+)
+from tests.test_data.ontology_blurb import ONTOLOGY_BLURB
+
+DUMMY_PRIVATE_KEY = (
+    Ed25519PrivateKey.generate()
+    .private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.OpenSSH,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    .decode("utf-8")
+)
+
+
+@pytest.fixture
+def client():
+    client = EncordUserClient.create_with_ssh_private_key(DUMMY_PRIVATE_KEY)
+    return client
+
+
+@pytest.fixture
+def ontology():
+    ontology = Ontology(None, None, OrmOntology.from_dict(ONTOLOGY_BLURB))
+    return ontology
+
+
+@pytest.fixture
+@patch.object(EncordClientProject, "get_project")
+def project(client_project_mock, client: EncordUserClient, ontology: Ontology):
+    client_project_mock.return_value = OrmProject(
+        {"ontology_hash": "dummy-ontology-hash", "project_hash": "dummy-project-hash"}
+    )
+    project = client.get_project("dummy-project-hash")
+    project._ontology = ontology
+    return project
+
+
+@patch.object(Querier, "_execute")
+@patch.object(EncordClientProject, "list_label_rows")
+def test_workflow_reopen(list_label_rows_mock: MagicMock, querier_request_mock: MagicMock, project: Project):
+    label_rows_metadata = [LabelRowMetadata.from_dict(row) for row in LABEL_ROW_METADATA_BLURB]
+    list_label_rows_mock.return_value = label_rows_metadata
+    querier_request_mock.return_value = (True, RequestContext())
+
+    test_label_row = project.list_label_rows_v2()[0]
+
+    test_label_row.workflow_reopen()
+
+    querier_request_mock.assert_called_once()
+
+    request = querier_request_mock.call_args[0][0]
+    request_data = json.loads(request.data)
+
+    assert request_data["query_type"] == "labelworkflowgraphnode"
+    assert request_data["values"]["uid"] == [test_label_row.label_hash]


### PR DESCRIPTION
worfklow_reopen method has a type annotation that is accepted only by python 3.11. Change it to make compatible with earlier versions.