### PR TITLE
Introduced __str__/__repr__ methods to give EncordUserClient a nicer representation

### DIFF
--- a/encord/configs.py
+++ b/encord/configs.py
@@ -67,6 +67,8 @@ class BaseConfig(ABC):
     def define_headers(self, data: str) -> Dict:
         pass
 
+    def __str__(self) -> str:
+        return self.requests_settings.__str__()
 
 def _get_signature(data: str, private_key: Ed25519PrivateKey) -> bytes:
     hash_builder = hashlib.sha256()
@@ -137,7 +139,8 @@ class UserConfig(BaseConfig):
         else:
             raise ValueError(f"Provided key [{ssh_private_key}] is not an Ed25519 private key")
 
-
+    def __str__(self) -> str:
+        return super().__str__()
 class Config(BaseConfig):
     """
     Config defining endpoint, project id, API key, and timeouts.

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -725,8 +725,8 @@ class EncordUserClient:
                 "upload_dir": upload_dir,
             },
         )
-
-
+    def __repr__(self) -> str:
+        return "EncordUserClient: " + self.user_config.__str__()
 class ListingFilter(Enum):
     """
     Available properties_filter keys for get_projects() and get_datasets().


### PR DESCRIPTION
# Introduction and Explanation
Was looking at the RequestSettings and was a bit annoyed that the EncordUserClient doesn't communicate to the User. Their request settings. 

Demo:
```
(encord-py3.11) encord:encord-client-python (jb/repr_methods) % python
Python 3.11.5 (main, Sep 11 2023, 08:31:25) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from encord.user_client import EncordUserClient
>>> EncordUserClient.create_with_ssh_private_key(ssh_private_key_path="/Users/encord/Documents/jims-public-key-private-key.txt")
EncordUserClient: RequestsSettings(max_retries=3, backoff_factor=1.5, connection_retries=3, connect_timeout=180, read_timeout=180, write_timeout=180)
```
Could additionally show the user what endpoint there are using but it didn't seem useful to me. May be more intrepretable to those with knowledge.