### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -92,6 +92,7 @@ jobs:
           python-version: 3.11.2
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_11 }}
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
+          sdk-repository-url: https://github.com/encord-team/encord-client-python@${{ github.sha }}
 
 
   publish-test-reports:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
**New Feature:**
- GitHub Actions workflow now triggers on `pull_request` instead of `push`.
- Added a new step to run integration tests for Python 3.11.
- Introduced new input parameters `sdk-repository-url` and `ref` to specify the SDK repository URL and branch reference.

**Test:**
- Integration test job configuration now accepts `sdk-repository-url` parameter, allowing tests to use a specific version of the SDK.
```

> 🎉 Here's to the code that's ever so bright,  
> With each pull request, it takes flight.  
> Tests run with precision, on Python's new edition,  
> In our repo, there's always light! 🌟

<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->