### PR TITLE
Explicitly deprecate some older methods

### DIFF
--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -25,6 +25,7 @@ from uuid import UUID
 from dateutil import parser
 
 from encord.common.constants import DATETIME_STRING_FORMAT
+from encord.common.deprecated import deprecated
 from encord.constants.enums import DataType
 from encord.exceptions import EncordException
 from encord.orm import base_orm
@@ -383,6 +384,7 @@ class DataRow(dict, Formatter):
         return self["images_data"]
 
     @property
+    @deprecated("0.1.98", ".is_image_sequence")
     def is_optimised_image_group(self) -> Optional[bool]:
         """
         If the data type is an :meth:`DataType.IMG_GROUP <encord.constants.enums.DataType.IMG_GROUP>`,

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from dateutil import parser as datetime_parser
 
 from encord.client import EncordClient, EncordClientDataset, EncordClientProject
+from encord.common.deprecated import deprecated
 from encord.configs import SshConfig, UserConfig, get_env_ssh_key
 from encord.constants.string_constants import TYPE_DATASET, TYPE_ONTOLOGY, TYPE_PROJECT
 from encord.dataset import Dataset
@@ -366,6 +367,7 @@ class EncordUserClient:
     def get_or_create_project_api_key(self, project_hash: str) -> str:
         return self.querier.basic_put(ProjectAPIKey, uid=project_hash, payload={})
 
+    @deprecated("0.1.98", ".get_dataset()")
     def get_dataset_client(
         self,
         dataset_hash: str,
@@ -383,6 +385,7 @@ class EncordUserClient:
             dataset_access_settings=dataset_access_settings,
         )
 
+    @deprecated("0.1.98", ".get_project()")
     def get_project_client(self, project_hash: str, **kwargs) -> Union[EncordClientProject, EncordClientDataset]:
         """
         DEPRECATED - prefer using :meth:`get_project()` instead.


### PR DESCRIPTION
Add @deprecated to a few long-deprecated methods
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

**Refactor:**
- Added `@deprecated` decorator to the `is_optimised_image_group` property in `dataset.py`.
- Marked `get_dataset_client` and `get_project_client` methods in the `EncordClient` class in `user_client.py` as deprecated.

> 🎉 Here's to the old, making way for the new,
> 
> Deprecated functions bid adieu.
> 
> With every change, we grow and learn,
> 
> To better code, we always yearn. 🚀
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->