### PR TITLE
Allow for uploads to dynamic datasets by specifying a folder to store the item

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -44,7 +44,7 @@ import uuid
 from datetime import datetime
 from math import ceil
 from pathlib import Path
-from typing import Iterable, List, Optional, Tuple, Union, cast
+from typing import Dict, Iterable, List, Optional, Tuple, Union, cast
 
 import requests
 
@@ -73,7 +73,6 @@ from encord.http.v2.payloads import Page
 from encord.orm.analytics import (
     CollaboratorTimer,
     CollaboratorTimerParams,
-    CollaboratorTimersGroupBy,
 )
 from encord.orm.api_key import ApiKeyMeta
 from encord.orm.bearer_request import BearerTokenResponse
@@ -512,7 +511,7 @@ class EncordClientDataset(EncordClient):
         title: Optional[str] = None,
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
         folder_uuid: Optional[uuid.UUID] = None,
-    ):
+    ) -> Dict:
         """
         This function is documented in :meth:`encord.dataset.Dataset.create_dicom_series`.
         """
@@ -550,7 +549,7 @@ class EncordClientDataset(EncordClient):
         if not res:
             raise encord.exceptions.EncordException(message="An error has occurred during the DICOM series creation.")
 
-        return DicomSeries(**res)
+        return res
 
     def upload_image(
         self,

--- a/encord/client.py
+++ b/encord/client.py
@@ -443,7 +443,8 @@ class EncordClientDataset(EncordClient):
         file_path: str,
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
         title: Optional[str] = None,
-    ):
+        folder_uuid: Optional[uuid.UUID] = None,
+    ) -> Video:
         """
         This function is documented in :meth:`encord.dataset.Dataset.upload_video`.
         """
@@ -451,10 +452,10 @@ class EncordClientDataset(EncordClient):
             signed_urls = upload_to_signed_url_list(
                 [file_path], self._config, self._querier, Video, cloud_upload_settings=cloud_upload_settings
             )
-            res = upload_video_to_encord(signed_urls[0], title, self._querier)
+            res = upload_video_to_encord(signed_urls[0], title, folder_uuid, self._querier)
             if res:
                 logger.info("Upload complete.")
-                return res
+                return Video(res)
             else:
                 raise encord.exceptions.EncordException(message="An error has occurred during video upload.")
         else:
@@ -468,7 +469,8 @@ class EncordClientDataset(EncordClient):
         title: Optional[str] = None,
         *,
         create_video: bool = True,
-    ):
+        folder_uuid: Optional[uuid.UUID] = None,
+    ) -> List[ImageGroup]:
         """
         This function is documented in :meth:`encord.dataset.Dataset.create_image_group`.
         """
@@ -484,19 +486,23 @@ class EncordClientDataset(EncordClient):
         upload_images_to_encord(successful_uploads, self._querier)
 
         image_hash_list = [successful_upload.get("data_hash") for successful_upload in successful_uploads]
+        payload = {
+            "image_group_title": title,
+            "create_video": create_video,
+        }
+        if folder_uuid is not None:
+            payload["folder_uuid"] = str(folder_uuid)
+
         res = self._querier.basic_setter(
             ImageGroup,
             uid=image_hash_list,  # type: ignore
-            payload={
-                "image_group_title": title,
-                "create_video": create_video,
-            },
+            payload=payload,
         )
 
         if res:
             titles = [video_data.get("title") for video_data in res]
             logger.info(f"Upload successful! {titles} created.")
-            return res
+            return [ImageGroup(obj) for obj in res]
         else:
             raise encord.exceptions.EncordException(message="An error has occurred during image group creation.")
 
@@ -505,6 +511,7 @@ class EncordClientDataset(EncordClient):
         file_paths: List[str],
         title: Optional[str] = None,
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
+        folder_uuid: Optional[uuid.UUID] = None,
     ):
         """
         This function is documented in :meth:`encord.dataset.Dataset.create_dicom_series`.
@@ -532,17 +539,25 @@ class EncordClientDataset(EncordClient):
             for file in successful_uploads
         ]
 
-        res = self._querier.basic_setter(DicomSeries, uid=dicom_files, payload={"title": title})
+        payload = {
+            "title": title,
+        }
+
+        if folder_uuid is not None:
+            payload["folder_uuid"] = str(folder_uuid)
+
+        res = self._querier.basic_setter(DicomSeries, uid=dicom_files, payload=payload)
         if not res:
             raise encord.exceptions.EncordException(message="An error has occurred during the DICOM series creation.")
 
-        return res
+        return DicomSeries(**res)
 
     def upload_image(
         self,
         file_path: Union[Path, str],
         title: Optional[str] = None,
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
+        folder_uuid: Optional[uuid.UUID] = None,
     ) -> Image:
         """
         This function is documented in :meth:`encord.dataset.Dataset.upload_image`.
@@ -559,6 +574,8 @@ class EncordClientDataset(EncordClient):
             raise encord.exceptions.EncordException("Image upload failed.")
 
         upload = successful_uploads[0]
+        if folder_uuid is not None:
+            upload["folder_uuid"] = str(folder_uuid)
         if title is not None:
             upload["title"] = title
 
@@ -619,6 +636,7 @@ class EncordClientDataset(EncordClient):
         integration_id: str,
         private_files: Union[str, typing.Dict, Path, typing.TextIO],
         ignore_errors: bool = False,
+        folder_uuid: Optional[uuid.UUID] = None,
     ) -> str:
         """
         This function is documented in :meth:`encord.dataset.Dataset.add_private_data_to_dataset_start`.
@@ -641,14 +659,18 @@ class EncordClientDataset(EncordClient):
         else:
             raise ValueError(f"Type [{type(private_files)}] of argument private_files is not supported")
 
+        payload = {
+            "files": files,
+            "integration_id": integration_id,
+            "ignore_errors": ignore_errors,
+        }
+        if folder_uuid is not None:
+            payload["folder_uuid"] = str(folder_uuid)
+
         process_hash = self._querier.basic_setter(
             DatasetDataLongPolling,
             self._querier.resource_id,
-            payload={
-                "files": files,
-                "integration_id": integration_id,
-                "ignore_errors": ignore_errors,
-            },
+            payload=payload,
         )["process_hash"]
 
         print(f"add_private_data_to_dataset job started with upload_job_id={process_hash}.")

--- a/encord/dataset.py
+++ b/encord/dataset.py
@@ -264,7 +264,7 @@ class Dataset:
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
         title: Optional[str] = None,
         folder: Optional[Union[UUID, StorageFolder]] = None,
-    ):
+    ) -> Dict:
         """
         Upload a DICOM series to Encord storage
 
@@ -280,7 +280,7 @@ class Dataset:
                 When uploading to a non-mirror dataset, you have to specify the folder to store the file in.
                 This can be either a :class:`encord.storage.Folder` instance or the UUID of the folder.
         Returns:
-            Bool.
+            A dictionary describing the created series.
 
         Raises:
             UploadOperationNotSupportedError: If trying to upload to external

--- a/encord/http/utils.py
+++ b/encord/http/utils.py
@@ -3,6 +3,7 @@ import mimetypes
 import os.path
 from dataclasses import dataclass
 from typing import Iterable, List, Optional, Type, Union
+from uuid import UUID
 
 from tqdm import tqdm
 
@@ -101,7 +102,10 @@ def upload_to_signed_url_list(
 
 
 def upload_video_to_encord(
-    signed_url: Union[SignedVideoURL, SignedImageURL, SignedDicomURL], video_title: Optional[str], querier: Querier
+    signed_url: Union[SignedVideoURL, SignedImageURL, SignedDicomURL],
+    video_title: Optional[str],
+    folder_uuid: Optional[UUID],
+    querier: Querier,
 ) -> Video:
     payload = {
         "signed_url": signed_url["signed_url"],
@@ -110,6 +114,9 @@ def upload_video_to_encord(
         "file_link": signed_url["file_link"],
         "video_title": video_title,
     }
+    if folder_uuid is not None:
+        payload["folder_uuid"] = str(folder_uuid)
+
     return querier.basic_put(
         Video,
         uid=signed_url.get("data_hash"),


### PR DESCRIPTION
# Introduction and Explanation

Allow for "wrong side" uploads, so that people who have pre-existing upload scripts can make fewer changes as they onboard to 'files&folders'

# JIRA

Fixes https://linear.app/encord/issue/EC-3381/allow-for-uploads-to-free-form-datasets-via-sdk-add-parameter-to-the

# Documentation

Some docstrings; will need publishing when released.

# Tests

Coming with the BE implementation in a separate PR

