### PR TITLE
Change the cryptography dependency version requirements to allow major version changes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2048,4 +2048,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "348df8983910892d8e62cf9eadec9bd2e122bbf4b0c7c6d49174808d6c5fba36"
+content-hash = "95393044a204c409ebfd446fe2aedab5c3eb99aa07a1e122c46e75984a2a7d24"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers=[
 python = "^3.7"
 python-dateutil = "^2.8.2"
 requests = "^2.25.0"
-cryptography = "^3.4.8"
+cryptography = ">=3.4.8"
 tqdm = "^4.32.1"
 importlib_metadata = {version = "^6.1.0", python = "<3.8"}
 


### PR DESCRIPTION
Cryptograhy dependency changes major versions way too often, which makes it impossible to find the major version that works for the most of the customers. Thus, allowing the major version change, while keeping the known minimal bar.