### PR TITLE
Allow user to provide a mapping function to adapt file names to CVAT image names if necessary

### DIFF
--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -461,6 +461,13 @@ class EncordUserClient:
         )
         log.info("Image upload completed.")
 
+        # This is a bit hacky, but allows more flexibility for CVAT project imports
+        if import_method.map_filename_to_cvat_name:
+            image_title_to_image_hash_map = {
+                import_method.map_filename_to_cvat_name(key): value
+                for key, value in image_title_to_image_hash_map.items()
+            }
+
         payload = {
             "cvat": {
                 "annotations_base64": annotations_base64,

--- a/encord/utilities/client_utilities.py
+++ b/encord/utilities/client_utilities.py
@@ -17,7 +17,7 @@ import pprint
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional, Set, TypeVar, Union
+from typing import Callable, List, Optional, Set, TypeVar, Union
 
 from encord.common.time_parser import parse_datetime
 
@@ -58,11 +58,17 @@ class APIKeyScopes(Enum):
 @dataclass
 class LocalImport:
     """
-    file_path: Supply the path of the exported folder which contains the images and `annotations.xml` file. Make
-    sure to select "Save images" when exporting your CVAT Task or Project.
+    file_path:
+        Supply the path of the exported folder which contains the images and `annotations.xml` file. Make
+        sure to select "Save images" when exporting your CVAT Task or Project.
+    transform_file_names:
+        Encord expects that file names (including their relative paths), exactly matches the
+        "name" parameter of CVAT image.
+        If it is not, user can supply transform_file_names function that maps filename to the image name.
     """
 
     file_path: str
+    map_filename_to_cvat_name: Optional[Callable[[str], str]] = None
 
 
 ImportMethod = LocalImport


### PR DESCRIPTION
E.g. here is how would this feature be used if file extension needs to be stripped: 

```
user_client.create_project_from_cvat(
    LocalImport(file_path=data_folder,  map_filename_to_cvat_name=lambda x: Path(x).stem),
    dataset_name
)
```