### PR TITLE
Expose some "newer" ontology features

### DIFF
--- a/encord/objects/attributes.py
+++ b/encord/objects/attributes.py
@@ -92,7 +92,7 @@ class Attribute(OntologyNestedElement, Generic[OptionType]):
         ret: Dict[str, Any] = dict()
         ret["id"] = _decode_nested_uid(self.uid)
         ret["name"] = self.name
-        ret["type"] = self.get_property_type()
+        ret["type"] = self.get_property_type().value
         ret["featureNodeHash"] = self.feature_node_hash
         ret["required"] = self.required
         ret["dynamic"] = self.dynamic

--- a/encord/objects/ontology_object.py
+++ b/encord/objects/ontology_object.py
@@ -21,7 +21,7 @@ class Object(OntologyElement):
     color: str
     shape: Shape
     feature_node_hash: str
-    required: bool
+    required: bool = False
     attributes: List[Attribute] = field(default_factory=list)
 
     @property

--- a/encord/objects/ontology_object.py
+++ b/encord/objects/ontology_object.py
@@ -21,6 +21,7 @@ class Object(OntologyElement):
     color: str
     shape: Shape
     feature_node_hash: str
+    required: bool
     attributes: List[Attribute] = field(default_factory=list)
 
     @property
@@ -51,6 +52,7 @@ class Object(OntologyElement):
             shape=shape_opt,
             feature_node_hash=d["featureNodeHash"],
             attributes=attributes_ret,
+            required=bool(d.get("required", False)),
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -60,6 +62,7 @@ class Object(OntologyElement):
             "color": self.color,
             "shape": self.shape.value,
             "featureNodeHash": self.feature_node_hash,
+            "required": self.required,
         }
         if attributes_list := attributes_to_list_dict(self.attributes):
             ret["attributes"] = attributes_list

--- a/tests/objects/data/editor_blob.json
+++ b/tests/objects/data/editor_blob.json
@@ -5,7 +5,8 @@
             "name": "Eye",
             "color": "#D33115",
             "shape": "bounding_box",
-            "featureNodeHash": "a55abbeb"
+            "featureNodeHash": "a55abbeb",
+            "required": false
         },
         {
             "id": "2",
@@ -13,6 +14,7 @@
             "color": "#E27300",
             "shape": "polygon",
             "featureNodeHash": "86648f32",
+            "required": false,
             "attributes": [
                 {
                     "id": "2.1",
@@ -44,6 +46,7 @@
             "color": "#FE9200",
             "shape": "polyline",
             "featureNodeHash": "6eeba59b",
+            "required": false,
             "attributes": [
                 {
                     "id": "4.1",


### PR DESCRIPTION
# Introduction and Explanation

Somehow one of our tests kinda relies on "ontology JSON" being a pass-through into the DB, which isn't true anymore (we're re-serialising stuff from/to some models).

Fix the `from_dict()` and `to_dict()` to match reality.

See also the PR in the tests: https://github.com/encord-team/cord-backend/pull/3314