### PR TITLE
Add deprecated annotation to log warning for long-deprecated project ontology accessor methods

### DIFF
--- a/encord/project.py
+++ b/encord/project.py
@@ -125,7 +125,6 @@ class Project:
         return self._project_instance.datasets
 
     @property
-    @deprecated(version="0.1.95", alternative=".list_label_rows_v2()")
     def label_rows(self) -> dict:
         """
         Get the label rows.
@@ -828,7 +827,6 @@ class Project:
             include_reviews=include_reviews,
         )
 
-    @deprecated(version="0.1.95", alternative=".list_label_rows_v2()")
     def get_label_rows(
         self,
         uids: List[str],

--- a/encord/project.py
+++ b/encord/project.py
@@ -125,11 +125,11 @@ class Project:
         return self._project_instance.datasets
 
     @property
-    @deprecated(version="0.1.95", alternative=".list_label_row_v2()")
+    @deprecated(version="0.1.95", alternative=".list_label_rows_v2()")
     def label_rows(self) -> dict:
         """
         Get the label rows.
-        DEPRECATED: Prefer using :meth:`list_label_row_v2()` method and :meth:`LabelRowV2` class to work with the data.
+        DEPRECATED: Prefer using :meth:`list_label_rows_v2()` method and :meth:`LabelRowV2` class to work with the data.
 
         .. code::
 
@@ -828,7 +828,7 @@ class Project:
             include_reviews=include_reviews,
         )
 
-    @deprecated(version="0.1.95", alternative=".list_label_row_v2()")
+    @deprecated(version="0.1.95", alternative=".list_label_rows_v2()")
     def get_label_rows(
         self,
         uids: List[str],

--- a/encord/project.py
+++ b/encord/project.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Iterable, List, Optional, Set, Tuple, Union
 
 from encord.client import EncordClientProject
+from encord.common.deprecated import deprecated
 from encord.constants.model import AutomationModels, Device
 from encord.http.bundle import Bundle
 from encord.http.v2.api_client import ApiClient
@@ -82,6 +83,7 @@ class Project:
         return self._project_instance.last_edited_at
 
     @property
+    @deprecated(version="0.1.95", alternative=".ontology_structure")
     def ontology(self) -> dict:
         """
         Get the ontology of the project.
@@ -123,6 +125,7 @@ class Project:
         return self._project_instance.datasets
 
     @property
+    @deprecated(version="0.1.95", alternative=".list_label_row_v2()")
     def label_rows(self) -> dict:
         """
         Get the label rows.
@@ -330,9 +333,10 @@ class Project:
         self.refetch_data()
         return res
 
+    @deprecated(version="0.1.95", alternative=".ontology_structure")
     def get_project_ontology(self) -> LegacyOntology:
         """
-        DEPRECATED - prefer using the `ontology` property accessor instead.
+        DEPRECATED - prefer using the `ontology_structure` property accessor instead.
         """
         return self._client.get_project_ontology()
 

--- a/encord/project.py
+++ b/encord/project.py
@@ -828,6 +828,7 @@ class Project:
             include_reviews=include_reviews,
         )
 
+    @deprecated(version="0.1.95", alternative=".list_label_row_v2()")
     def get_label_rows(
         self,
         uids: List[str],


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

**Refactor:**
- Deprecated several methods in the `project.py` file to streamline and modernize our codebase.
  - The `ontology` property and `get_project_ontology` method are now deprecated. Please use the `ontology_structure` property instead.
  - The `label_rows` property is also deprecated. Use the `list_label_row_v2()` method as an alternative.

> 🎉 Out with the old, in with the new, 🔄
> 
> Code's evolving, changing its hue. 🌈
> 
> Ontology's structure, a beacon so bright, 💡
> 
> Label rows v2, taking flight! 🚀
> 
> Celebrate the refactor, for it's no small feat, 🏆
> 
> Making our project more complete! 🎊
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->