### PR TITLE
Bitmask input array dimension check

### DIFF
--- a/encord/objects/bitmask.py
+++ b/encord/objects/bitmask.py
@@ -136,26 +136,28 @@ class BitmaskCoordinates:
 
     @staticmethod
     def _from_array(source: Any) -> BitmaskCoordinates.EncodedBitmask:
-        if source is not None:
-            if hasattr(source, "__array_interface__"):
-                arr = source.__array_interface__
-                data_type = arr["typestr"]
-                data = arr["data"]
-                shape = arr["shape"]
+        if source is not None and hasattr(source, "__array_interface__"):
+            arr = source.__array_interface__
+            data_type = arr["typestr"]
+            data = arr["data"]
+            shape = arr["shape"]
 
-                if data_type != "|b1":
-                    raise EncordException(
-                        "Bitmask should be an array of boolean values. For numpy array call .astype(bool)."
-                    )
+            if len(shape) != 2:
+                raise EncordException("Bitmask should be a 2-dimensional array.")
 
-                raw_data = data if isinstance(data, bytes) else source.tobytes()
-
-                rle = _mask_to_rle(raw_data)
-                rle_string = _rle_to_string(rle)
-
-                return BitmaskCoordinates.EncodedBitmask(
-                    top=0, left=0, height=shape[0], width=shape[1], rle_string=rle_string
+            if data_type != "|b1":
+                raise EncordException(
+                    "Bitmask should be an array of boolean values. For numpy array call .astype(bool)."
                 )
+
+            raw_data = data if isinstance(data, bytes) else source.tobytes()
+
+            rle = _mask_to_rle(raw_data)
+            rle_string = _rle_to_string(rle)
+
+            return BitmaskCoordinates.EncodedBitmask(
+                top=0, left=0, height=shape[0], width=shape[1], rle_string=rle_string
+            )
 
         raise EncordException(f"Can't import bitmask from {source.__class__}")
 

--- a/encord/objects/bitmask.py
+++ b/encord/objects/bitmask.py
@@ -171,14 +171,14 @@ class BitmaskCoordinates:
 
     def to_numpy_array(self):
         """
-        Converts the mask to numpy array with dtype bool.
+        Converts the mask to a 2D numpy array with dtype bool.
 
-        Numpy needs to be installed for this call to work
+        Numpy needs to be installed for this call to work.
         """
         try:
             import numpy as np  # type: ignore[missing-import]
-        except ImportError:
-            raise EncordException("Numpy is required for .to_numpy call.")
+        except ImportError as e:
+            raise EncordException("Numpy is required for .to_numpy_array call.") from e
 
         return np.array(self)
 

--- a/encord/objects/bitmask.py
+++ b/encord/objects/bitmask.py
@@ -136,30 +136,29 @@ class BitmaskCoordinates:
 
     @staticmethod
     def _from_array(source: Any) -> BitmaskCoordinates.EncodedBitmask:
-        if source is not None and hasattr(source, "__array_interface__"):
-            arr = source.__array_interface__
-            data_type = arr["typestr"]
-            data = arr["data"]
-            shape = arr["shape"]
+        if source is None:
+            raise EncordException("Bitmask can't be created from None")
 
-            if len(shape) != 2:
-                raise EncordException("Bitmask should be a 2-dimensional array.")
+        if not hasattr(source, "__array_interface__"):
+            raise EncordException(f"Can't import bitmask from {source.__class__}")
 
-            if data_type != "|b1":
-                raise EncordException(
-                    "Bitmask should be an array of boolean values. For numpy array call .astype(bool)."
-                )
+        arr = source.__array_interface__
+        data_type = arr["typestr"]
+        data = arr["data"]
+        shape = arr["shape"]
 
-            raw_data = data if isinstance(data, bytes) else source.tobytes()
+        if len(shape) != 2:
+            raise EncordException("Bitmask should be a 2-dimensional array.")
 
-            rle = _mask_to_rle(raw_data)
-            rle_string = _rle_to_string(rle)
+        if data_type != "|b1":
+            raise EncordException("Bitmask should be an array of boolean values. For numpy array call .astype(bool).")
 
-            return BitmaskCoordinates.EncodedBitmask(
-                top=0, left=0, height=shape[0], width=shape[1], rle_string=rle_string
-            )
+        raw_data = data if isinstance(data, bytes) else source.tobytes()
 
-        raise EncordException(f"Can't import bitmask from {source.__class__}")
+        rle = _mask_to_rle(raw_data)
+        rle_string = _rle_to_string(rle)
+
+        return BitmaskCoordinates.EncodedBitmask(top=0, left=0, height=shape[0], width=shape[1], rle_string=rle_string)
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -1149,7 +1149,7 @@ class LabelRowV2:
                 frame_view.height == coordinates._encoded_bitmask.height
                 and frame_view.width == coordinates._encoded_bitmask.width
             ):
-                raise ValueError("Bitmask resolution doesn't match the media resolution")
+                raise ValueError("Bitmask dimensions don't match the media dimensions")
             encord_object["bitmask"] = coordinates.to_dict()
         else:
             raise NotImplementedError(f"adding coordinatees for this type not yet implemented {type(coordinates)}")


### PR DESCRIPTION
Raise an exception with the clear error message if a provided bitmask is not a 2d array
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

**Bug fix:**
- Added validation to ensure the provided bitmask is a 2-dimensional array in `bitmask.py`.
- Improved error handling in `BitmaskCoordinates` class methods `_from_array`, `from_array`, and `to_numpy_array` in `bitmask.py`.
- Updated an error message for better clarity in `ontology_labels_impl.py`.

> 🎉 Here's to the bugs we've squashed, 🐛
>
> To the errors caught, and the crashes paused. 🚫💥
>
> With each line of code, our software grows, 🌱
>
> Like a poet finding rhythm in prose. 🖋️📜
>
> So here's to the changes, big and small, 🔄
>
> Making our code the best of all! 🏆💻
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->