### PR TITLE
EC-3686 Un-encode url before signing

### DIFF
--- a/encord/http/v2/error_utils.py
+++ b/encord/http/v2/error_utils.py
@@ -12,6 +12,7 @@ HTTP_UNAUTHORIZED = 401
 HTTP_FORBIDDEN = 403
 HTTP_NOT_FOUND = 404
 HTTP_METHOD_NOT_ALLOWED = 405
+HTTP_UNPROCESSABLE_ENTITY = 422
 HTTP_GENERAL_ERROR = 500
 
 
@@ -35,6 +36,9 @@ def handle_error_response(status_code: int, message=None, context=None):
         raise MethodNotAllowedError("HTTP method is not allowed.", context=context)
 
     if status_code == HTTP_BAD_REQUEST:
+        raise InvalidArgumentsError(message or "Provided payload is invalid and can't be processed.", context=context)
+
+    if status_code == HTTP_UNPROCESSABLE_ENTITY:
         raise InvalidArgumentsError(message or "Provided payload is invalid and can't be processed.", context=context)
 
     raise UnknownException(message or "An unknown error occurred.", context=context)

--- a/encord/http/v2/request_signer.py
+++ b/encord/http/v2/request_signer.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 from datetime import datetime
 from typing import Dict, Union
+from urllib.parse import unquote
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from requests import PreparedRequest
@@ -9,8 +10,8 @@ from requests import PreparedRequest
 _SIGNATURE_LABEL = "encord-sig"
 
 """
-This file implements request signing according to the following RFC draft:
-https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-message-signatures
+This file implements request signing according to the following RFC:
+https://datatracker.ietf.org/doc/html/rfc9421
 """
 
 
@@ -50,7 +51,7 @@ def sign_request(request: PreparedRequest, key_id: str, private_key: Ed25519Priv
 
     signature_elements = {
         "@method": request.method.upper(),
-        "@request-target": request.path_url,
+        "@request-target": unquote(request.path_url),
         "content-digest": content_digest,
     }
 


### PR DESCRIPTION
Currently request signing works incorrectly if the URL has any non-ascii symbols, as we're signed not the raw, but url-encoded version of url, taken from the Request object.
Fixing it by un-encoding it before signing.