### PR TITLE
Classification without an attribute

### DIFF
--- a/encord/objects/classification.py
+++ b/encord/objects/classification.py
@@ -52,6 +52,8 @@ class Classification(OntologyElement):
         }
         if attributes_list := attributes_to_list_dict(self.attributes):
             ret["attributes"] = attributes_list
+        else:
+            raise ValueError(f"Classification {str(self.uid)} requires attribute before use")
 
         return ret
 

--- a/encord/objects/classification_instance.py
+++ b/encord/objects/classification_instance.py
@@ -224,8 +224,8 @@ class ClassificationInstance:
             attribute: The ontology attribute to set the answer for. If not set, this will be attempted to be
                 inferred.  For answers to :class:`encord.objects.common.RadioAttribute` or
                 :class:`encord.objects.common.ChecklistAttribute`, this can be inferred automatically. For
-                :class:`encord.objects.common.TextAttribute`, this will only be inferred there is only one possible
-                TextAttribute to set for the entire object instance. Otherwise, a
+                :class:`encord.objects.common.TextAttribute`, this will only be inferred if there is only one possible
+                TextAttribute to set for the entire classification instance. Otherwise, a
                 :class:`encord.exceptionsLabelRowError` will be thrown.
             overwrite: If `True`, the answer will be overwritten if it already exists. If `False`, this will throw
                 a LabelRowError if the answer already exists.

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -635,7 +635,11 @@ class EncordUserClient:
     def create_ontology(
         self, title: str, description: str = "", structure: Optional[OntologyStructure] = None
     ) -> Ontology:
-        structure_dict = structure.to_dict() if structure else OntologyStructure().to_dict()
+        try:
+            structure_dict = structure.to_dict() if structure else OntologyStructure().to_dict()
+        except ValueError as e:
+            raise ValueError("Can't create an Ontology containing a Classification without any attributes. " + str(e))
+
         ontology = {
             "title": title,
             "description": description,


### PR DESCRIPTION
```
import os
from encord import EncordUserClient
from encord.objects.ontology_structure import OntologyStructure
ont_struct = OntologyStructure()
ont_struct.add_classification()
user_client = EncordUserClient.create_with_ssh_private_key(ssh_private_key_path=os.getenv("ENCORD_SSH_KEY"))
user_client.create_ontology(title="TEST", structure=ont_struct)
```
would previously throw a Network error. This could be prevented SDK side. Most notable thing is where I choose to throw the error, technically this is logic in the serialisation code so a bit grim. We could be checking that len(attributes) > 0 in the create_ontology method but I thought slightly nicer as to keep that code simple.