### PR TITLE
Use "poetry run" to run unit tests

### DIFF
--- a/.github/actions/run-unit-tests/action.yml
+++ b/.github/actions/run-unit-tests/action.yml
@@ -42,8 +42,7 @@ runs:
 
       - name: Run tests
         run: |
-          source .venv/bin/activate
-          python -m pytest tests --verbose --junitxml=${{ inputs.test-report-file }}
+          poetry run python -m pytest tests --verbose --junitxml=${{ inputs.test-report-file }}
         shell: bash
 
       - name: Upload report

--- a/.github/workflows/sdk-pr.yml
+++ b/.github/workflows/sdk-pr.yml
@@ -52,13 +52,12 @@ jobs:
           key: unit-${{ hashFiles('poetry.lock') }}-${{ env.PYTHON }}-1
 
       - name: Install dependencies
-        if: steps.cached-poetry.outputs.cache-hit != 'true'
+        if: $${{ steps.cached-poetry.outputs.cache-hit != 'true' }}
         run: poetry install --no-interaction
 
       - name: Run tests
         run: |
-          source .venv/bin/activate
-          python -m pytest tests --verbose --junitxml=${{ env.UNIT_TEST_REPORT }}
+          poetry run python -m pytest tests --verbose --junitxml=${{ env.UNIT_TEST_REPORT }}
 
       - name: Upload report
         uses: actions/upload-artifact@v3


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

**Chore:**
- Updated the command used to run unit tests in GitHub Actions. The tests are now executed within the context of the Poetry-managed environment using `poetry run python -m pytest`.

> 🎉 Here's to the code that's ever so neat,  
> With Poetry's rhythm, it can't be beat.  
> Tests run in harmony, no missing beat,  
> In the world of code, this feat is elite! 🥳
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->