### PR TITLE
Improve exception message for setting singular answer to checklist attribute

### DIFF
--- a/encord/objects/answers.py
+++ b/encord/objects/answers.py
@@ -297,9 +297,15 @@ class ChecklistAnswer(Answer[List[FlatOption], ChecklistAttribute]):
         ]
 
     def set(self, values: Iterable[FlatOption]):
+        if not isinstance(values, Iterable):
+            raise ValueError(
+                "Checklist attribute answer should be an iterable of FlatOption values. "
+                "For setting a single option, consider wrapping it in a list: [value]."
+            )
+
         for value in values:
             if not isinstance(value, FlatOption):
-                raise ValueError("ChecklistAnswer can only be set to FlatOptions.")
+                raise ValueError("Checklist attribute values can only be set to FlatOption.")
 
         self._answered = True
         for key in self._feature_hash_to_answer_map.keys():


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
**Enhancement:**
- Improved error handling in `ChecklistAnswer` class of `encord/objects/answers.py`. The `set` method now checks if the `values` argument is iterable, raising a `ValueError` with a more descriptive message if it's not. 
- Enhanced guidance for users when setting a singular answer to the checklist attribute, suggesting wrapping the value in a list.
- Better exception message for setting non-`FlatOption` values to the checklist attribute.

> 🎉 Here's to code that's robust and clear,  
> To better messages when an error is near.  
> With each pull request, we strive to enhance,  
> Making our codebase take a forward advance. 🚀
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->