### PR TITLE
Speedup time parser

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -135,7 +135,7 @@ from encord.orm.workflow import (
 from encord.project_ontology.classification_type import ClassificationType
 from encord.project_ontology.object_type import ObjectShape
 from encord.project_ontology.ontology import Ontology
-from encord.utilities.client_utilities import optional_set_to_list, parse_datetime
+from encord.utilities.client_utilities import optional_datetime_to_iso_str, optional_set_to_list
 from encord.utilities.project_user import ProjectUser, ProjectUserRole
 
 LONG_POLLING_RESPONSE_RETRY_N = 3
@@ -354,8 +354,8 @@ class EncordClientDataset(EncordClient):
             UnknownError: If an error occurs while retrieving the dataset.
         """
 
-        created_before = parse_datetime("created_before", created_before)
-        created_after = parse_datetime("created_after", created_after)
+        created_before = optional_datetime_to_iso_str("created_before", created_before)
+        created_after = optional_datetime_to_iso_str("created_after", created_after)
 
         data_rows = cast(
             List[DataRow],
@@ -747,8 +747,8 @@ class EncordClientProject(EncordClient):
         label_statuses_values = (
             [label_status.value for label_status in label_statuses] if label_statuses is not None else None
         )
-        edited_before = parse_datetime("edited_before", edited_before)
-        edited_after = parse_datetime("edited_after", edited_after)
+        edited_before = optional_datetime_to_iso_str("edited_before", edited_before)
+        edited_after = optional_datetime_to_iso_str("edited_after", edited_after)
 
         payload = {
             "edited_before": edited_before,

--- a/encord/common/constants.py
+++ b/encord/common/constants.py
@@ -1,1 +1,2 @@
 DATETIME_STRING_FORMAT = "%Y-%m-%d %H:%M:%S"
+DATETIME_LONG_STRING_FORMAT = "%a, %d %b %Y %H:%M:%S %Z"

--- a/encord/common/time_parser.py
+++ b/encord/common/time_parser.py
@@ -2,6 +2,8 @@ from datetime import datetime
 
 from dateutil import parser
 
+from encord.common.constants import DATETIME_LONG_STRING_FORMAT
+
 
 def parse_datetime(time_string: str) -> datetime:
     """
@@ -14,7 +16,7 @@ def parse_datetime(time_string: str) -> datetime:
     and falling back to the most complicated logic only in case of all other attempt have failed.
     """
     try:
-        return datetime.strptime(time_string, "%a, %d %b %Y %H:%M:%S %Z")
+        return datetime.strptime(time_string, DATETIME_LONG_STRING_FORMAT)
     except Exception:
         pass
 

--- a/encord/common/time_parser.py
+++ b/encord/common/time_parser.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+
+from dateutil import parser
+
+
+def parse_datetime(time_string: str) -> datetime:
+    """
+    Parsing datetime strings in the most compatible yet performant way.
+
+    Our labels can contain timestamps in different formats, but applying dateutil.parse straight away is expensive
+    as it is very smart and tries to guess the time format.
+
+    So instead we're applying parsers with known formats, starting from the formats most likely to occur,
+    and falling back to the most complicated logic only in case of all other attempt have failed.
+    """
+    try:
+        return datetime.strptime(time_string, "%a, %d %b %Y %H:%M:%S %Z")
+    except Exception:
+        pass
+
+    try:
+        return parser.isoparse(time_string)
+    except Exception:
+        pass
+
+    return parser.parse(time_string)

--- a/encord/objects/classification_instance.py
+++ b/encord/objects/classification_instance.py
@@ -16,8 +16,7 @@ from typing import (
     Union,
 )
 
-from dateutil.parser import parse
-
+from encord.common.time_parser import parse_datetime
 from encord.constants.enums import DataType
 from encord.exceptions import LabelRowError
 from encord.objects.answers import Answer, ValueType, _get_static_answer_map
@@ -449,12 +448,12 @@ class ClassificationInstance:
         @staticmethod
         def from_dict(d: dict) -> ClassificationInstance.FrameData:
             if "lastEditedAt" in d:
-                last_edited_at = parse(d["lastEditedAt"])
+                last_edited_at = parse_datetime(d["lastEditedAt"])
             else:
                 last_edited_at = datetime.now()
 
             return ClassificationInstance.FrameData(
-                created_at=parse(d["createdAt"]),
+                created_at=parse_datetime(d["createdAt"]),
                 created_by=d["createdBy"],
                 confidence=d["confidence"],
                 manual_annotation=d["manualAnnotation"],

--- a/encord/objects/constants.py
+++ b/encord/objects/constants.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+# for backwards compatibility
+from encord.common.constants import DATETIME_LONG_STRING_FORMAT
+
 DEFAULT_CONFIDENCE = 1.0
 DEFAULT_MANUAL_ANNOTATION = True
-DATETIME_LONG_STRING_FORMAT = "%a, %d %b %Y %H:%M:%S %Z"
 AVAILABLE_COLORS = (
     "#D33115",
     "#E27300",

--- a/encord/objects/ontology_object_instance.py
+++ b/encord/objects/ontology_object_instance.py
@@ -17,8 +17,7 @@ from typing import (
     Union,
 )
 
-from dateutil.parser import parse
-
+from encord.common.time_parser import parse_datetime
 from encord.constants.enums import DataType
 from encord.exceptions import LabelRowError
 from encord.objects import ChecklistAttribute, RadioAttribute, TextAttribute
@@ -632,12 +631,12 @@ class ObjectInstance:
         @staticmethod
         def from_dict(d: dict):
             if "lastEditedAt" in d:
-                last_edited_at = parse(d["lastEditedAt"])
+                last_edited_at = parse_datetime(d["lastEditedAt"])
             else:
                 last_edited_at = datetime.now()
 
             return ObjectInstance.FrameInfo(
-                created_at=parse(d["createdAt"]),
+                created_at=parse_datetime(d["createdAt"]),
                 created_by=d["createdBy"],
                 last_edited_at=last_edited_at,
                 last_edited_by=d.get("lastEditedBy"),

--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -22,10 +22,9 @@ from enum import Enum, IntEnum
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from dateutil import parser
-
 from encord.common.constants import DATETIME_STRING_FORMAT
 from encord.common.deprecated import deprecated
+from encord.common.time_parser import parse_datetime
 from encord.constants.enums import DataType
 from encord.exceptions import EncordException
 from encord.orm import base_orm
@@ -155,8 +154,8 @@ class ImageData:
             file_size=json_dict["file_size"],
             image_hash=json_dict["image_hash"],
             storage_location=json_dict["storage_location"],
-            created_at=parser.parse(json_dict["created_at"]),
-            last_edited_at=parser.parse(json_dict["last_edited_at"]),
+            created_at=parse_datetime(json_dict["created_at"]),
+            last_edited_at=parse_datetime(json_dict["last_edited_at"]),
             height=json_dict["height"],
             width=json_dict["width"],
             signed_url=json_dict.get("signed_url"),
@@ -270,7 +269,7 @@ class DataRow(dict, Formatter):
 
     @property
     def created_at(self) -> datetime:
-        return parser.parse(self["created_at"])
+        return parse_datetime(self["created_at"])
 
     @created_at.setter
     def created_at(self, value: datetime) -> None:
@@ -336,7 +335,7 @@ class DataRow(dict, Formatter):
 
     @property
     def last_edited_at(self) -> datetime:
-        return parser.parse(self["last_edited_at"])
+        return parse_datetime(self["last_edited_at"])
 
     @property
     def file_link(self) -> Optional[str]:
@@ -484,9 +483,9 @@ class DataRow(dict, Formatter):
             title=json_dict["data_title"],
             # The API server currently returns upper-cased DataType strings.
             data_type=data_type,
-            created_at=parser.parse(json_dict["created_at"]),
+            created_at=parse_datetime(json_dict["created_at"]),
             client_metadata=json_dict.get("client_metadata"),
-            last_edited_at=parser.parse(json_dict["last_edited_at"]),
+            last_edited_at=parse_datetime(json_dict["last_edited_at"]),
             width=json_dict["width"],
             height=json_dict["height"],
             file_link=json_dict["file_link"],

--- a/encord/orm/label_row.py
+++ b/encord/orm/label_row.py
@@ -20,6 +20,7 @@ from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+from encord.common.time_parser import parse_datetime
 from encord.orm import base_orm
 from encord.orm.formatter import Formatter
 
@@ -285,10 +286,10 @@ class LabelRowMetadata(Formatter):
     def from_dict(cls, json_dict: Dict) -> LabelRowMetadata:
         created_at = json_dict.get("created_at", None)
         if created_at is not None:
-            created_at = datetime.datetime.fromisoformat(created_at)
+            created_at = parse_datetime(created_at)
         last_edited_at = json_dict.get("last_edited_at", None)
         if last_edited_at is not None:
-            last_edited_at = datetime.datetime.fromisoformat(last_edited_at)
+            last_edited_at = parse_datetime(last_edited_at)
 
         annotation_task_status = (
             AnnotationTaskStatus(json_dict["annotation_task_status"])

--- a/encord/orm/model.py
+++ b/encord/orm/model.py
@@ -18,8 +18,7 @@ from datetime import datetime
 from enum import Enum
 from typing import List, Optional
 
-from dateutil.parser import parse
-
+from encord.common.time_parser import parse_datetime
 from encord.constants.model import AutomationModels
 from encord.exceptions import EncordException
 from encord.orm import base_orm
@@ -138,7 +137,7 @@ class TrainingMetadata(Formatter):
         if created_at is None:
             return None
 
-        return parse(created_at)
+        return parse_datetime(created_at)
 
     @staticmethod
     def get_model_training_labels(json_dict: dict) -> Optional[ModelTrainingLabel]:

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -7,10 +7,9 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from dateutil import parser as datetime_parser
-
 from encord.client import EncordClient, EncordClientDataset, EncordClientProject
 from encord.common.deprecated import deprecated
+from encord.common.time_parser import parse_datetime
 from encord.configs import SshConfig, UserConfig, get_env_ssh_key
 from encord.constants.string_constants import TYPE_DATASET, TYPE_ONTOLOGY, TYPE_PROJECT
 from encord.dataset import Dataset
@@ -242,8 +241,8 @@ class EncordUserClient:
         )
 
         def convert_dates(dataset):
-            dataset["created_at"] = datetime_parser.isoparse(dataset["created_at"])
-            dataset["last_edited_at"] = datetime_parser.isoparse(dataset["last_edited_at"])
+            dataset["created_at"] = parse_datetime(dataset["created_at"])
+            dataset["last_edited_at"] = parse_datetime(dataset["last_edited_at"])
             return dataset
 
         return [
@@ -643,7 +642,7 @@ class EncordUserClient:
 
             if clause.value.endswith("before") or clause.value.endswith("after"):
                 if isinstance(val, str):
-                    val = datetime_parser.isoparse(val)
+                    val = parse_datetime(val)
                 if isinstance(val, datetime):
                     val = val.isoformat()
                 else:

--- a/encord/utilities/client_utilities.py
+++ b/encord/utilities/client_utilities.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from enum import Enum
 from typing import List, Optional, Set, TypeVar, Union
 
-from dateutil import parser as datetime_parser
+from encord.common.time_parser import parse_datetime
 
 
 def pretty_print(data):
@@ -120,11 +120,11 @@ class CvatImporterError:
     issues: Issues
 
 
-def parse_datetime(key: str, val: Optional[Union[str, datetime]]) -> Optional[str]:
+def optional_datetime_to_iso_str(key: str, val: Optional[Union[str, datetime]]) -> Optional[str]:
     if not val:
         return None
     if isinstance(val, str):
-        return datetime_parser.isoparse(val).isoformat()
+        return parse_datetime(val).isoformat()
     if isinstance(val, datetime):
         return val.isoformat()
     else:

--- a/tests/orm/test_dataset.py
+++ b/tests/orm/test_dataset.py
@@ -4,8 +4,7 @@
 from datetime import datetime
 from typing import Set
 
-from dateutil import parser
-
+from encord.common.time_parser import parse_datetime
 from encord.constants.enums import DataType
 from encord.orm.dataset import Dataset, StorageLocation
 
@@ -61,10 +60,10 @@ def test_dataset_fields():
 
     assert data_row.uid == data_row_json["data_hash"]
     assert data_row.title == data_row_json["data_title"]
-    assert data_row.created_at == parser.parse(data_row_json["created_at"])
+    assert data_row.created_at == parse_datetime(data_row_json["created_at"])
     assert data_row.data_type == DataType.from_upper_case_string(data_row_json["data_type"])
     assert data_row.client_metadata == data_row_json["client_metadata"]
-    assert data_row.last_edited_at == parser.parse(data_row_json["last_edited_at"])
+    assert data_row.last_edited_at == parse_datetime(data_row_json["last_edited_at"])
     assert data_row.width == data_row_json["width"]
     assert data_row.height == data_row_json["height"]
     assert data_row.file_link == data_row_json["file_link"]

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from encord import Project
+from encord.common.time_parser import parse_datetime
 from encord.http.v2.api_client import ApiClient
 from encord.http.v2.payloads import Page
 from encord.orm.analytics import (
@@ -31,7 +32,7 @@ def construct_timer(
 
 @patch.object(ApiClient, "get")
 def test_project_collaborator_timers_empty_page(api_client_get: MagicMock, project: Project):
-    after_time = datetime.fromisoformat("2023-01-01T21:00:00")
+    after_time = parse_datetime("2023-01-01T21:00:00")
 
     api_client_get.return_value = Page[CollaboratorTimer](results=[])
 
@@ -43,7 +44,7 @@ def test_project_collaborator_timers_empty_page(api_client_get: MagicMock, proje
 
 @patch.object(ApiClient, "get")
 def test_project_collaborator_timers_single_page(api_client_get: MagicMock, project: Project):
-    after_time = datetime.fromisoformat("2023-01-01T21:00:00")
+    after_time = parse_datetime("2023-01-01T21:00:00")
 
     return_value = Page[CollaboratorTimer](
         results=[
@@ -72,7 +73,7 @@ def test_project_collaborator_timers_single_page(api_client_get: MagicMock, proj
 
 @patch.object(ApiClient, "get")
 def test_project_collaborator_timers_multi_page(api_client_get: MagicMock, project: Project):
-    after_time = datetime.fromisoformat("2023-01-01T21:00:00")
+    after_time = parse_datetime("2023-01-01T21:00:00")
 
     return_value_page_1 = Page[CollaboratorTimer](
         results=[

--- a/tests/test_label_logs.py
+++ b/tests/test_label_logs.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from deepdiff import DeepDiff
 
+from encord.common.time_parser import parse_datetime
 from encord.http.querier import Querier, RequestContext
 from encord.project import Project
 from tests.fixtures import ontology, project, user_client
@@ -22,8 +23,8 @@ def get_mocked_answer(payload: Any) -> MagicMock:
 
 @patch.object(Querier, "_execute")
 def test_get_label_logs_filter_by_datetime(querier_mock: MagicMock, project: Project):
-    after_time = datetime.fromisoformat("2023-01-01T21:00:00")
-    before_time = datetime.fromisoformat("2023-01-02T21:00:00")
+    after_time = parse_datetime("2023-01-01T21:00:00")
+    before_time = parse_datetime("2023-01-02T21:00:00")
     querier_mock.return_value = ([], RequestContext())
 
     _ = project.get_label_logs(after=after_time, before=before_time)


### PR DESCRIPTION
We're using dateutil `parse` method, which is cool, as it can correctly guess the data format and pretty error-tolerant.
But this also makes parsing quite expensive, because in most of the cases date time is of correct known format.
So introducing a wrapper, that tries to parse known formats first, and fallbacks to the old behaviour only if necessary.
That provides up to 10x parsing speed improvement for usual case, while introducing only 1-2% overhead for cases that really need the more fault tolerant parsing.