### PR TITLE
fix: adds image hash field to image

### DIFF
--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -868,6 +868,7 @@ class Image(base_orm.BaseORM):
     DB_FIELDS = OrderedDict(
         [
             ("data_hash", str),
+            ("image_hash", str),
             ("title", str),
             ("file_link", str),
         ]


### PR DESCRIPTION
# Introduction and Explanation
Images returned from the BE have `image_hash` property rather than the `data_hash` property. Not sure if replacing is safe so I'm just adding a new field.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

**New Feature:**
- Added a new field `image_hash` to the `Image` class in the ORM. This will allow for more efficient image comparison and deduplication.

> 🎉 With every hash, we make a dash,
> 
> For images unique, no need to clash! 📸
> 
> In data we trust, deduplication is a must,
> 
> To keep our codebase robust! 💪🚀
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->