### PR TITLE
Implement 'get_signed_url' & friends

### DIFF
--- a/encord/orm/storage.py
+++ b/encord/orm/storage.py
@@ -248,6 +248,7 @@ class ListItemsParams(BaseDTO):
     desc: bool
     page_token: Optional[str]
     page_size: int
+    sign_urls: bool
 
 
 class ListFoldersParams(BaseDTO):
@@ -340,3 +341,7 @@ class MoveItemsPayload(BaseDTO):
 class MoveFoldersPayload(BaseDTO):
     folder_uuids: List[UUID]
     new_parent_uuid: Optional[UUID]
+
+
+class GetItemParams(BaseDTO):
+    sign_url: bool

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -837,6 +837,7 @@ class EncordUserClient:
 
     def list_storage_folders(
         self,
+        *,
         search: Optional[str] = None,
         dataset_synced: Optional[bool] = None,
         order: FoldersSortBy = FoldersSortBy.NAME,
@@ -871,6 +872,7 @@ class EncordUserClient:
 
     def find_storage_folders(
         self,
+        *,
         search: Optional[str] = None,
         dataset_synced: Optional[bool] = None,
         order: FoldersSortBy = FoldersSortBy.NAME,
@@ -905,11 +907,13 @@ class EncordUserClient:
 
     def find_storage_items(
         self,
+        *,
         search: Optional[str] = None,
         is_in_dataset: Optional[bool] = None,
         item_types: Optional[List[StorageItemType]] = None,
         order: FoldersSortBy = FoldersSortBy.NAME,
         desc: bool = False,
+        get_signed_urls: bool = False,
         page_size: int = 100,
     ) -> Iterable[StorageItem]:
         """
@@ -923,6 +927,7 @@ class EncordUserClient:
             item_types: Filter items by type.
             order: Sort order.
             desc: Sort in descending order.
+            get_signed_urls: If True, return signed URLs for the items.
             page_size: Number of items to return per page.
 
         At least one of `search` or `item_types` must be provided.
@@ -941,6 +946,7 @@ class EncordUserClient:
             desc=desc,
             page_token=None,
             page_size=page_size,
+            sign_urls=get_signed_urls,
         )
 
         paged_items = self._api_client.get_paged_iterator(


### PR DESCRIPTION
# Introduction and Explanation

Signing URLs in Storage SDK, both 'bulk' when listing items and point-fetch for individual item

# JIRA

Fixes https://linear.app/encord/issue/EC-3052/signed-urls-for-items-sdk-methods

# Documentation

Some docstrings

# Tests

Here: https://github.com/encord-team/cord-backend/pull/3173

# Known issues

If this is actively used, then maybe re-fetching the whole item to get the signed URL is slightly wasteful.