### PR TITLE
Add deprecated annotation

### DIFF
--- a/encord/common/deprecated.py
+++ b/encord/common/deprecated.py
@@ -1,8 +1,6 @@
 import functools
 import warnings
 
-warnings.simplefilter("always", DeprecationWarning)
-
 
 def deprecated(version, alternative=None):
     def decorator(func):

--- a/encord/common/deprecated.py
+++ b/encord/common/deprecated.py
@@ -1,0 +1,21 @@
+import functools
+import warnings
+
+warnings.simplefilter("always", DeprecationWarning)
+
+
+def deprecated(version, alternative=None):
+    def decorator(func):
+        @functools.wraps(func)
+        def new_func(*args, **kwargs):
+            message = f"Function {func.__name__} is deprecated"
+            if version:
+                message += f" since version {version}"
+            if alternative:
+                message += f", use {alternative} instead"
+            warnings.warn(message, category=DeprecationWarning, stacklevel=2)
+            return func(*args, **kwargs)
+
+        return new_func
+
+    return decorator

--- a/encord/objects/answers.py
+++ b/encord/objects/answers.py
@@ -309,12 +309,12 @@ class ChecklistAnswer(Answer[List[FlatOption], ChecklistAttribute]):
             self._verify_flat_option(value)
             self._feature_hash_to_answer_map[value.feature_node_hash] = True
 
-    @deprecated("0.1.80", alternative=".set(options)")
+    @deprecated("0.1.91", alternative=".set(options)")
     def set_options(self, values: Iterable[FlatOption]):
         # Deprecated: please use :meth:`set` instead
         return self.set(values)
 
-    @deprecated("0.1.80", alternative=".get()")
+    @deprecated("0.1.91", alternative=".get()")
     def get_options(self) -> List[FlatOption]:
         # Deprecated: please use :meth:`get()` instead
 
@@ -327,7 +327,7 @@ class ChecklistAnswer(Answer[List[FlatOption], ChecklistAttribute]):
                 if self._feature_hash_to_answer_map[option.feature_node_hash]
             ]
 
-    @deprecated("0.1.80", alternative=".get_option_value(option)")
+    @deprecated("0.1.91", alternative=".get_option_value(option)")
     def get_value(self, value: FlatOption) -> bool:
         # Deprecated: please use :meth:`get_option_value` instead
         return self.get_option_value(value)

--- a/encord/objects/answers.py
+++ b/encord/objects/answers.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, Generic, Iterable, List, NoReturn, Optional, Set, TypeVar
 
+from encord.common.deprecated import deprecated
 from encord.objects.attributes import (
     Attribute,
     ChecklistAttribute,
@@ -308,10 +309,12 @@ class ChecklistAnswer(Answer[List[FlatOption], ChecklistAttribute]):
             self._verify_flat_option(value)
             self._feature_hash_to_answer_map[value.feature_node_hash] = True
 
+    @deprecated("0.1.80", alternative=".set(options)")
     def set_options(self, values: Iterable[FlatOption]):
         # Deprecated: please use :meth:`set` instead
         return self.set(values)
 
+    @deprecated("0.1.80", alternative=".get()")
     def get_options(self) -> List[FlatOption]:
         # Deprecated: please use :meth:`get()` instead
 
@@ -324,6 +327,7 @@ class ChecklistAnswer(Answer[List[FlatOption], ChecklistAttribute]):
                 if self._feature_hash_to_answer_map[option.feature_node_hash]
             ]
 
+    @deprecated("0.1.80", alternative=".get_option_value(option)")
     def get_value(self, value: FlatOption) -> bool:
         # Deprecated: please use :meth:`get_option_value` instead
         return self.get_option_value(value)

--- a/encord/objects/answers.py
+++ b/encord/objects/answers.py
@@ -367,7 +367,7 @@ class ChecklistAnswer(Answer[List[FlatOption], ChecklistAttribute]):
 
     def _to_encord_dict_impl(self, is_dynamic: bool = False) -> Dict[str, Any]:
         ontology_attribute: ChecklistAttribute = self._ontology_attribute
-        checked_options = [option for option in ontology_attribute.options if self.get_value(option)]
+        checked_options = [option for option in ontology_attribute.options if self.get_option_value(option)]
         answers = [
             {
                 "name": option.label,

--- a/encord/project.py
+++ b/encord/project.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Iterable, List, Optional, Set, Tuple, Union
 
 from encord.client import EncordClientProject
+from encord.common.deprecated import deprecated
 from encord.constants.model import AutomationModels, Device
 from encord.http.bundle import Bundle
 from encord.http.v2.api_client import ApiClient
@@ -130,6 +131,7 @@ class Project:
         return project_instance.datasets
 
     @property
+    @deprecated("0.1.69", "list_label_row_v2()")
     def label_rows(self) -> dict:
         """
         Get the label rows.

--- a/encord/project.py
+++ b/encord/project.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Iterable, List, Optional, Set, Tuple, Union
 
 from encord.client import EncordClientProject
-from encord.common.deprecated import deprecated
 from encord.constants.model import AutomationModels, Device
 from encord.http.bundle import Bundle
 from encord.http.v2.api_client import ApiClient
@@ -131,7 +130,6 @@ class Project:
         return project_instance.datasets
 
     @property
-    @deprecated("0.1.69", "list_label_row_v2()")
     def label_rows(self) -> dict:
         """
         Get the label rows.


### PR DESCRIPTION
Adds @deprecated(version, alternative) annotation to make deprecated method more noticeable
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

**Refactor:**
- Introduced a `@deprecated` decorator in `encord/common/deprecated.py` to mark deprecated methods and provide warnings.
- Marked `set_options`, `get_options`, and `get_value` methods as deprecated in `encord/objects/answers.py` with suggestions for alternative methods.

> 🎉 Here's to the code that evolves,  
> To the old we bid adieu,  
> With `@deprecated` we resolve,  
> To make way for the new! 🚀
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->