### PR TITLE
adding support of passing data_hash also as string in delete_data fun…

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -561,10 +561,12 @@ class EncordClientDataset(EncordClient):
         """
         self._querier.basic_delete(ImageGroup, uid=data_hash)
 
-    def delete_data(self, data_hashes: List[str]):
+    def delete_data(self, data_hashes: Union[List[str], str]):
         """
         This function is documented in :meth:`encord.dataset.Dataset.delete_data`.
         """
+        if isinstance(data_hashes, str):
+            data_hashes = [data_hashes]
         self._querier.basic_delete(Video, uid=data_hashes)
 
     def add_private_data_to_dataset(

--- a/encord/dataset.py
+++ b/encord/dataset.py
@@ -259,7 +259,7 @@ class Dataset:
         """
         return self._client.delete_image_group(data_hash)
 
-    def delete_data(self, data_hashes: List[str]):
+    def delete_data(self, data_hashes: Union[List[str], str]):
         """
         Delete a video/image group from a dataset.
 


### PR DESCRIPTION
Adding in support to pass data_hash as a string in delete_data() which was restricted to List only.

Docs Link: https://docs.encord.com/reference/sdk-ref-dataset#delete_data