### PR TITLE
Expose the 'data_hashes' filter on a dataset

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -336,6 +336,7 @@ class EncordClientDataset(EncordClient):
         created_before: Optional[Union[str, datetime]] = None,
         created_after: Optional[Union[str, datetime]] = None,
         data_types: Optional[List[DataType]] = None,
+        data_hashes: Optional[List[str]] = None,
     ) -> List[DataRow]:
         """
         Retrieve dataset rows (pointers to data, labels).
@@ -346,6 +347,7 @@ class EncordClientDataset(EncordClient):
             created_before: optional datetime row filter
             created_after: optional datetime row filter
             data_types: optional data types row filter
+            data_hashes: optional list of individual data unit hashes to include
 
         Returns:
             List[DataRow]: A list of DataRows object that match the filter
@@ -372,6 +374,7 @@ class EncordClientDataset(EncordClient):
                     if data_types is not None
                     else None,
                     "dataset_access_settings": dataclasses.asdict(self._dataset_access_settings),
+                    "data_hashes": data_hashes,
                 },
             ),
         )

--- a/encord/dataset.py
+++ b/encord/dataset.py
@@ -72,6 +72,7 @@ class Dataset:
         created_before: Optional[Union[str, datetime]] = None,
         created_after: Optional[Union[str, datetime]] = None,
         data_types: Optional[List[DataType]] = None,
+        data_hashes: Optional[List[str]] = None,
     ) -> List[DataRow]:
         """
         Retrieve dataset rows (pointers to data, labels).
@@ -82,6 +83,8 @@ class Dataset:
             created_before: optional datetime row filter
             created_after: optional datetime row filter
             data_types: optional data types row filter
+            data_hashes: optional list of individual data unit hashes to include
+
 
         Returns:
             List[DataRow]: A list of DataRows object that match the filter
@@ -92,7 +95,7 @@ class Dataset:
             UnknownError: If an error occurs while retrieving the dataset.
         """
 
-        return self._client.list_data_rows(title_eq, title_like, created_before, created_after, data_types)
+        return self._client.list_data_rows(title_eq, title_like, created_before, created_after, data_types, data_hashes)
 
     def refetch_data(self) -> None:
         """


### PR DESCRIPTION
# Introduction and Explanation

See https://github.com/encord-team/cord-backend/pull/2686

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

## Release Notes

### New Feature
- Added an optional `data_hashes` parameter to the `list_data_rows` function in the dataset module. This allows users to filter dataset rows based on a list of individual data unit hashes.

> 🎉 Here's to the code that's ever so bright,  
> Adding features that feel just right.  
> With `data_hashes` we take flight,  
> Filtering data with all our might! 🚀🌟
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->