### PR TITLE
Add datetime filter to project.get_label_logs 

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -1265,7 +1265,7 @@ class EncordClientProject(EncordClient):
             from_unix_seconds=from_unix_seconds,
         )
 
-        return self._querier.get_multiple(LabelLog, payload=payload)
+        return self._querier.get_multiple(LabelLog, payload=payload.to_dict(by_alias=False))
 
     def __set_project_ontology(self, ontology: Ontology) -> bool:
         """

--- a/encord/client.py
+++ b/encord/client.py
@@ -88,7 +88,7 @@ from encord.orm.dataset import (
     SingleImage,
     Video,
 )
-from encord.orm.label_log import LabelLog
+from encord.orm.label_log import LabelLog, LabelLogParameters
 from encord.orm.label_row import (
     AnnotationTaskStatus,
     LabelRow,
@@ -1240,6 +1240,8 @@ class EncordClientProject(EncordClient):
         data_hash: Optional[str] = None,
         from_unix_seconds: Optional[int] = None,
         to_unix_seconds: Optional[int] = None,
+        after: Optional[datetime] = None,
+        before: Optional[datetime] = None,
     ) -> List[LabelLog]:
         """
         This function is documented in :meth:`encord.project.Project.get_label_logs`.
@@ -1251,6 +1253,13 @@ class EncordClientProject(EncordClient):
         function_arguments = locals()
 
         query_payload = {k: v for (k, v) in function_arguments.items() if k != "self" and v is not None}
+
+        payload = LabelLogParameters(
+            user_hash=user_hash,
+            data_hash=data_hash,
+            to_unix_seconds=to_unix_seconds,
+            from_unix_seconds=from_unix_seconds,
+        )
 
         return self._querier.get_multiple(LabelLog, payload=query_payload)
 

--- a/encord/client.py
+++ b/encord/client.py
@@ -88,7 +88,7 @@ from encord.orm.dataset import (
     SingleImage,
     Video,
 )
-from encord.orm.label_log import LabelLog, LabelLogParameters
+from encord.orm.label_log import LabelLog, LabelLogParams
 from encord.orm.label_row import (
     AnnotationTaskStatus,
     LabelRow,
@@ -1246,22 +1246,26 @@ class EncordClientProject(EncordClient):
         """
         This function is documented in :meth:`encord.project.Project.get_label_logs`.
         """
+        if after is not None:
+            if from_unix_seconds is not None:
+                raise ValueError("Only one of 'from_unix_seconds' and 'after' parameters should be specified")
 
-        # Flag for backwards compatibility
-        include_user_email_and_interface_key = True
+            from_unix_seconds = int(after.timestamp())
 
-        function_arguments = locals()
+        if before is not None:
+            if to_unix_seconds is not None:
+                raise ValueError("Only one of 'to_unix_seconds' and 'before' parameters should be specified")
 
-        query_payload = {k: v for (k, v) in function_arguments.items() if k != "self" and v is not None}
+            to_unix_seconds = int(before.timestamp())
 
-        payload = LabelLogParameters(
+        payload = LabelLogParams(
             user_hash=user_hash,
             data_hash=data_hash,
             to_unix_seconds=to_unix_seconds,
             from_unix_seconds=from_unix_seconds,
         )
 
-        return self._querier.get_multiple(LabelLog, payload=query_payload)
+        return self._querier.get_multiple(LabelLog, payload=payload)
 
     def __set_project_ontology(self, ontology: Ontology) -> bool:
         """

--- a/encord/common/utils.py
+++ b/encord/common/utils.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import re
+
+
+def snake_to_camel(snake_case_str: str) -> str:
+    camel = re.sub("([0-9A-Za-z])_(?=[0-9A-Z])", lambda m: m.group(1), snake_case_str.title())
+    return re.sub("(^_*[A-Z])", lambda m: m.group(1).lower(), camel)

--- a/encord/objects/utils.py
+++ b/encord/objects/utils.py
@@ -19,11 +19,6 @@ def _lower_snake_case(s: str):
     return s.lower().replace(" ", "_")
 
 
-def _snake_to_camel(snake_case_str: str) -> str:
-    camel = re.sub("([0-9A-Za-z])_(?=[0-9A-Z])", lambda m: m.group(1), snake_case_str.title())
-    return re.sub("(^_*[A-Z])", lambda m: m.group(1).lower(), camel)
-
-
 def check_type(obj: Any, type_: Optional[Type[Any]]) -> None:
     if not does_type_match(obj, type_):
         raise TypeError(f"Expected {type_}, got {type(obj)}")

--- a/encord/orm/analytics.py
+++ b/encord/orm/analytics.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum, auto
 from typing import Optional
 
-from encord.objects.utils import _snake_to_camel
+from encord.common.utils import snake_to_camel
 from encord.orm.base_dto import BaseDTO
 from encord.utilities.project_user import ProjectUserRole
 
@@ -10,7 +10,7 @@ from encord.utilities.project_user import ProjectUserRole
 class CamelStrEnum(str, Enum):
     # noinspection PyMethodParameters
     def _generate_next_value_(name, start, count, last_values) -> str:  # type: ignore
-        return _snake_to_camel(name)
+        return snake_to_camel(name)
 
 
 class CollaboratorTimersGroupBy(CamelStrEnum):

--- a/encord/orm/base_dto/base_dto_interface.py
+++ b/encord/orm/base_dto/base_dto_interface.py
@@ -11,5 +11,5 @@ class BaseDTOInterface(ABC):
         pass
 
     @abstractmethod
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self, by_alias=True, exclude_none=True) -> Dict[str, Any]:
         pass

--- a/encord/orm/base_dto/base_dto_pydantic_v1.py
+++ b/encord/orm/base_dto/base_dto_pydantic_v1.py
@@ -3,15 +3,15 @@ from typing import Any, Dict, Type, TypeVar
 from pydantic import BaseModel, ValidationError
 from pydantic.generics import GenericModel
 
+from encord.common.utils import snake_to_camel
 from encord.exceptions import EncordException
-from encord.objects.utils import _snake_to_camel
 from encord.orm.base_dto.base_dto_interface import BaseDTOInterface, T
 
 
 class BaseDTO(BaseDTOInterface, BaseModel):
     class Config:
         allow_extra = True
-        alias_generator = _snake_to_camel
+        alias_generator = snake_to_camel
         allow_population_by_field_name = True
 
     @classmethod
@@ -31,7 +31,7 @@ DataT = TypeVar("DataT")
 class GenericBaseDTO(BaseDTOInterface, GenericModel):
     class Config:
         allow_extra = True
-        alias_generator = _snake_to_camel
+        alias_generator = snake_to_camel
         allow_population_by_field_name = True
 
     @classmethod

--- a/encord/orm/base_dto/base_dto_pydantic_v1.py
+++ b/encord/orm/base_dto/base_dto_pydantic_v1.py
@@ -21,8 +21,8 @@ class BaseDTO(BaseDTOInterface, BaseModel):
         except ValidationError as e:
             raise EncordException(message=str(e)) from e
 
-    def to_dict(self) -> Dict[str, Any]:
-        return self.dict(by_alias=True)  # type: ignore[attr-defined]
+    def to_dict(self, by_alias=True, exclude_none=True) -> Dict[str, Any]:
+        return self.dict(by_alias=by_alias, exclude_none=exclude_none)  # type: ignore[attr-defined]
 
 
 DataT = TypeVar("DataT")
@@ -41,5 +41,5 @@ class GenericBaseDTO(BaseDTOInterface, GenericModel):
         except ValidationError as e:
             raise EncordException(message=str(e)) from e
 
-    def to_dict(self) -> Dict[str, Any]:
-        return self.dict(by_alias=True)  # type: ignore[attr-defined]
+    def to_dict(self, by_alias=True, exclude_none=True) -> Dict[str, Any]:
+        return self.dict(by_alias=by_alias, exclude_none=exclude_none)  # type: ignore[attr-defined]

--- a/encord/orm/base_dto/base_dto_pydantic_v2.py
+++ b/encord/orm/base_dto/base_dto_pydantic_v2.py
@@ -4,13 +4,13 @@ from typing import Any, Dict, Type, TypeVar
 from pydantic import ConfigDict  # type: ignore[attr-defined]
 from pydantic import BaseModel, ValidationError
 
+from encord.common.utils import snake_to_camel
 from encord.exceptions import EncordException
-from encord.objects.utils import _snake_to_camel
 from encord.orm.base_dto.base_dto_interface import BaseDTOInterface, T
 
 
 class BaseDTO(BaseDTOInterface, BaseModel):
-    model_config = ConfigDict(extra="allow", populate_by_name=True, alias_generator=_snake_to_camel)
+    model_config = ConfigDict(extra="allow", populate_by_name=True, alias_generator=snake_to_camel)
 
     @classmethod
     def from_dict(cls: Type[T], d: Dict[str, Any]) -> T:
@@ -27,7 +27,7 @@ DataT = TypeVar("DataT")
 
 
 class GenericBaseDTO(BaseDTOInterface, BaseModel):
-    model_config = ConfigDict(extra="allow", populate_by_name=True, alias_generator=_snake_to_camel)
+    model_config = ConfigDict(extra="allow", populate_by_name=True, alias_generator=snake_to_camel)
 
     @classmethod
     def from_dict(cls: Type[T], d: Dict[str, Any]) -> T:

--- a/encord/orm/base_dto/base_dto_pydantic_v2.py
+++ b/encord/orm/base_dto/base_dto_pydantic_v2.py
@@ -19,8 +19,8 @@ class BaseDTO(BaseDTOInterface, BaseModel):
         except ValidationError as e:
             raise EncordException(message=str(e)) from e
 
-    def to_dict(self) -> Dict[str, Any]:
-        return self.model_dump(by_alias=True)  # type: ignore[attr-defined]
+    def to_dict(self, by_alias=True, exclude_none=True) -> Dict[str, Any]:
+        return self.model_dump(by_alias=by_alias, exclude_none=exclude_none)  # type: ignore[attr-defined]
 
 
 DataT = TypeVar("DataT")
@@ -36,5 +36,5 @@ class GenericBaseDTO(BaseDTOInterface, BaseModel):
         except ValidationError as e:
             raise EncordException(message=str(e)) from e
 
-    def to_dict(self) -> Dict[str, Any]:
-        return self.model_dump(by_alias=True)  # type: ignore[attr-defined]
+    def to_dict(self, by_alias=True, exclude_none=True) -> Dict[str, Any]:
+        return self.model_dump(by_alias=by_alias, exclude_none=exclude_none)  # type: ignore[attr-defined]

--- a/encord/orm/label_log.py
+++ b/encord/orm/label_log.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import IntEnum
 
+from encord.orm.base_dto import BaseDTO
+
 
 @dataclass(frozen=True)
 class LabelLog:
@@ -54,3 +56,10 @@ class Action(IntEnum):
     BUFFERING_OVERLAY_SHOWN = 30
     BITRATE_WARNING_SHOWN = 31
     SEEKING_OVERLAY_SHOWN = 32
+
+
+class LabelLogParameters(BaseDTO):
+    user_hash: str
+    data_hash: str
+    to_unix_seconds: int
+    from_unix_seconds: int

--- a/encord/orm/label_log.py
+++ b/encord/orm/label_log.py
@@ -58,8 +58,10 @@ class Action(IntEnum):
     SEEKING_OVERLAY_SHOWN = 32
 
 
-class LabelLogParameters(BaseDTO):
+class LabelLogParams(BaseDTO):
     user_hash: str
     data_hash: str
     to_unix_seconds: int
     from_unix_seconds: int
+    # Flag for backwards compatibility
+    include_user_email_and_interface_key: bool = True

--- a/encord/orm/label_log.py
+++ b/encord/orm/label_log.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from enum import IntEnum
+from typing import Optional
 
 from encord.orm.base_dto import BaseDTO
 
@@ -59,9 +60,9 @@ class Action(IntEnum):
 
 
 class LabelLogParams(BaseDTO):
-    user_hash: str
-    data_hash: str
-    to_unix_seconds: int
-    from_unix_seconds: int
+    user_hash: Optional[str]
+    data_hash: Optional[str]
+    to_unix_seconds: Optional[int]
+    from_unix_seconds: Optional[int]
     # Flag for backwards compatibility
     include_user_email_and_interface_key: bool = True

--- a/encord/project.py
+++ b/encord/project.py
@@ -716,7 +716,7 @@ class Project:
             from_unix_seconds: Filter the label logs to only include labels after this timestamp. **Deprecated**: use parameter **after** instead
             to_unix_seconds: Filter the label logs to only include labels before this timestamp. **Deprecated**: use parameter **before** instead
             after: Filter the label logs to only include labels after the specified time.
-            before: Filter the label logs to only include labels after the specified time.
+            before: Filter the label logs to only include labels before the specified time.
         """
         return self._client.get_label_logs(user_hash, data_hash, from_unix_seconds, to_unix_seconds, after, before)
 

--- a/encord/project.py
+++ b/encord/project.py
@@ -702,6 +702,8 @@ class Project:
         data_hash: Optional[str] = None,
         from_unix_seconds: Optional[int] = None,
         to_unix_seconds: Optional[int] = None,
+        after: Optional[datetime.datetime] = None,
+        before: Optional[datetime.datetime] = None,
     ) -> List[LabelLog]:
         """
         Get label logs, which represent the actions taken in the UI to create labels.
@@ -711,10 +713,12 @@ class Project:
         Args:
             user_hash: Filter the label logs by the user.
             data_hash: Filter the label logs by the data_hash.
-            from_unix_seconds: Filter the label logs to only include labels after this timestamp.
-            from_unix_seconds: Filter the label logs to only include labels before this timestamp.
+            from_unix_seconds: Filter the label logs to only include labels after this timestamp. **Deprecated**: use parameter **after** instead
+            to_unix_seconds: Filter the label logs to only include labels before this timestamp. **Deprecated**: use parameter **before** instead
+            after: Filter the label logs to only include labels after the specified time.
+            before: Filter the label logs to only include labels after the specified time.
         """
-        return self._client.get_label_logs(user_hash, data_hash, from_unix_seconds, to_unix_seconds)
+        return self._client.get_label_logs(user_hash, data_hash, from_unix_seconds, to_unix_seconds, after, before)
 
     def get_cloud_integrations(self) -> List[CloudIntegration]:
         return self._client.get_cloud_integrations()

--- a/tests/test_label_logs.py
+++ b/tests/test_label_logs.py
@@ -1,8 +1,8 @@
 import pytest
 
-from tests.fixtures import ontology, user_client
+from tests.fixtures import ontology, project, user_client
 
-assert user_client and ontology  # Need to import all fixtures
+assert project and user_client and ontology  # Need to import all fixtures
 
 import json
 from datetime import datetime

--- a/tests/test_label_logs.py
+++ b/tests/test_label_logs.py
@@ -1,0 +1,83 @@
+import pytest
+
+from tests.fixtures import ontology, user_client
+
+assert user_client and ontology  # Need to import all fixtures
+
+import json
+from datetime import datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from deepdiff import DeepDiff
+
+from encord.http.querier import Querier, RequestContext
+from encord.project import Project
+
+
+def get_mocked_answer(payload: Any) -> MagicMock:
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"status": 200, "response": payload}
+    return mock_response
+
+
+@patch.object(Querier, "_execute")
+def test_get_label_logs_filter_by_datetime(querier_mock: MagicMock, project: Project):
+    after_time = datetime.fromisoformat("2023-01-01T21:00:00")
+    before_time = datetime.fromisoformat("2023-01-02T21:00:00")
+    querier_mock.return_value = ([], RequestContext())
+
+    _ = project.get_label_logs(after=after_time, before=before_time)
+
+    querier_mock.assert_called_once()
+
+    request = querier_mock.call_args[0][0]
+    request_data = json.loads(request.data)
+
+    assert request_data["query_type"] == "labellog"
+    assert not DeepDiff(
+        request_data["values"]["payload"],
+        {
+            "from_unix_seconds": int(after_time.timestamp()),
+            "to_unix_seconds": int(before_time.timestamp()),
+            "include_user_email_and_interface_key": True,
+        },
+        ignore_order=True,
+    )
+
+
+@patch.object(Querier, "_execute")
+def test_get_label_logs_filter_by_unix_timestamp(querier_mock: MagicMock, project: Project):
+    after_timestamp = 22
+    before_timestamp = 33
+    querier_mock.return_value = ([], RequestContext())
+
+    _ = project.get_label_logs(from_unix_seconds=after_timestamp, to_unix_seconds=before_timestamp)
+
+    querier_mock.assert_called_once()
+
+    request = querier_mock.call_args[0][0]
+    request_data = json.loads(request.data)
+
+    assert request_data["query_type"] == "labellog"
+    assert not DeepDiff(
+        request_data["values"]["payload"],
+        {
+            "from_unix_seconds": after_timestamp,
+            "to_unix_seconds": before_timestamp,
+            "include_user_email_and_interface_key": True,
+        },
+        ignore_order=True,
+    )
+
+
+@patch.object(Querier, "_execute")
+def test_get_label_logs_raises_when_both_time_filter_specified(querier_mock: MagicMock, project: Project):
+    with pytest.raises(ValueError):
+        _ = project.get_label_logs(from_unix_seconds=22, after=datetime.now())
+
+    with pytest.raises(ValueError):
+        _ = project.get_label_logs(to_unix_seconds=22, before=datetime.now())
+
+    querier_mock.assert_not_called()


### PR DESCRIPTION
Project.get_label_logs only allows filtering by unix timestamp, which is not very convenient and also totally different from all other time filters we have in the API.
To fix that adding the datetime filter parameters and deprecating old timestamp ones.