### PR TITLE
Various amends to example scripts in documentation

### DIFF
--- a/docs/source/code_examples/tutorials/projects/creating_a_project_object.py
+++ b/docs/source/code_examples/tutorials/projects/creating_a_project_object.py
@@ -4,4 +4,4 @@ user_client: EncordUserClient = EncordUserClient.create_with_ssh_private_key(
     "<your_private_key>"
 )
 
-project: Project = user_client.get_project("<dataset_hash>")
+project: Project = user_client.get_project("<project_hash>")


### PR DESCRIPTION
Changing SDK docs to amend incorrect "dataset_hash" to "project_hash" in example script.