### PR TITLE
Long polling more time to recover

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -142,7 +142,7 @@ from encord.utilities.client_utilities import optional_set_to_list, parse_dateti
 from encord.utilities.project_user import ProjectUser, ProjectUserRole
 
 LONG_POLLING_RESPONSE_RETRY_N = 3
-LONG_POLLING_SLEEP_ON_FAILURE_SECONDS = 3
+LONG_POLLING_SLEEP_ON_FAILURE_SECONDS = 10
 LONG_POLLING_MAX_REQUEST_TIME_SECONDS = 60
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
# Introduction and Explanation
Long polling more time to recover

With current settings we wait up to `LONG_POLLING_SLEEP_ON_FAILURE_SECONDS * LONG_POLLING_RESPONSE_RETRY_N` seconds for server to respond correctly.

With current defaults that is 3 * 3s = 9s in total, which is too small, let's increase this to 3 * 10s = 30s
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

**Chore:**
- Increased the value of `LONG_POLLING_SLEEP_ON_FAILURE_SECONDS` from 3 to 10 in `encord/client.py`. This extends the time the system waits for a server response on failure, improving resilience against temporary network issues.

> 🎉🎈
>
> In the realm where code and servers play,
>
> A change was made, a delay to stay.
>
> From three to ten, the seconds grew,
>
> For stronger bonds, between me and you. 💻💞
>
> So celebrate this chore, small but mighty,
>
> Making our connection more flighty! 🚀🌟
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->