### PR TITLE
Expose label validation state and errors via the SDK

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -106,6 +106,7 @@ from encord.orm.label_row import (
     LabelRow,
     LabelRowMetadata,
     LabelStatus,
+    LabelValidationState,
     Review,
     ShadowDataState,
 )
@@ -1362,6 +1363,18 @@ class EncordClientProject(EncordClient):
         return self._get_api_client().get(
             "analytics/collaborators/timers", params=params, result_type=Page[CollaboratorTimer]
         )
+
+    def get_label_validation_errors(self, label_hash: str) -> List[str]:
+        errors = self._get_api_client().get(
+            f"project/{self.project_hash}/label/{label_hash}/validation-errors",
+            params=None,
+            result_type=LabelValidationState,
+        )
+
+        if errors.label_is_valid:
+            return []
+
+        return errors.errors or []
 
 
 def _device_to_string(device: Device) -> str:

--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -246,6 +246,10 @@ class LabelRowV2:
         return self._label_row_read_only_data.priority
 
     @property
+    def label_is_valid(self) -> bool:
+        return self._label_row_read_only_data.label_is_valid
+
+    @property
     def ontology_structure(self) -> OntologyStructure:
         """Get the corresponding ontology structure"""
         return self._ontology.structure
@@ -794,6 +798,12 @@ class LabelRowV2:
             payload=BundledSetPriorityPayload(priorities=[(self.data_hash, priority)]),
         )
 
+    def get_label_validation_errors(self) -> list[str] | None:
+        if not self.label_hash or self.label_is_valid:
+            return None
+
+        return self._project_client.get_label_validation_errors(self.label_hash)
+
     class FrameViewMetadata:
         """
         This class can be used to inspect what metadata for a frame view
@@ -1055,6 +1065,7 @@ class LabelRowV2:
         frame_level_data: Dict[int, LabelRowV2.FrameLevelImageGroupData] = field(default_factory=dict)
         image_hash_to_frame: Dict[str, int] = field(default_factory=dict)
         frame_to_image_hash: Dict[int, str] = field(default_factory=dict)
+        label_is_valid: bool = field(default=True)
 
     def _to_object_answers(self) -> Dict[str, Any]:
         ret: Dict[str, Any] = {}
@@ -1319,6 +1330,7 @@ class LabelRowV2:
             else [LabelRowV2.LabelRowReadOnlyDataImagesDataEntry(**data) for data in label_row_metadata.images_data],
             client_metadata=label_row_metadata.client_metadata,
             file_type=label_row_metadata.file_type,
+            label_is_valid=label_row_metadata.label_is_valid,
         )
 
     def _parse_label_row_dict(self, label_row_dict: dict) -> LabelRowReadOnlyData:
@@ -1387,6 +1399,7 @@ class LabelRowV2:
             client_metadata=label_row_dict.get("client_metadata", self._label_row_read_only_data.client_metadata),
             images_data=label_row_dict.get("images_data", self._label_row_read_only_data.images_data),
             file_type=label_row_dict.get("file_type", None),
+            label_is_valid=bool(label_row_dict.get("label_is_valid", True)),
         )
 
     def _parse_labels_from_dict(self, label_row_dict: dict):

--- a/encord/orm/label_row.py
+++ b/encord/orm/label_row.py
@@ -287,6 +287,7 @@ class LabelRowMetadata(Formatter):
     images_data: Optional[list] = None
     file_type: Optional[str] = None
     """Only available for certain read requests"""
+    label_is_valid: bool = True
 
     @classmethod
     def from_dict(cls, json_dict: Dict) -> LabelRowMetadata:
@@ -326,6 +327,7 @@ class LabelRowMetadata(Formatter):
             client_metadata=json_dict.get("client_metadata", None),
             images_data=json_dict.get("images_data", None),
             file_type=json_dict.get("file_type"),
+            label_is_valid=bool(json_dict.get("label_is_valid", True)),
         )
 
     @classmethod

--- a/encord/orm/label_row.py
+++ b/encord/orm/label_row.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Optional
 
 from encord.common.time_parser import parse_datetime
 from encord.orm import base_orm
+from encord.orm.base_dto import BaseDTO
 from encord.orm.formatter import Formatter
 
 
@@ -186,6 +187,7 @@ class LabelRow(base_orm.BaseORM):
             ("object_actions", dict),
             ("label_status", str),
             ("annotation_task_status", str),
+            ("label_is_valid", bool),
         ]
     )
 
@@ -351,3 +353,11 @@ class LabelRowMetadata(Formatter):
             return value
 
         return {k: transform(v) for k, v in asdict(self).items()}
+
+
+class LabelValidationState(BaseDTO):
+    label_hash: str
+    branch_name: str
+    version: int
+    label_is_valid: bool
+    errors: list[str]


### PR DESCRIPTION
# Introduction and Explanation

${title}, really. 

# JIRA

Fixes https://linear.app/encord/issue/EC-2405/sdk-part-of-get-validation-errors-api

# Documentation

TBD.

# Tests

SDK integration tests coming in a separate PR

# Known issues

I'm not entirely sure about code organisation here.
