### PR TITLE
Fix datetime parsing ontology

### DIFF
--- a/encord/orm/ontology.py
+++ b/encord/orm/ontology.py
@@ -55,8 +55,8 @@ class Ontology(dict, Formatter):
                 "title": title,
                 "description": description,
                 "structure": structure,
-                "created_at": datetime.strptime(created_at, "%Y-%m-%d %H:%M:%S"),
-                "last_edited_at": datetime.strptime(last_edited_at, "%Y-%m-%d %H:%M:%S"),
+                "created_at": created_at,
+                "last_edited_at": last_edited_at,
             }
         )
 
@@ -103,6 +103,6 @@ class Ontology(dict, Formatter):
             description=json_dict["description"],
             ontology_hash=json_dict["ontology_hash"],
             structure=OntologyStructure.from_dict(json_dict["editor"]),
-            created_at=json_dict["created_at"],
-            last_edited_at=json_dict["last_edited_at"],
+            created_at=datetime.strptime(json_dict["created_at"], "%Y-%m-%d %H:%M:%S"),
+            last_edited_at=datetime.strptime(json_dict["last_edited_at"], "%Y-%m-%d %H:%M:%S"),
         )

--- a/encord/orm/ontology.py
+++ b/encord/orm/ontology.py
@@ -55,8 +55,8 @@ class Ontology(dict, Formatter):
                 "title": title,
                 "description": description,
                 "structure": structure,
-                "created_at": created_at,
-                "last_edited_at": last_edited_at,
+                "created_at": datetime.strptime(created_at, "%Y-%m-%d %H:%M:%S"),
+                "last_edited_at": datetime.strptime(last_edited_at, "%Y-%m-%d %H:%M:%S"),
             }
         )
 


### PR DESCRIPTION
# Introduction and Explanation
Was sorting ontologies by datetime and realised that despite being typed as datetime, they are strings. I took the parsing code from orm/base_orm line 58. 

# Tests
Not sure where a test would have fitted in. Must be somewhere that's most appropriate. I looked into the fixtures that are provided for basically a mock Ontology response but still find it a bit confusing.