### PR TITLE
Fix some minor typing issues

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -508,7 +508,7 @@ class EncordClientDataset(EncordClient):
 
     def create_dicom_series(
         self,
-        file_paths: typing.Collection[Union[Path, str]],
+        file_paths: Union[typing.Collection[str], typing.Collection[Path], typing.Collection[Union[str, Path]]],
         title: Optional[str] = None,
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
         folder_uuid: Optional[uuid.UUID] = None,
@@ -1087,7 +1087,7 @@ class EncordClientProject(EncordClient):
         }
         return self._querier.basic_setter(LabelRow, uid=uids, payload=multirequest_payload, retryable=True)
 
-    def create_label_row(self, uid, *, get_signed_url=False) -> typing.Any:
+    def create_label_row(self, uid, *, get_signed_url=False) -> LabelRow:
         """
         This function is documented in :meth:`encord.project.Project.create_label_row`.
         """

--- a/encord/dataset.py
+++ b/encord/dataset.py
@@ -303,7 +303,7 @@ class Dataset:
 
     def create_dicom_series(
         self,
-        file_paths: Collection[Union[Path, str]],
+        file_paths: Union[Collection[str], Collection[Path], Collection[Union[Path, str]]],
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
         title: Optional[str] = None,
         folder: Optional[Union[UUID, StorageFolder]] = None,

--- a/encord/http/utils.py
+++ b/encord/http/utils.py
@@ -62,10 +62,11 @@ class CloudUploadSettings:
 
 
 def _get_content_type(
-    orm_class: Union[Type[Images], Type[Video], Type[DicomSeries], Type[Audio]], file_path: str
+    orm_class: Union[Type[Images], Type[Video], Type[DicomSeries], Type[Audio]], file_path: Union[str
+, Path]
 ) -> Optional[str]:
     if orm_class == Images:
-        return mimetypes.guess_type(file_path)[0]
+        return mimetypes.guess_type(str(file_path))[0]
     elif orm_class == Video or orm_class == Audio:
         return "application/octet-stream"
     elif orm_class == DicomSeries:

--- a/encord/http/utils.py
+++ b/encord/http/utils.py
@@ -62,8 +62,7 @@ class CloudUploadSettings:
 
 
 def _get_content_type(
-    orm_class: Union[Type[Images], Type[Video], Type[DicomSeries], Type[Audio]], file_path: Union[str
-, Path]
+    orm_class: Union[Type[Images], Type[Video], Type[DicomSeries], Type[Audio]], file_path: Union[str, Path]
 ) -> Optional[str]:
     if orm_class == Images:
         return mimetypes.guess_type(str(file_path))[0]

--- a/encord/storage.py
+++ b/encord/storage.py
@@ -1676,7 +1676,7 @@ class StorageItem:
         self,
         target_folder: Union[StorageFolder, UUID],
         allow_mirror_dataset_changes: bool = False,
-    ):
+    ) -> None:
         """
         Move the item to another folder.
 

--- a/tests/objects/test_label_structure.py
+++ b/tests/objects/test_label_structure.py
@@ -449,7 +449,7 @@ def test_classification_index_answer_overwrite():
     assert classification_instance.get_answer() == "Aphrodite"
 
 
-def test_classification_answering_with_ontology_access():
+def test_classification_answering_with_ontology_access() -> None:
     """A demonstrative test to show how easy it would be for clients to use the ontology to answer classifications"""
 
     # NOTE: it is important to add the `Classification` here, to distinguish between the attribute and classification,
@@ -975,7 +975,7 @@ def test_label_status_forwards_compatibility():
     assert LabelStatus("new-unknown-status").value == "_MISSING_LABEL_STATUS_"
 
 
-def test_frame_view(ontology):
+def test_frame_view(ontology) -> None:
     label_row_metadata_dict = asdict(FAKE_LABEL_ROW_METADATA)
     label_row_metadata_dict["frames_per_second"] = 25
     label_row_metadata_dict["duration"] = 0.2


### PR DESCRIPTION
# Introduction and Explanation

A little tidy-up so that we can declare it `py.typed` and have the `sdk_integration_tests` be properly typed, too.

# Known issues

There are some unfixable-ish issues anyway, but let's fix what's easy to fix.