### PR TITLE
Enable retries

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -749,7 +749,7 @@ class EncordClientProject(EncordClient):
             "workflow_graph_node_title_eq": workflow_graph_node_title_eq,
             "workflow_graph_node_title_like": workflow_graph_node_title_like,
         }
-        return self._querier.get_multiple(LabelRowMetadata, payload=payload)
+        return self._querier.get_multiple(LabelRowMetadata, payload=payload, retryable=True)
 
     def set_label_status(self, label_hash: str, label_status: LabelStatus) -> bool:
         """
@@ -833,7 +833,7 @@ class EncordClientProject(EncordClient):
             "include_reviews": include_reviews,
         }
 
-        return self._querier.basic_getter(LabelRow, uid, payload=payload)
+        return self._querier.basic_getter(LabelRow, uid, payload=payload, retryable=True)
 
     def get_label_rows(
         self,
@@ -855,14 +855,14 @@ class EncordClientProject(EncordClient):
             "include_reviews": include_reviews,
         }
 
-        return self._querier.get_multiple(LabelRow, uids, payload=payload)
+        return self._querier.get_multiple(LabelRow, uids, payload=payload, retryable=True)
 
     def save_label_row(self, uid, label):
         """
         This function is documented in :meth:`encord.project.Project.save_label_row`.
         """
         label = LabelRow(label)
-        return self._querier.basic_setter(LabelRow, uid, payload=label)
+        return self._querier.basic_setter(LabelRow, uid, payload=label, retryable=True)
 
     def save_label_rows(self, uids: List[str], payload=List[LabelRow]):
         """
@@ -881,7 +881,7 @@ class EncordClientProject(EncordClient):
             "multi_request": True,
             "labels": payload,
         }
-        return self._querier.basic_setter(LabelRow, uid=uids, payload=payload)
+        return self._querier.basic_setter(LabelRow, uid=uids, payload=payload, retryable=True)
 
     def create_label_row(self, uid):
         """

--- a/encord/client.py
+++ b/encord/client.py
@@ -709,7 +709,9 @@ class EncordClientProject(EncordClient):
             ResourceNotFoundError: If no project exists by the specified project EntityId.
             UnknownError: If an error occurs while retrieving the project.
         """
-        return self._querier.basic_getter(OrmProject, payload={"include_labels_metadata": include_labels_metadata})
+        return self._querier.basic_getter(
+            OrmProject, payload={"include_labels_metadata": include_labels_metadata}, retryable=True
+        )
 
     def list_label_rows(
         self,

--- a/encord/configs.py
+++ b/encord/configs.py
@@ -52,7 +52,7 @@ _ENCORD_SSH_KEY_FILE = "ENCORD_SSH_KEY_FILE"
 
 READ_TIMEOUT = 180  # In seconds
 WRITE_TIMEOUT = 180  # In seconds
-CONNECT_TIMEOUT = 180  # In seconds
+CONNECT_TIMEOUT = 5  # In seconds
 
 logger = logging.getLogger(__name__)
 

--- a/encord/http/constants.py
+++ b/encord/http/constants.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 
 DEFAULT_CONNECTION_RETRIES = 3
-DEFAULT_MAX_RETRIES = 0
-DEFAULT_BACKOFF_FACTOR = 0.1
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_BACKOFF_FACTOR = 1.5
 
 
 @dataclass
@@ -12,7 +12,7 @@ class RequestsSettings:
     """
 
     max_retries: int = DEFAULT_MAX_RETRIES
-    """Number of allowed retries when a request is sent."""
+    """Number of allowed retries when a request is sent. It only affects idempotent retryable requests."""
 
     backoff_factor: float = DEFAULT_BACKOFF_FACTOR
     """With each retry, there will be a sleep of backoff_factor * (2 ** (retry_number - 1) )"""

--- a/encord/http/constants.py
+++ b/encord/http/constants.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+DEFAULT_CONNECTION_RETRIES = 3
 DEFAULT_MAX_RETRIES = 0
 DEFAULT_BACKOFF_FACTOR = 0.1
 
@@ -15,6 +16,9 @@ class RequestsSettings:
 
     backoff_factor: float = DEFAULT_BACKOFF_FACTOR
     """With each retry, there will be a sleep of backoff_factor * (2 ** (retry_number - 1) )"""
+
+    connection_retries: int = DEFAULT_CONNECTION_RETRIES
+    """Number of allowed retries to establish TCP connection when a request is sent."""
 
 
 DEFAULT_REQUESTS_SETTINGS = RequestsSettings()


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

**New Features:**
- Added a `retryable` parameter to several functions in `client.py` and `querier.py`, enabling automatic retries for improved reliability.
- Introduced a `connection_retries` attribute to the `RequestsSettings` data class in `http/constants.py`, allowing for retries when establishing a TCP connection.

**Refactor:**
- Adjusted the `CONNECT_TIMEOUT` value from 180 seconds to 5 seconds in `configs.py`.
- Updated default values for `max_retries` and `backoff_factor` in `http/constants.py`.

> 🎉 Here's to the code that never gives up, 🔄
> To the requests that retry, when times are tough. 💪
> With shorter timeouts, we're swift as a hare, 🐇
> And with new settings, we're prepared and aware. 🛠️
> So here's to the changes, may they serve us well, 👏
> In the tale of our software, they'll have stories to tell! 📖🎉
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->