### PR TITLE
Remove the organisation id from the routes for metadata schemas

### DIFF
--- a/encord/client_metadata_schema.py
+++ b/encord/client_metadata_schema.py
@@ -4,9 +4,7 @@ import encord.orm.client_metadata_schema as orm
 from encord.http.v2.api_client import ApiClient
 
 
-def set_client_metadata_schema_from_dict(
-    api_client: ApiClient, organisation_id: int, json_dict: Dict[str, orm.ClientMetadataSchemaTypes]
-):
+def set_client_metadata_schema_from_dict(api_client: ApiClient, json_dict: Dict[str, orm.ClientMetadataSchemaTypes]):
     try:
         validated_dict = {key: orm.ClientMetadataSchemaTypes(val) for key, val in json_dict.items()}
     except ValueError:
@@ -15,16 +13,12 @@ def set_client_metadata_schema_from_dict(
             f"{', '.join([v for v in orm.ClientMetadataSchemaTypes])}."
         )
     payload = orm.ClientMetadataSchemaPayload(metadata_schema=validated_dict)
-    api_client.post(
-        f"organisation/{organisation_id}/client-metadata-schema", params=None, payload=payload, result_type=None
-    )
+    api_client.post("organisation/client-metadata-schema", params=None, payload=payload, result_type=None)
 
 
-def get_client_metadata_schema(
-    api_client: ApiClient, organisation_id: int
-) -> Optional[Dict[str, orm.ClientMetadataSchemaTypes]]:
+def get_client_metadata_schema(api_client: ApiClient) -> Optional[Dict[str, orm.ClientMetadataSchemaTypes]]:
     client_metadata_schema: Optional[orm.ClientMetadataSchema] = api_client.get(
-        f"organisation/{organisation_id}/client-metadata-schema",
+        "organisation/client-metadata-schema",
         params=None,
         result_type=orm.ClientMetadataSchema,
         allow_none=True,

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -958,13 +958,11 @@ class EncordUserClient:
         for item in paged_items:
             yield StorageItem(self._api_client, item)
 
-    def get_client_metadata_schema(self, organisation_id: int) -> Optional[Dict[str, ClientMetadataSchemaTypes]]:
-        return get_client_metadata_schema(self._api_client, organisation_id)
+    def get_client_metadata_schema(self) -> Optional[Dict[str, ClientMetadataSchemaTypes]]:
+        return get_client_metadata_schema(self._api_client)
 
-    def set_client_metadata_schema_from_dict(
-        self, organisation_id: int, json_dict: Dict[str, ClientMetadataSchemaTypes]
-    ):
-        set_client_metadata_schema_from_dict(self._api_client, organisation_id, json_dict)
+    def set_client_metadata_schema_from_dict(self, json_dict: Dict[str, ClientMetadataSchemaTypes]):
+        set_client_metadata_schema_from_dict(self._api_client, json_dict)
 
 
 class ListingFilter(Enum):


### PR DESCRIPTION
# Introduction and Explanation
We don't want to mandate the organisation-id in the route for organisation endpoints
