### PR TITLE
Storage: list child items of image groups and DICOM series

### DIFF
--- a/encord/orm/storage.py
+++ b/encord/orm/storage.py
@@ -345,3 +345,12 @@ class MoveFoldersPayload(BaseDTO):
 
 class GetItemParams(BaseDTO):
     sign_url: bool
+
+
+class GetChildItemsParams(BaseDTO):
+    sign_urls: bool = False
+
+
+class GetItemsBulkPayload(BaseDTO):
+    item_uuids: list[UUID]
+    sign_urls: bool = False

--- a/encord/orm/storage.py
+++ b/encord/orm/storage.py
@@ -352,5 +352,5 @@ class GetChildItemsParams(BaseDTO):
 
 
 class GetItemsBulkPayload(BaseDTO):
-    item_uuids: list[UUID]
+    item_uuids: List[UUID]
     sign_urls: bool = False

--- a/encord/storage.py
+++ b/encord/storage.py
@@ -996,7 +996,7 @@ class StorageItem:
             result_type=StorageItemSummary,
         )
 
-    def get_child_items(self, get_signed_urls: bool = False) -> List["StorageItem"]:
+    def get_child_items(self, get_signed_urls: bool = False) -> Iterable["StorageItem"]:
         """
         Get child items of the item (e.g. frames of an image group or files of DICOM series).
         Only returns those items that are accessible to the user. See also :meth:`.get_summary`.

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -819,7 +819,7 @@ class EncordUserClient:
         """
         return StorageFolder._get_folder(self._api_client, folder_uuid)
 
-    def get_storage_item(self, item_uuid: UUID) -> StorageItem:
+    def get_storage_item(self, item_uuid: UUID, sign_url: bool = False) -> StorageItem:
         """
         Get a storage item by its UUID.
 
@@ -833,7 +833,7 @@ class EncordUserClient:
             :class:`encord.exceptions.AuthorizationError` : If the item with the given UUID does not exist or
                 the user does not have access to it.
         """
-        return StorageItem._get_item(self._api_client, item_uuid)
+        return StorageItem._get_item(self._api_client, item_uuid, sign_url)
 
     def list_storage_folders(
         self,


### PR DESCRIPTION
# Introduction and Explanation

`items.get_child_items()` to return frames of groups&series for now.

# JIRA

Fixes https://linear.app/encord/issue/EC-3069/image-group-and-dicom-series-list-frame-items-sdk-methods

# Documentation

Docstrings

# Tests

SDK integration tests coming in that separate PR

