### PR TITLE
Fix project dataset backward compatibility

### DIFF
--- a/encord/project.py
+++ b/encord/project.py
@@ -121,7 +121,7 @@ class Project:
 
         Get the info about datasets associated with this project.
         """
-        return [project_dataset.to_dict() for project_dataset in self.list_datasets()]
+        return [project_dataset.to_dict(by_alias=False) for project_dataset in self.list_datasets()]
 
     @property
     def project_type(self) -> ProjectType:


### PR DESCRIPTION
Fixing accidental naming of values when `project.datasets` is called