### PR TITLE
Report cloud upload errors in a more structured way

### DIFF
--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -991,6 +991,24 @@ class LongPollingStatus(str, Enum):
     """
 
 
+class DataUnitError(BaseDTO):
+    """
+    A description of an error for an individual upload item
+    """
+
+    object_urls: List[str]
+    """URLs involved. A single item for videos and images; a list of frames for image groups and DICOM"""
+
+    error: str
+    """The error message"""
+
+    subtask_uuid: UUID
+    """Opaque ID of the process. Please quote this when contacting Encord support."""
+
+    action_description: str
+    """Human-readable description of the action that failed (e.g. 'Uploading DICOM series'."""
+
+
 class DatasetDataLongPolling(BaseDTO):
     """
     Response of the upload job's long polling request.
@@ -1007,6 +1025,9 @@ class DatasetDataLongPolling(BaseDTO):
 
     errors: List[str]
     """Stringified list of exceptions."""
+
+    data_units_errors: Optional[List[DataUnitError]]
+    """Structured list of per-item upload errors. See :class:`DataUnitError` for more details."""
 
     units_pending_count: int
     """Number of upload job units that have pending status."""

--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -1026,7 +1026,7 @@ class DatasetDataLongPolling(BaseDTO):
     errors: List[str]
     """Stringified list of exceptions."""
 
-    data_units_errors: Optional[List[DataUnitError]] = None
+    data_units_errors: List[DataUnitError]
     """Structured list of per-item upload errors. See :class:`DataUnitError` for more details."""
 
     units_pending_count: int

--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -976,11 +976,11 @@ class LongPollingStatus(str, Enum):
     """
     Job has finished successfully (possibly with errors if `ignore_errors=True`).
 
-    If `ignore_errors=False` was specified in :meth:`encord.dataset.Dataset.add_private_data_to_dataset_start`
-    , job will only have the status `DONE` if there were no errors.
+    If `ignore_errors=False` was specified in :meth:`encord.dataset.Dataset.add_private_data_to_dataset_start,
+    the job will only have the status `DONE` if there were no errors.
 
-    If `ignore_errors=True` was specified in :meth:`encord.dataset.Dataset.add_private_data_to_dataset_start`
-    , job will always show the status `DONE` once complete and will never show `ERROR`
+    If `ignore_errors=True` was specified in :meth:`encord.dataset.Dataset.add_private_data_to_dataset_start`,
+    the job will always show the status `DONE` once complete and will never show `ERROR`
     status if this flag was set to `True`. There could be errors that were ignored.
 
     Information about number of errors and stringified exceptions is available in the

--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -974,12 +974,15 @@ class LongPollingStatus(str, Enum):
 
     DONE = "DONE"
     """
-    Job has finished successfully (possibly with errors if `ignore_errors=True`)
+    Job has finished successfully (possibly with errors if `ignore_errors=True`).
+
     If `ignore_errors=False` was specified in :meth:`encord.dataset.Dataset.add_private_data_to_dataset_start`
     , job will only have the status `DONE` if there were no errors.
+
     If `ignore_errors=True` was specified in :meth:`encord.dataset.Dataset.add_private_data_to_dataset_start`
     , job will always show the status `DONE` once complete and will never show `ERROR`
     status if this flag was set to `True`. There could be errors that were ignored.
+
     Information about number of errors and stringified exceptions is available in the
     `units_error_count: int` and `errors: List[str]` attributes.
     """

--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -1026,7 +1026,7 @@ class DatasetDataLongPolling(BaseDTO):
     errors: List[str]
     """Stringified list of exceptions."""
 
-    data_units_errors: List[DataUnitError]
+    data_unit_errors: List[DataUnitError]
     """Structured list of per-item upload errors. See :class:`DataUnitError` for more details."""
 
     units_pending_count: int

--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -1026,7 +1026,7 @@ class DatasetDataLongPolling(BaseDTO):
     errors: List[str]
     """Stringified list of exceptions."""
 
-    data_units_errors: Optional[List[DataUnitError]]
+    data_units_errors: Optional[List[DataUnitError]] = None
     """Structured list of per-item upload errors. See :class:`DataUnitError` for more details."""
 
     units_pending_count: int

--- a/tests/orm/test_base_dto.py
+++ b/tests/orm/test_base_dto.py
@@ -74,6 +74,7 @@ def test_complex_model_deserialization():
         "data_hashes_with_titles": [
             {"data_hash": "abc", "title": "dummy title", "backing_item_uuid": str(backing_item_uuid)}
         ],
+        "data_units_errors": [],
     }
 
     model = DatasetDataLongPolling.from_dict(data_dict)

--- a/tests/orm/test_base_dto.py
+++ b/tests/orm/test_base_dto.py
@@ -74,7 +74,7 @@ def test_complex_model_deserialization():
         "data_hashes_with_titles": [
             {"data_hash": "abc", "title": "dummy title", "backing_item_uuid": str(backing_item_uuid)}
         ],
-        "data_units_errors": [],
+        "data_unit_errors": [],
     }
 
     model = DatasetDataLongPolling.from_dict(data_dict)


### PR DESCRIPTION
# Introduction and Explanation

Right now, we have `.errors` in the upload result object, but it's all just strings. Return a bit more data so that at least the failed URLs are machine readable.

# JIRA

Fixes https://linear.app/encord/issue/EC-3107/report-upload-errors-to-the-sdk-in-a-reasonably-machine-readable

# Documentation
Some dosctrings are there

# Tests

Coming together with the BE implementation here: https://github.com/encord-team/cord-backend/pull/3206
# Known issues

We'll need to do the same on the `Storage` side; will have a follow-up probably next week.