### PR TITLE
Make DataRow.client_metadata explicitly read only

### DIFF
--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -19,6 +19,7 @@ import json
 from collections import OrderedDict
 from datetime import datetime
 from enum import Enum, IntEnum
+from types import MappingProxyType
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
@@ -288,7 +289,7 @@ class DataRow(dict, Formatter):
         return self["duration"]
 
     @property
-    def client_metadata(self) -> Optional[dict]:
+    def client_metadata(self) -> Optional[MappingProxyType]:
         """
         The currently cached client metadata. To cache the client metadata, use the
         :meth:`~encord.orm.dataset.DataRow.refetch_data()` function.
@@ -296,7 +297,7 @@ class DataRow(dict, Formatter):
         The setter updates the custom client metadata. This queues a request for the backend which will
         be executed on a call of :meth:`.DataRow.upload`.
         """
-        return self["client_metadata"]
+        return MappingProxyType(self["client_metadata"]) if self["client_metadata"] is not None else None
 
     @client_metadata.setter
     def client_metadata(self, new_client_metadata: Dict) -> None:

--- a/tests/orm/test_dataset.py
+++ b/tests/orm/test_dataset.py
@@ -27,7 +27,7 @@ DATASET_JSON = {
             "file_size": 3560366.0,
             "file_type": "image/png",
             "data_type": "IMG_GROUP",
-            "client_metadata": {"key", "value"},
+            "client_metadata": {"key": "value"},
             "storage_location": StorageLocation.CORD_STORAGE.value,
             "is_optimised_image_group": None,
             "frames_per_second": None,


### PR DESCRIPTION
Disallow inplace modifications for DataRow.client_metadata. These updates are currently ignored by the sdk, which might cause confusion