### PR TITLE
Add user_email filter to label logs

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -1242,6 +1242,7 @@ class EncordClientProject(EncordClient):
         to_unix_seconds: Optional[int] = None,
         after: Optional[datetime] = None,
         before: Optional[datetime] = None,
+        user_email: Optional[str] = None,
     ) -> List[LabelLog]:
         """
         This function is documented in :meth:`encord.project.Project.get_label_logs`.
@@ -1260,6 +1261,7 @@ class EncordClientProject(EncordClient):
 
         payload = LabelLogParams(
             user_hash=user_hash,
+            user_email=user_email,
             data_hash=data_hash,
             to_unix_seconds=to_unix_seconds,
             from_unix_seconds=from_unix_seconds,

--- a/encord/orm/label_log.py
+++ b/encord/orm/label_log.py
@@ -64,5 +64,6 @@ class LabelLogParams(BaseDTO):
     data_hash: Optional[str]
     to_unix_seconds: Optional[int]
     from_unix_seconds: Optional[int]
+    user_email: Optional[str]
     # Flag for backwards compatibility
     include_user_email_and_interface_key: bool = True

--- a/encord/project.py
+++ b/encord/project.py
@@ -703,6 +703,7 @@ class Project:
         to_unix_seconds: Optional[int] = None,
         after: Optional[datetime.datetime] = None,
         before: Optional[datetime.datetime] = None,
+        user_email: Optional[str] = None,
     ) -> List[LabelLog]:
         """
         Get label logs, which represent the actions taken in the UI to create labels.
@@ -716,8 +717,11 @@ class Project:
             to_unix_seconds: Filter the label logs to only include labels before this timestamp. **Deprecated**: use parameter **before** instead
             after: Filter the label logs to only include labels after the specified time.
             before: Filter the label logs to only include labels before the specified time.
+            user_email: Filter by the annotator email.
         """
-        return self._client.get_label_logs(user_hash, data_hash, from_unix_seconds, to_unix_seconds, after, before)
+        return self._client.get_label_logs(
+            user_hash, data_hash, from_unix_seconds, to_unix_seconds, after, before, user_email
+        )
 
     def get_cloud_integrations(self) -> List[CloudIntegration]:
         return self._client.get_cloud_integrations()


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

## Release Notes

### New Feature
- Added an optional `user_email` parameter to the `get_label_logs` function in `client.py` and `project.py`. This feature allows users to filter label logs based on a specific email address.
- Extended the `LabelLogParams` class in `orm/label_log.py` with a new optional parameter `user_email` for more refined data querying.

> 🎉 Here's to the code that now stands tall,  
> Filtering logs at a user's call.  
> With an email, find your trace,  
> In the vast digital space. 🚀🌟
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->