### PR TITLE
Swapped out RuntimeError for CloudUploadError to support upload errors

### DIFF
--- a/encord/http/utils.py
+++ b/encord/http/utils.py
@@ -166,4 +166,4 @@ def _upload_single_file(
                 )
 
                 logger.error(error_string)
-                raise RuntimeError(error_string)
+                raise CloudUploadError(error_string)


### PR DESCRIPTION
# Introduction and Explanation
The _upload_single_file() function in utils.py raises an RuntimeError if the upload fails. However upload_to_signed_url_list only excepts a CloudUploadError and so this causes a runtime error with the error code:
ConnectionError: HTTPSConnectionPool(host='[api.encord.com](http://api.encord.com/)', port=443): Max retries exceeded with url: /public (Caused by ProtocolError('Connection aborted.', OSError(22, 'Invalid argument')))
Furthermore, the CloudUploadError is not used anywhere in the package as is but only expected here.
# JIRA

_Link ticket(s)_


# Documentation
_There should be enough internal documentation for a product owner to write customer-facing documentation or a separate PR linked if writing the customer documentation directly. Link all that are relevant below_.
- Internal: _notion link_
- Customer docs PR: _link_
- OpenAPI/SDK
    - Generated docs: _link to example if possible_
    - Command to generate: _here_

# Tests
Ideally I would have written a test

# Known issues
AFAIK shouldn't be an issue elsewhere.