### PR TITLE
fix: bitmask roundtrip

### DIFF
--- a/encord/objects/bitmask.py
+++ b/encord/objects/bitmask.py
@@ -118,16 +118,21 @@ class BitmaskCoordinates:
 
         if isinstance(source, BitmaskCoordinates.EncodedBitmask):
             self._encoded_bitmask = source
+        elif (
+            isinstance(source, dict)
+            and len(set(source.keys()).intersection({"top", "left", "height", "width", "rle_string"})) == 5
+        ):
+            self._encoded_bitmask = BitmaskCoordinates.EncodedBitmask(**source)
         else:
             self._encoded_bitmask = BitmaskCoordinates._from_array(source)
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> BitmaskCoordinates:
-        bitmask = d["bitmask"]
+        bitmask = d["bitmask"] if "bitmask" in d else d  # Backward compatibility
         return BitmaskCoordinates(
             BitmaskCoordinates.EncodedBitmask(
                 top=int(bitmask["top"]),
-                left=int(bitmask["top"]),
+                left=int(bitmask["left"]),
                 height=int(bitmask["height"]),
                 width=int(bitmask["width"]),
                 rle_string=bitmask["rleString"],

--- a/poetry.lock
+++ b/poetry.lock
@@ -740,6 +740,37 @@ files = [
 setuptools = "*"
 
 [[package]]
+name = "numpy"
+version = "1.22.0"
+description = "NumPy is the fundamental package for array computing with Python."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "numpy-1.22.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3d22662b4b10112c545c91a0741f2436f8ca979ab3d69d03d19322aa970f9695"},
+    {file = "numpy-1.22.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:11a1f3816ea82eed4178102c56281782690ab5993251fdfd75039aad4d20385f"},
+    {file = "numpy-1.22.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5dc65644f75a4c2970f21394ad8bea1a844104f0fe01f278631be1c7eae27226"},
+    {file = "numpy-1.22.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42c16cec1c8cf2728f1d539bd55aaa9d6bb48a7de2f41eb944697293ef65a559"},
+    {file = "numpy-1.22.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a97e82c39d9856fe7d4f9b86d8a1e66eff99cf3a8b7ba48202f659703d27c46f"},
+    {file = "numpy-1.22.0-cp310-cp310-win_amd64.whl", hash = "sha256:e41e8951749c4b5c9a2dc5fdbc1a4eec6ab2a140fdae9b460b0f557eed870f4d"},
+    {file = "numpy-1.22.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:bece0a4a49e60e472a6d1f70ac6cdea00f9ab80ff01132f96bd970cdd8a9e5a9"},
+    {file = "numpy-1.22.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:818b9be7900e8dc23e013a92779135623476f44a0de58b40c32a15368c01d471"},
+    {file = "numpy-1.22.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:47ee7a839f5885bc0c63a74aabb91f6f40d7d7b639253768c4199b37aede7982"},
+    {file = "numpy-1.22.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a024181d7aef0004d76fb3bce2a4c9f2e67a609a9e2a6ff2571d30e9976aa383"},
+    {file = "numpy-1.22.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f71d57cc8645f14816ae249407d309be250ad8de93ef61d9709b45a0ddf4050c"},
+    {file = "numpy-1.22.0-cp38-cp38-win32.whl", hash = "sha256:283d9de87c0133ef98f93dfc09fad3fb382f2a15580de75c02b5bb36a5a159a5"},
+    {file = "numpy-1.22.0-cp38-cp38-win_amd64.whl", hash = "sha256:2762331de395739c91f1abb88041f94a080cb1143aeec791b3b223976228af3f"},
+    {file = "numpy-1.22.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:76ba7c40e80f9dc815c5e896330700fd6e20814e69da9c1267d65a4d051080f1"},
+    {file = "numpy-1.22.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0cfe07133fd00b27edee5e6385e333e9eeb010607e8a46e1cd673f05f8596595"},
+    {file = "numpy-1.22.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6ed0d073a9c54ac40c41a9c2d53fcc3d4d4ed607670b9e7b0de1ba13b4cbfe6f"},
+    {file = "numpy-1.22.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41388e32e40b41dd56eb37fcaa7488b2b47b0adf77c66154d6b89622c110dfe9"},
+    {file = "numpy-1.22.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b55b953a1bdb465f4dc181758570d321db4ac23005f90ffd2b434cc6609a63dd"},
+    {file = "numpy-1.22.0-cp39-cp39-win32.whl", hash = "sha256:5a311ee4d983c487a0ab546708edbdd759393a3dc9cd30305170149fedd23c88"},
+    {file = "numpy-1.22.0-cp39-cp39-win_amd64.whl", hash = "sha256:a97a954a8c2f046d3817c2bce16e3c7e9a9c2afffaf0400f5c16df5172a67c9c"},
+    {file = "numpy-1.22.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb02929b0d6bfab4c48a79bd805bd7419114606947ec8284476167415171f55b"},
+    {file = "numpy-1.22.0.zip", hash = "sha256:a955e4128ac36797aaffd49ab44ec74a71c11d6938df83b1285492d277db5397"},
+]
+
+[[package]]
 name = "ordered-set"
 version = "4.1.0"
 description = "An OrderedSet is a custom MutableSet that remembers its order, so that every"
@@ -1581,4 +1612,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "2be3ae74679c41add8554119117b431548167f5c2708d6094f1a23ba2f4b7006"
+content-hash = "79002b268b10d541e5ec6d09a8c382bda7f78ffba83c80e6b34f0fe48d789b98"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ types-python-dateutil = "^2.8.19"
 types-tqdm = "^4.32.1"
 pyyaml = "^6.0.1"
 pyright = "^1.1.338"
+numpy = "1.22"
 
 [build-system]
 requires = ["poetry-core>=1.3.2"]

--- a/tests/objects/test_bitmask.py
+++ b/tests/objects/test_bitmask.py
@@ -1,4 +1,7 @@
+import numpy as np
+
 from encord.objects.bitmask import (
+    BitmaskCoordinates,
     _mask_to_rle,
     _rle_to_mask,
     _rle_to_string,
@@ -46,3 +49,29 @@ def test_rle_to_mask():
     rle = _string_to_rle(encoded_str)
     mask = _rle_to_mask(rle, size=resolution)
     assert len(mask) == resolution
+
+
+def test_mask_roundtrip():
+    orig_mask = np.zeros((2000, 3000), dtype=bool)
+    orig_mask[:1000, 1000:] = 1
+    orig_mask[1000:, :1000] = 1
+
+    mask_coordinates = BitmaskCoordinates(orig_mask)
+
+    new_mask = mask_coordinates.to_numpy_array()
+    assert np.allclose(orig_mask, new_mask)
+
+    new_mask_using_constructor = np.array(mask_coordinates)
+    assert np.allclose(orig_mask, new_mask_using_constructor)
+
+
+def test_mask_rle_mask_roundtrip():
+    orig_mask = np.zeros((2000, 3000), dtype=bool)
+    orig_mask[:1000, 1000:] = 1
+    orig_mask[1000:, :1000] = 1
+
+    mask_coordinates = BitmaskCoordinates(orig_mask)
+    mask_dict = mask_coordinates.to_dict()
+
+    new_mask = BitmaskCoordinates.from_dict(mask_dict).to_numpy_array()
+    assert np.allclose(orig_mask, new_mask)


### PR DESCRIPTION
# Introduction and Explanation
I wanted to do a very simple roundtrip for numpy arrays and `BitmaskCoordinates` for example purposes but realized that this was not intuitive.

```python
import numpy as np

from encord.objects.bitmask import BitmaskCoordinates

def test_mask_rle_mask_roundtrip():
    orig_mask = np.zeros((2000, 3000), dtype=bool)
    orig_mask[:1000, 1000:] = 1
    orig_mask[1000:, :1000] = 1

    rle_dict = BitmaskCoordinates(orig_mask).to_dict()
    # 👇 This did not work without replacing `rle_dict` with `{"bitmask": rle_dict}`
    new_mask = BitmaskCoordinates.from_dict(rle_dict).to_numpy_array()
    assert np.allclose(orig_mask, new_mask)
```

There was also a typo in the `BitmaskCoordinates.from_dict` where `left` coordinate would be set to the previous `top` coordinate.

# JIRA

_Link ticket(s)_


# Documentation
...

# Tests
I wanted to add the unittest listed above but we don't have `numpy` as a dev depoendency. I tried to add it with `poetry add --group dev numpy` but it complained that numpy is not supported for python 3.8. Perhaps it's time to let go of that old fella :-)

# Known issues
Not an issue as such, but the `BitmaskCoordinates.EncodedBitmask.(top|left)` coordinates are not used at all. Perhaps we should just get rid of them? 