### PR TITLE
Omit duplicated frame classifications when parsing label row dict

### DIFF
--- a/encord/objects/classification_instance.py
+++ b/encord/objects/classification_instance.py
@@ -13,6 +13,7 @@ from typing import (
     NoReturn,
     Optional,
     Sequence,
+    Set,
     Union,
 )
 
@@ -133,7 +134,12 @@ class ClassificationInstance:
 
         frames_list = frames_class_to_frames_list(frames)
 
-        self._check_classification_already_present(frames_list)
+        conflicting_frames_list = self._is_classification_already_present(frames_list)
+
+        frames_to_add = set(frames_list) - conflicting_frames_list if conflicting_frames_list else frames_list
+        if not frames_to_add:
+            # Classification already exists on the given frames, nothing to do
+            return
 
         for frame in frames_list:
             self._check_within_range(frame)
@@ -534,16 +540,10 @@ class ClassificationInstance:
                 f"The supplied frame of `{frame}` is not within the acceptable bounds of `0` to `{self._last_frame}`."
             )
 
-    def _check_classification_already_present(self, frames: Iterable[int]) -> None:
+    def _is_classification_already_present(self, frames: Iterable[int]) -> Set[int]:
         if self._parent is None:
-            return
-        already_present_frame = self._parent._is_classification_already_present(self.ontology_item, frames)
-        if already_present_frame is not None:
-            raise LabelRowError(
-                f"The LabelRowV2, that this classification is part of, already has a classification of the same type "
-                f"on frame `{already_present_frame}`. The same type of classification can only be present once per "
-                f"frame per LabelRowV2."
-            )
+            return set()
+        return self._parent._is_classification_already_present(self.ontology_item, frames)
 
     def __repr__(self):
         return (

--- a/encord/objects/classification_instance.py
+++ b/encord/objects/classification_instance.py
@@ -30,7 +30,7 @@ from encord.objects.attributes import (
 )
 from encord.objects.classification import Classification
 from encord.objects.constants import DEFAULT_CONFIDENCE, DEFAULT_MANUAL_ANNOTATION
-from encord.objects.frames import Frames, frames_class_to_frames_list
+from encord.objects.frames import Frames, frames_class_to_frames_list, frames_to_ranges
 from encord.objects.internal_helpers import (
     _infer_attribute_from_answer,
     _search_child_attributes,
@@ -135,10 +135,16 @@ class ClassificationInstance:
         frames_list = frames_class_to_frames_list(frames)
 
         conflicting_frames_list = self._is_classification_already_present(frames_list)
+        if conflicting_frames_list and not overwrite:
+            raise LabelRowError(
+                f"The classification '{self.classification_hash}' already exists "
+                f"on the frames {frames_to_ranges(conflicting_frames_list)}. "
+                f"Set 'overwrite' parameter to True to override."
+            )
 
         frames_to_add = set(frames_list) - conflicting_frames_list if conflicting_frames_list else frames_list
         if not frames_to_add:
-            # Classification already exists on the given frames, nothing to do
+            # Nothing to do
             return
 
         for frame in frames_list:

--- a/encord/objects/frames.py
+++ b/encord/objects/frames.py
@@ -9,6 +9,9 @@ class Range:
     start: int
     end: int
 
+    def __repr__(self):
+        return f"({self.start}:{self.end})"
+
 
 Ranges = List[Range]
 FramesList = List[int]

--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -4,7 +4,6 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
-from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Type, Union
 
 from encord.client import EncordClientProject
@@ -43,7 +42,7 @@ from encord.objects.coordinates import (
     PolylineCoordinates,
     RotatableBoundingBoxCoordinates,
 )
-from encord.objects.frames import Frames, frames_class_to_frames_list
+from encord.objects.frames import Frames, frames_class_to_frames_list, frames_to_ranges
 from encord.objects.metadata import DICOMSeriesMetadata, DICOMSliceMetadata
 from encord.objects.ontology_object import Object
 from encord.objects.ontology_object_instance import ObjectInstance
@@ -542,7 +541,7 @@ class LabelRowV2:
         frames = set(_frame_views_to_frame_numbers(classification_instance.get_annotations()))
 
         classification_hash = classification_instance.classification_hash
-        already_present_frame = self._is_classification_already_present(
+        already_present_frames = self._is_classification_already_present(
             classification_instance.ontology_item,
             frames,
         )
@@ -551,11 +550,12 @@ class LabelRowV2:
                 "The supplied ClassificationInstance was already previously added. (the classification_hash is the same)."
             )
 
-        if already_present_frame is not None and not force:
+        if already_present_frames and not force:
             raise LabelRowError(
-                f"A ClassificationInstance of the same type was already added and has overlapping frames. One "
-                f"overlapping frame that was found is `{already_present_frame}`. Make sure that you only add "
-                f"classifications which are on frames where the same type of classification does not yet exist."
+                f"A ClassificationInstance {classification_hash} was already added and has overlapping frames. "
+                f"Overlapping frames that were found are `{frames_to_ranges(already_present_frames)}`. "
+                f"Make sure that you only add classifications which are on frames where the same type of "
+                f"classification does not yet exist."
             )
 
         if classification_hash in self._classifications_map and force:
@@ -1163,11 +1163,9 @@ class LabelRowV2:
 
         return ret
 
-    def _is_classification_already_present(
-        self, classification: Classification, frames: Iterable[int]
-    ) -> Optional[int]:
+    def _is_classification_already_present(self, classification: Classification, frames: Iterable[int]) -> Set[int]:
         present_frames = self._classifications_to_frames.get(classification, set())
-        return next((frame for frame in frames if frame in present_frames), None)
+        return present_frames.intersection(frames)
 
     def _add_frames_to_classification(self, classification: Classification, frames: Iterable[int]) -> None:
         self._classifications_to_frames[classification].update(set(frames))

--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -533,26 +533,26 @@ class LabelRowV2:
 
         if classification_instance.is_assigned_to_label_row():
             raise LabelRowError(
-                "The supplied ClassificationInstance is already part of a LabelRowV2. You can only add a ClassificationInstance"
-                " to one LabelRowV2. You can do a ClassificationInstance.copy() to create an identical ObjectInstance which is "
-                "not part of any LabelRowV2."
+                "Provided ClassificationInstance object is already attached to a different LabelRowV2 object. "
+                "You can only add a ClassificationInstance to one label row. "
+                "You can do a ClassificationInstance.copy() to create an identical ClassificationInstance which is not part of any label row."
             )
 
-        frames = set(_frame_views_to_frame_numbers(classification_instance.get_annotations()))
-
         classification_hash = classification_instance.classification_hash
+        frames = set(_frame_views_to_frame_numbers(classification_instance.get_annotations()))
         already_present_frames = self._is_classification_already_present(
             classification_instance.ontology_item,
             frames,
         )
         if classification_hash in self._classifications_map and not force:
             raise LabelRowError(
-                "The supplied ClassificationInstance was already previously added. (the classification_hash is the same)."
+                f"A ClassificationInstance for classification hash '{classification_hash}' already exists on the label row object. "
+                f"Pass 'force=True' to override it."
             )
 
         if already_present_frames and not force:
             raise LabelRowError(
-                f"A ClassificationInstance {classification_hash} was already added and has overlapping frames. "
+                f"A ClassificationInstance '{classification_hash}' was already added and has overlapping frames. "
                 f"Overlapping frames that were found are `{frames_to_ranges(already_present_frames)}`. "
                 f"Make sure that you only add classifications which are on frames where the same type of "
                 f"classification does not yet exist."
@@ -1469,6 +1469,7 @@ class LabelRowV2:
             last_edited_at=frame_view.last_edited_at,
             last_edited_by=frame_view.last_edited_by,
             reviews=frame_view.reviews,
+            overwrite=True,  # Always overwrite during label row dict parsing, as older dicts known to have duplicates
         )
 
         answers_dict = classification_answers[classification_hash]["classifications"]
@@ -1494,6 +1495,7 @@ class LabelRowV2:
             last_edited_at=frame_view.last_edited_at,
             last_edited_by=frame_view.last_edited_by,
             reviews=frame_view.reviews,
+            overwrite=True,  # Always overwrite during label row dict parsing, as older dicts known to have duplicates
         )
 
     def _check_labelling_is_initalised(self):

--- a/tests/objects/test_label_structure.py
+++ b/tests/objects/test_label_structure.py
@@ -626,14 +626,16 @@ def test_add_and_get_classification_instances_to_label_row(ontology):
     label_row.add_classification_instance(overlapping_classification_instance)
     with pytest.raises(LabelRowError):
         overlapping_classification_instance.set_for_frames(1)
-    with pytest.raises(LabelRowError):
-        overlapping_classification_instance.set_for_frames(1, overwrite=True)
+
+    # Do not raise if overwrite flag is passed
+    overlapping_classification_instance.set_for_frames(1, overwrite=True)
 
     label_row.remove_classification(classification_instance_1)
     overlapping_classification_instance.set_for_frames(1)
 
     with pytest.raises(LabelRowError):
         overlapping_classification_instance.set_for_frames(3)
+
     classification_instance_2.remove_from_frames(3)
     overlapping_classification_instance.set_for_frames(3)
 


### PR DESCRIPTION
Older label row dictionaries are known to have overlapping frame ranges, that cause parsing errors in LabelRowV2 parser.
So switching the default behavior to remove these duplications, as this is not a destructive operation.
Also adding more debug information to error messages.