### PR TITLE
Add Option.add_nested_attribute method and deprecate .add_nested_option method

### DIFF
--- a/encord/objects/options.py
+++ b/encord/objects/options.py
@@ -5,6 +5,7 @@ from abc import abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Type, TypeVar
 
+from encord.common.deprecated import deprecated
 from encord.objects.ontology_element import (
     OntologyElement,
     OntologyNestedElement,
@@ -109,7 +110,24 @@ class NestableOption(Option):
             nested_options=nested_options_ret,
         )
 
+    @deprecated(version="0.1.100", alternative=".add_nested_attribute")
     def add_nested_option(
+        self,
+        cls: Type[AttributeType],
+        name: str,
+        local_uid: Optional[int] = None,
+        feature_node_hash: Optional[str] = None,
+        required: bool = False,
+    ) -> AttributeType:
+        """
+        This method is deprecated, please use :meth:`.add_nested_option` instead.
+        There is no functional difference between these methods.
+        """
+        return self.add_nested_attribute(
+            cls=cls, name=name, local_uid=local_uid, feature_node_hash=feature_node_hash, required=required
+        )
+
+    def add_nested_attribute(
         self,
         cls: Type[AttributeType],
         name: str,

--- a/tests/objects/test_ontology.py
+++ b/tests/objects/test_ontology.py
@@ -313,8 +313,8 @@ def test_build_nested_options():
     assert isinstance(one, encord.objects.NestableOption)
     assert isinstance(two, encord.objects.NestableOption)
 
-    detail1 = one.add_nested_option(encord.objects.RadioAttribute, "detail one")
-    one.add_nested_option(encord.objects.TextAttribute, "detail two")
+    detail1 = one.add_nested_attribute(encord.objects.RadioAttribute, "detail one")
+    one.add_nested_attribute(encord.objects.TextAttribute, "detail two")
 
     detail1value1 = detail1.add_option("value 1")
     assert isinstance(detail1value1, encord.objects.NestableOption)
@@ -354,7 +354,7 @@ def build_expected_ontology():
         encord.objects.RadioAttribute, feature_node_hash="cabfedb5", name="Radio with options"
     )
     nested = radio.add_option(feature_node_hash="5d102ce6", label="Nested Option")
-    _ = nested.add_nested_option(encord.objects.RadioAttribute, feature_node_hash="59204845", name="Leaf")
+    _ = nested.add_nested_attribute(encord.objects.RadioAttribute, feature_node_hash="59204845", name="Leaf")
     cls = ontology.add_classification(feature_node_hash="a39d81c0")
     cat_standing = cls.add_attribute(
         encord.objects.RadioAttribute,


### PR DESCRIPTION
The old .add_nested_option name is misleading, as it actually adds an Attribute.
Old method is kept for backward compatibility