### PR TITLE
Explicit opt-in to label validation on write

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -904,14 +904,16 @@ class EncordClientProject(EncordClient):
 
         return self._querier.get_multiple(LabelRow, uids, payload=payload, retryable=True)
 
-    def save_label_row(self, uid, label):
+    def save_label_row(self, uid, label, validate_before_saving: bool = False):
         """
         This function is documented in :meth:`encord.project.Project.save_label_row`.
         """
         label = LabelRow(label)
+        if validate_before_saving:
+            label["validate_before_saving"] = True
         return self._querier.basic_setter(LabelRow, uid, payload=label, retryable=True)
 
-    def save_label_rows(self, uids: List[str], payload: List[LabelRow]):
+    def save_label_rows(self, uids: List[str], payload: List[LabelRow], validate_before_saving: bool = False):
         """
         This function is meant for internal use, please consider using :class:`encord.objects.LabelRowV2` class instead
 
@@ -927,6 +929,7 @@ class EncordClientProject(EncordClient):
         multirequest_payload = {
             "multi_request": True,
             "labels": payload,
+            "validate_before_saving": validate_before_saving,
         }
         return self._querier.basic_setter(LabelRow, uid=uids, payload=multirequest_payload, retryable=True)
 

--- a/encord/http/error_utils.py
+++ b/encord/http/error_utils.py
@@ -96,9 +96,16 @@ def check_error_response(response, context=None, payload=None):
         )
 
     if response == CORRUPTED_LABEL_ERROR:
+        message = "The label blurb is corrupted."
+
+        if payload and isinstance(payload, str):
+            message += "\n" + payload
+        else:
+            message += (
+                " This could be due to the number of frame labels exceeding the number of frames in the labelled video."
+            )
         raise CorruptedLabelError(
-            "The label blurb is corrupted. This could be due to the number of "
-            "frame labels exceeding the number of frames in the labelled video.",
+            message=message,
             context=context,
         )
 

--- a/encord/objects/bundled_operations.py
+++ b/encord/objects/bundled_operations.py
@@ -36,10 +36,12 @@ class BundledCreateRowsPayload:
 class BundledSaveRowsPayload:
     uids: List[str]
     payload: List[Dict]
+    validate_before_saving: Optional[bool]
 
     def add(self, other: BundledSaveRowsPayload) -> BundledSaveRowsPayload:
         self.uids.extend(other.uids)
         self.payload.extend(other.payload)
+        self.validate_before_saving = self.validate_before_saving or other.validate_before_saving
         return self
 
 

--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -406,13 +406,15 @@ class LabelRowV2:
             raise LabelRowError("This function is only supported for label rows of image or image group data types.")
         return self._label_row_read_only_data.image_hash_to_frame[image_hash]
 
-    def save(self, bundle: Optional[Bundle] = None) -> None:
+    def save(self, bundle: Optional[Bundle] = None, validate_before_saving: bool = False) -> None:
         """
         Upload the created labels with the Encord server. This will overwrite any labels that someone has created
         in the platform in the meantime.
 
         Args:
             bundle: if not passed, save is executed immediately. If passed, it is executed as a part of the bundle
+            validate_before_saving: enable stricter server-side integrity checks. Boolean, `False` by default.
+
         """
         self._check_labelling_is_initalised()
         assert self.label_hash is not None  # Checked earlier, assert is just to silence mypy
@@ -420,7 +422,9 @@ class LabelRowV2:
         bundled_operation(
             bundle,
             self._project_client.save_label_rows,
-            payload=BundledSaveRowsPayload(uids=[self.label_hash], payload=[self.to_encord_dict()]),
+            payload=BundledSaveRowsPayload(
+                uids=[self.label_hash], payload=[self.to_encord_dict()], validate_before_saving=validate_before_saving
+            ),
         )
 
     @property

--- a/encord/project.py
+++ b/encord/project.py
@@ -916,7 +916,7 @@ class Project:
             include_reviews=include_reviews,
         )
 
-    def save_label_row(self, uid, label):
+    def save_label_row(self, uid, label, validate_before_saving: bool = False):
         """
         DEPRECATED: Prefer using the list_label_rows_v2 function to interact with label rows.
 
@@ -929,6 +929,7 @@ class Project:
         Args:
             uid: A label_hash (uid) string.
             label: A label row instance.
+            validate_before_saving: enable stricter server-side integrity checks. Boolean, `False` by default.
 
         Returns:
             Bool.
@@ -942,7 +943,7 @@ class Project:
             AnswerDictionaryError: If an object or classification instance is missing in answer dictionaries.
             CorruptedLabelError: If a blurb is corrupted (e.g. if the frame labels have more frames than the video).
         """
-        return self._client.save_label_row(uid, label)
+        return self._client.save_label_row(uid, label, validate_before_saving)
 
     def create_label_row(self, uid: str):
         """


### PR DESCRIPTION
# Introduction and Explanation

$title

# JIRA

Fixes https://linear.app/encord/issue/EC-2335/sdk-part-pass-extra-server-side-validation-parameter-though-the-sdk-to

# Documentation

Docstrings hopefully in place; would probably need a "howto"-level doc once it's actually out.

# Tests

Coming in a follow-up PR (to the BE repo)


