### PR TITLE
Remove lazy init from Project and Dataset

### DIFF
--- a/encord/dataset.py
+++ b/encord/dataset.py
@@ -24,32 +24,28 @@ class Dataset:
     Access dataset related data and manipulate the dataset.
     """
 
-    def __init__(self, client: EncordClientDataset):
+    def __init__(self, client: EncordClientDataset, orm_dataset: OrmDataset):
         self._client = client
-        self._dataset_instance: Optional[OrmDataset] = None
+        self._dataset_instance = orm_dataset
 
     @property
     def dataset_hash(self) -> str:
         """
         Get the dataset hash (i.e. the Dataset ID).
         """
-        dataset_instance = self._get_dataset_instance()
-        return dataset_instance.dataset_hash
+        return self._dataset_instance.dataset_hash
 
     @property
     def title(self) -> str:
-        dataset_instance = self._get_dataset_instance()
-        return dataset_instance.title
+        return self._dataset_instance.title
 
     @property
     def description(self) -> str:
-        dataset_instance = self._get_dataset_instance()
-        return dataset_instance.description
+        return self._dataset_instance.description
 
     @property
     def storage_location(self) -> StorageLocation:
-        dataset_instance = self._get_dataset_instance()
-        return dataset_instance.storage_location
+        return self._dataset_instance.storage_location
 
     @property
     def data_rows(self) -> List[DataRow]:
@@ -62,8 +58,7 @@ class Dataset:
             dataset.set_access_settings(DatasetAccessSettings(fetch_client_metadata=True))
             print(dataset.data_rows)
         """
-        dataset_instance = self._get_dataset_instance()
-        return dataset_instance.data_rows
+        return self._dataset_instance.data_rows
 
     def list_data_rows(
         self,
@@ -99,7 +94,7 @@ class Dataset:
         The Dataset class will only fetch its properties once. Use this function if you suspect the state of those
         properties to be dirty.
         """
-        self._dataset_instance = self.get_dataset()
+        self._dataset_instance = self._client.get_dataset()
 
     def get_dataset(self) -> OrmDataset:
         """
@@ -399,8 +394,3 @@ class Dataset:
 
     def get_cloud_integrations(self) -> List[CloudIntegration]:
         return self._client.get_cloud_integrations()
-
-    def _get_dataset_instance(self):
-        if self._dataset_instance is None:
-            self._dataset_instance = self.get_dataset()
-        return self._dataset_instance

--- a/encord/ontology.py
+++ b/encord/ontology.py
@@ -1,5 +1,4 @@
 import datetime
-from typing import Optional
 
 from encord.configs import SshConfig
 from encord.http.querier import Querier
@@ -13,68 +12,60 @@ class Ontology:
     :meth:`encord.user_client.EncordUserClient.get_ontology()`
     """
 
-    def __init__(self, querier: Querier, config: SshConfig, instance: Optional[OrmOntology] = None):
+    def __init__(self, querier: Querier, config: SshConfig, instance: OrmOntology):
         self._querier = querier
         self._config = config
-        self._ontology_instance: Optional[OrmOntology] = instance
+        self._ontology_instance = instance
 
     @property
     def ontology_hash(self) -> str:
         """
         Get the ontology hash (i.e. the Ontology ID).
         """
-        ontology_instance = self._get_ontology_instance()
-        return ontology_instance.ontology_hash
+        return self._ontology_instance.ontology_hash
 
     @property
     def title(self) -> str:
         """
         Get the title of the ontology.
         """
-        ontology_instance = self._get_ontology_instance()
-        return ontology_instance.title
+        return self._ontology_instance.title
 
     @title.setter
     def title(self, value: str) -> None:
-        ontology_instance = self._get_ontology_instance()
-        ontology_instance.title = value
+        self._ontology_instance.title = value
 
     @property
     def description(self) -> str:
         """
         Get the description of the ontology.
         """
-        ontology_instance = self._get_ontology_instance()
-        return ontology_instance.description
+        return self._ontology_instance.description
 
     @description.setter
     def description(self, value: str) -> None:
-        ontology_instance = self._get_ontology_instance()
-        ontology_instance.description = value
+        self._ontology_instance.description = value
 
     @property
     def created_at(self) -> datetime.datetime:
         """
         Get the time the ontology was created at.
         """
-        ontology_instance = self._get_ontology_instance()
-        return ontology_instance.created_at
+        return self._ontology_instance.created_at
 
     @property
     def last_edited_at(self) -> datetime.datetime:
         """
         Get the time the ontology was last edited at.
         """
-        ontology_instance = self._get_ontology_instance()
-        return ontology_instance.last_edited_at
+        return self._ontology_instance.last_edited_at
 
     @property
     def structure(self) -> OntologyStructure:
         """
         Get the structure of the ontology.
         """
-        ontology_instance = self._get_ontology_instance()
-        return ontology_instance.structure
+        return self._ontology_instance.structure
 
     def refetch_data(self) -> None:
         """
@@ -95,8 +86,3 @@ class Ontology:
 
     def _get_ontology(self):
         return self._querier.basic_getter(OrmOntology, self._config.resource_id)
-
-    def _get_ontology_instance(self):
-        if self._ontology_instance is None:
-            self._ontology_instance = self._get_ontology()
-        return self._ontology_instance

--- a/encord/orm/ontology.py
+++ b/encord/orm/ontology.py
@@ -13,6 +13,7 @@
 # under the License.
 from __future__ import annotations
 
+from datetime import datetime
 from enum import IntEnum
 from typing import Dict, Optional
 
@@ -33,6 +34,8 @@ class Ontology(dict, Formatter):
         title: str,
         structure: OntologyStructure,
         ontology_hash: str,
+        created_at: datetime,
+        last_edited_at: datetime,
         description: Optional[str] = None,
     ):
         """
@@ -52,6 +55,8 @@ class Ontology(dict, Formatter):
                 "title": title,
                 "description": description,
                 "structure": structure,
+                "created_at": created_at,
+                "last_edited_at": last_edited_at,
             }
         )
 
@@ -83,6 +88,14 @@ class Ontology(dict, Formatter):
     def structure(self, value: OntologyStructure) -> None:
         self["structure"] = value
 
+    @property
+    def created_at(self) -> datetime:
+        return self["created_at"]
+
+    @property
+    def last_edited_at(self) -> datetime:
+        return self["last_edited_at"]
+
     @classmethod
     def from_dict(cls, json_dict: Dict) -> Ontology:
         return Ontology(
@@ -90,4 +103,6 @@ class Ontology(dict, Formatter):
             description=json_dict["description"],
             ontology_hash=json_dict["ontology_hash"],
             structure=OntologyStructure.from_dict(json_dict["editor"]),
+            created_at=json_dict["created_at"],
+            last_edited_at=json_dict["last_edited_at"],
         )

--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -105,15 +105,15 @@ class Project(base_orm.BaseORM):
         return [label.get("label_hash") for label in labels]
 
     @property
-    def project_hash(self):
+    def project_hash(self) -> str:
         return self["project_hash"]
 
     @property
-    def title(self):
+    def title(self) -> str:
         return self["title"]
 
     @property
-    def description(self):
+    def description(self) -> str:
         return self["description"]
 
     @property
@@ -129,12 +129,20 @@ class Project(base_orm.BaseORM):
         return self["label_rows"]
 
     @property
-    def ontology_hash(self):
+    def ontology_hash(self) -> str:
         return self["ontology_hash"]
 
     @property
     def source_projects(self):
         return self["source_projects"]
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        return self["created_at"]
+
+    @property
+    def last_edited_at(self) -> datetime.datetime:
+        return self["last_edited_at"]
 
 
 class ProjectCopy:

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -126,14 +126,17 @@ class EncordUserClient:
         # not full access, that is implied by get_ontology method
         ontology_hash = orm_project["ontology_hash"]
         config = SshConfig(self.user_config, resource_type=TYPE_ONTOLOGY, resource_id=ontology_hash)
-        project_ontology = Ontology(querier, config)
+
+        orm_ontology = querier.basic_getter(OrmOntology, config.resource_id)
+        project_ontology = Ontology(querier, config, orm_ontology)
 
         return Project(client, orm_project, project_ontology, client_v2=self._api_client)
 
     def get_ontology(self, ontology_hash: str) -> Ontology:
         config = SshConfig(self.user_config, resource_type=TYPE_ONTOLOGY, resource_id=ontology_hash)
         querier = Querier(config)
-        return Ontology(querier, config)
+        orm_ontology = querier.basic_getter(OrmOntology, ontology_hash)
+        return Ontology(querier, config, orm_ontology)
 
     def create_private_dataset(
         self,

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -97,7 +97,8 @@ class EncordUserClient:
         config = SshConfig(self.user_config, resource_type=TYPE_DATASET, resource_id=dataset_hash)
         querier = Querier(config)
         client = EncordClientDataset(querier=querier, config=config, dataset_access_settings=dataset_access_settings)
-        return Dataset(client)
+        orm_dataset = client.get_dataset()
+        return Dataset(client, orm_dataset)
 
     def get_project(self, project_hash: str) -> Project:
         """

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -6,6 +6,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from encord import EncordUserClient
 from encord.client import EncordClientProject
+from encord.http.querier import Querier
 from encord.ontology import Ontology
 from encord.orm.ontology import Ontology as OrmOntology
 from encord.orm.project import Project as OrmProject
@@ -36,10 +37,13 @@ def user_client():
 
 @pytest.fixture
 @patch.object(EncordClientProject, "get_project")
-def project(client_project_mock, user_client: EncordUserClient, ontology: Ontology):
+@patch.object(Querier, "basic_getter")
+def project(querier_mock: Querier, client_project_mock, user_client: EncordUserClient, ontology: Ontology):
+    querier_mock.return_value = OrmOntology.from_dict(ONTOLOGY_BLURB)
+
     client_project_mock.return_value = OrmProject(
         {"ontology_hash": "dummy-ontology-hash", "project_hash": "dummy-project-hash"}
     )
+
     project = user_client.get_project("dummy-project-hash")
-    project._ontology = ontology
     return project

--- a/tests/test_bundled_label_operations.py
+++ b/tests/test_bundled_label_operations.py
@@ -2,22 +2,20 @@ from copy import deepcopy
 from typing import Dict
 from unittest.mock import MagicMock, patch
 
-import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
-from encord import EncordUserClient, Project
+from encord import Project
 from encord.client import EncordClientProject
 from encord.objects import LabelRowV2
-from encord.ontology import Ontology
 from encord.orm.label_row import LabelRow, LabelRowMetadata
-from encord.orm.ontology import Ontology as OrmOntology
-from encord.orm.project import Project as OrmProject
+from tests.fixtures import ontology, project, user_client
 from tests.test_data.label_rows_metadata_blurb import (
     LABEL_ROW_BLURB,
     LABEL_ROW_METADATA_BLURB,
 )
-from tests.test_data.ontology_blurb import ONTOLOGY_BLURB
+
+assert user_client and project and ontology
 
 DUMMY_PRIVATE_KEY = (
     Ed25519PrivateKey.generate()
@@ -28,29 +26,6 @@ DUMMY_PRIVATE_KEY = (
     )
     .decode("utf-8")
 )
-
-
-@pytest.fixture
-def client():
-    client = EncordUserClient.create_with_ssh_private_key(DUMMY_PRIVATE_KEY)
-    return client
-
-
-@pytest.fixture
-def ontology():
-    ontology = Ontology(None, None, OrmOntology.from_dict(ONTOLOGY_BLURB))
-    return ontology
-
-
-@pytest.fixture
-@patch.object(EncordClientProject, "get_project")
-def project(client_project_mock, client: EncordUserClient, ontology: Ontology):
-    client_project_mock.return_value = OrmProject(
-        {"ontology_hash": "dummy-ontology-hash", "project_hash": "dummy-project-hash"}
-    )
-    project = client.get_project("dummy-project-hash")
-    project._ontology = ontology
-    return project
 
 
 def remove_label_hash(obj: Dict) -> Dict:

--- a/tests/test_data/ontology_blurb.py
+++ b/tests/test_data/ontology_blurb.py
@@ -2,6 +2,8 @@ ONTOLOGY_BLURB = {
     "ontology_hash": "bab95d1e-3070-48fb-9d40-ad168b55310e",
     "title": "Test ontology",
     "description": "",
+    "created_at": "Thu, 18 Feb 2021 22:24:59 GMT",
+    "last_edited_at": "Thu, 18 Feb 2021 22:24:59 GMT",
     "editor": {
         "objects": [
             {

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -7,14 +6,15 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from requests import Session
 
 from encord.client import EncordClientProject
-from encord.configs import _ENCORD_SSH_KEY_FILE
 from encord.constants.model import Device
 from encord.constants.model_weights import faster_rcnn_R_101_C4_3x
 from encord.exceptions import EncordException
 from encord.orm.label_row import LabelRow
 from encord.orm.project import Project as OrmProject
 from encord.project import Project
-from encord.user_client import EncordUserClient
+from tests.fixtures import ontology, project, user_client
+
+assert user_client and project and ontology
 
 PRIVATE_KEY = (
     Ed25519PrivateKey.generate()
@@ -26,27 +26,6 @@ PRIVATE_KEY = (
     .decode("utf-8")
 )
 UID = "d958ddbb-fcd0-477a-adf9-de14431dbbd2"
-
-
-@pytest.fixture
-def ssh_key_file_path():
-    return os.path.join(os.path.dirname(__file__), "resources/test_key")
-
-
-def teardown_function():
-    if _ENCORD_SSH_KEY_FILE in os.environ:
-        del os.environ[_ENCORD_SSH_KEY_FILE]
-
-
-@pytest.fixture
-@patch.object(EncordClientProject, "get_project")
-def project(project_client_mock: MagicMock, ssh_key_file_path):
-    project_client_mock.get_project.return_value = MagicMock()
-
-    os.environ[_ENCORD_SSH_KEY_FILE] = ssh_key_file_path
-    user_client = EncordUserClient.create_with_ssh_private_key()
-    assert isinstance(user_client, EncordUserClient)
-    return user_client.get_project("test_project")
 
 
 @pytest.mark.parametrize("weights", [None, "invalid-weight"])

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from cryptography.hazmat.primitives import serialization
@@ -120,12 +120,13 @@ def test_valid_device(mock_send, project: Project, device):
 
 @patch.object(EncordClientProject, "get_project")
 def test_label_rows_property_queries_metadata(project_client_mock: MagicMock, project: Project):
-    project._project_instance.label_rows = None
+    project_current_orm_mock = MagicMock(spec=OrmProject)
+    type(project_current_orm_mock).label_rows = PropertyMock(return_value=None)
+    project._project_instance = project_current_orm_mock
 
     project_orm_mock = MagicMock(spec=OrmProject)
-    project_orm_mock.label_rows = [LabelRow({"data_title": "abc"})]
-
     project_client_mock.return_value = project_orm_mock
+    type(project_orm_mock).label_rows = PropertyMock(return_value=[LabelRow({"data_title": "abc"})])
 
     project_client_mock.assert_not_called()
 
@@ -139,6 +140,6 @@ def test_label_rows_property_queries_metadata(project_client_mock: MagicMock, pr
     assert len(rows) == 1
     assert rows[0].data_title == "abc"
 
-    # Expect label rows metadata to be cached
-    project.label_rows
+    # Expect label rows metadata to be cached, so data query doesn't happen again
+    _ = project.label_rows
     project_client_mock.assert_called_once()

--- a/tests/test_workflow_actions.py
+++ b/tests/test_workflow_actions.py
@@ -1,19 +1,17 @@
 import json
 from unittest.mock import MagicMock, patch
 
-import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
-from encord import EncordUserClient, Project
+from encord import Project
 from encord.client import EncordClientProject
 from encord.http.querier import Querier, RequestContext
-from encord.ontology import Ontology
 from encord.orm.label_row import LabelRowMetadata
-from encord.orm.ontology import Ontology as OrmOntology
-from encord.orm.project import Project as OrmProject
+from tests.fixtures import ontology, project, user_client
 from tests.test_data.label_rows_metadata_blurb import LABEL_ROW_METADATA_BLURB
-from tests.test_data.ontology_blurb import ONTOLOGY_BLURB
+
+assert user_client and project and ontology
 
 DUMMY_PRIVATE_KEY = (
     Ed25519PrivateKey.generate()
@@ -24,29 +22,6 @@ DUMMY_PRIVATE_KEY = (
     )
     .decode("utf-8")
 )
-
-
-@pytest.fixture
-def client():
-    client = EncordUserClient.create_with_ssh_private_key(DUMMY_PRIVATE_KEY)
-    return client
-
-
-@pytest.fixture
-def ontology():
-    ontology = Ontology(None, None, OrmOntology.from_dict(ONTOLOGY_BLURB))
-    return ontology
-
-
-@pytest.fixture
-@patch.object(EncordClientProject, "get_project")
-def project(client_project_mock, client: EncordUserClient, ontology: Ontology):
-    client_project_mock.return_value = OrmProject(
-        {"ontology_hash": "dummy-ontology-hash", "project_hash": "dummy-project-hash"}
-    )
-    project = client.get_project("dummy-project-hash")
-    project._ontology = ontology
-    return project
 
 
 @patch.object(Querier, "_execute")


### PR DESCRIPTION
Remove lazy initialisation patter from the project class. Now it is guaranteed that project object is already in initialised state and property reads doesn't result in network calls. It makes error handling easier
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

### Refactor:
- Removed lazy initialization pattern from `Dataset`, `Ontology`, `Project` classes and their corresponding ORM classes.
- Updated constructors to require additional parameters for direct instance initialization.
- Enhanced error handling across the codebase by ensuring objects are always in an initialized state.
- Updated user client functions (`get_dataset`, `get_project`, `get_ontology`) to pass additional parameters when creating new instances.

### Test:
- Updated test cases for `Project` class and related tests to reflect changes in object initialization.
- Modified `test_label_rows_property_queries_metadata` to use `PropertyMock`.

### New Feature:
- Added `created_at` and `last_edited_at` properties to `Ontology` class.

> 🎉 No more waiting, no more baiting,
> Our code is now eagerly initializing! 🚀
> With new features and better testing,
> Our project's performance is arresting! 💪🎊
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->