### PR TITLE
Implement item and folder summaries APIs

### DIFF
--- a/encord/orm/storage.py
+++ b/encord/orm/storage.py
@@ -139,11 +139,17 @@ class CustomerProvidedVideoMetadata(BaseDTO):
     """
 
     fps: float
+    """Frame rate of the video in frames per second."""
     duration: float
+    """Video duration in (float) seconds."""
     width: int
+    """Width of the video in pixels."""
     height: int
+    """Height of the video in pixels."""
     file_size: int
+    """Size of the video file in bytes."""
     mime_type: str
+    """MIME type of the video file (e.g. `video/mp4` or `video/webm`)."""
 
 
 class DataUploadImage(BaseDTO):
@@ -263,3 +269,50 @@ class PatchFolderPayload(BaseDTO):
     name: Optional[str] = None
     description: Optional[str] = None
     client_metadata: Optional[dict] = None
+
+
+class StorageFolderSummary(BaseDTO):
+    files: int
+    folders: int
+    videos: int
+    images: int
+    image_groups: int
+    image_sequences: int
+    dicom_files: int
+    dicom_series: int
+    tombstones: int
+    upload_jobs: int
+    total_size: float
+
+
+class ItemShortInfo(BaseDTO):
+    uuid: UUID
+    name: str
+    parent_uuid: UUID
+    parent_name: str
+    item_type: StorageItemType
+
+
+class DatasetShortInfo(BaseDTO):
+    dataset_hash: str
+    backing_folder_uuid: Optional[UUID]
+    title: str
+    data_hashes: List[UUID]
+    data_units_created_at: datetime
+
+
+class StorageItemSummary(BaseDTO):
+    """
+    A summary of item usage in the system
+    """
+
+    frame_in_groups: int
+    """A number of group items (DICOM_SERIES, IMAGE_GROUP, IMAGE_SEQUENCE) that contain this item"""
+    accessible_group_items: List[ItemShortInfo]
+    """List of group items that contain this item (only those that the user has access to,
+    so the length of this list can be less than `frame_in_groups`)"""
+    used_in_datasets: int
+    """A number of datasets that contain this item as a `DataRow`"""
+    accessible_datasets: List[DatasetShortInfo]
+    """List of datasets that contain this item as a `DataRow` (only those that the user has access to, so
+    the length of this list can be less than `used_in_datasets`)"""

--- a/encord/storage.py
+++ b/encord/storage.py
@@ -2,7 +2,6 @@ import json
 import mimetypes
 import os
 import time
-import typing
 from datetime import datetime
 from math import ceil
 from pathlib import Path
@@ -27,6 +26,8 @@ from encord.orm.storage import (
     ListItemsParams,
     PatchFolderPayload,
     PatchItemPayload,
+    StorageFolderSummary,
+    StorageItemSummary,
     StorageItemType,
     UploadSignedUrlsPayload,
 )
@@ -501,6 +502,17 @@ class StorageFolder:
             page_size=page_size,
         )
 
+    def get_summary(self) -> StorageFolderSummary:
+        """
+        Get a summary of the folder (total size, number of items, etc). See :class:`encord.StorageFolderSummary` for
+        exact set of information provided.
+        """
+        return self._api_client.get(
+            f"storage/folders/{self.uuid}/summary",
+            params=None,
+            result_type=StorageFolderSummary,
+        )
+
     def update(
         self,
         name: Optional[str] = None,
@@ -885,6 +897,17 @@ class StorageItem:
     def get_signed_url(self) -> str:
         raise NotImplementedError()
 
+    def get_summary(self) -> StorageItemSummary:
+        """
+        Get a summary of the item (linked datasets, etc.). See :class:`encord.StorageItemSummary` for
+        exact set of information provided.
+        """
+        return self._api_client.get(
+            f"storage/folders/{self.parent_folder_uuid}/items/{self.uuid}/summary",
+            params=None,
+            result_type=StorageItemSummary,
+        )
+
     def update(
         self,
         name: Optional[str] = None,
@@ -892,7 +915,7 @@ class StorageItem:
         client_metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
-        Update the items's modifiable properties. Any parameters that are not provided will not be updated.
+        Update the item's modifiable properties. Any parameters that are not provided will not be updated.
 
         Args:
             name: New item name.


### PR DESCRIPTION
# JIRA

Fixes https://linear.app/encord/issue/EC-2674/folder-detailed-summary-sdk-method
Fixes https://linear.app/encord/issue/EC-3035/item-summary-sdk-methods
# Documentation

Some docstrings are there

# Tests

Coming in here: https://github.com/encord-team/cord-backend/pull/3165
