### PR TITLE
EC-3689 COCO Exporter

### DIFF
--- a/encord/project.py
+++ b/encord/project.py
@@ -1184,6 +1184,45 @@ class Project:
             branch_name=branch_name,
         )
 
+    def export_coco_labels(
+        self,
+        label_hashes: Optional[List[str]] = None,
+        include_object_feature_hashes: Optional[Set[str]] = None,
+        include_classification_feature_hashes: Optional[Set[str]] = None,
+        branch_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Export labels from the project to the COCO format.
+        This method requires the 'coco' extra to be installed. Install it using:
+        `pip install encord[coco]`.
+        Args:
+            label_hashes: List of label hashes to include. If not provided, all label rows will be included.
+            include_object_feature_hashes: If `None`, all objects will be included.
+                 Otherwise, only objects with the specified feature hashes will be included.
+            include_classification_feature_hashes: If `None`, all classifications will be included.
+                Otherwise, only classifications with the specified feature hashes will be included.
+            branch_name: Optionally specify a branch name. Defaults to the `main` branch.
+        Returns:
+            Dict[str, Any]: A dictionary in the COCO format containing the exported labels,
+                including annotations and metadata conforming to COCO standards.
+                The dictionary also includes additional fields specific to Encord,
+                providing supplementary information not defined in the COCO standard.
+        Raises:
+            ImportError: If the 'coco' extra dependencies are not installed.
+        """
+        from encord.utilities.coco.exporter import CocoExporter
+
+        label_rows = self.list_label_rows_v2(label_hashes=label_hashes, branch_name=branch_name)
+        with self.create_bundle() as bundle:
+            for row in label_rows:
+                row.initialise_labels(
+                    include_object_feature_hashes=include_object_feature_hashes,
+                    include_classification_feature_hashes=include_classification_feature_hashes,
+                    bundle=bundle,
+                )
+        labels = [row.to_encord_dict() for row in label_rows]
+        coco_labels = CocoExporter(labels, ontology=self.ontology_structure).export()
+        return coco_labels
+
     def get_collection(self, collection_uuid: Union[str, UUID]) -> ProjectCollection:
         return ProjectCollection._get_collection(
             project_client=self._client,

--- a/encord/utilities/coco/exporter.py
+++ b/encord/utilities/coco/exporter.py
@@ -1,0 +1,1029 @@
+try:
+    import pycocotools
+    import shapely
+except ImportError as e:
+    raise ImportError(
+        "The 'pycocotools' and 'shapely' packages are required for the COCO export. "
+        "Install them with: `pip install encord[coco]`"
+    ) from e
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from itertools import chain
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import numpy as np
+from pycocotools import mask as cocomask
+from pydantic import BaseModel
+from shapely.geometry import Polygon
+
+from encord.exceptions import EncordException
+from encord.objects.attributes import Attribute
+from encord.objects.common import PropertyType, Shape
+from encord.objects.ontology_object import Object
+from encord.objects.ontology_structure import OntologyStructure
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DicomAnnotationData:
+    dicom_instance_uid: str
+    multiframe_frame_number: Optional[int]  # only present for multi-frame DICOMs
+    file_uri: str
+    width: int
+    height: int
+
+
+class CocoAnnotation(BaseModel):
+    area: float
+    bbox: Tuple[float, float, float, float]
+    category_id: int
+    id_: int
+    image_id: int
+    is_crowd: int
+    segmentation: Union[List[List[float]], Dict[str,Any]]
+    keypoints: Optional[List[float]] = None
+    num_keypoints: Optional[int] = None
+    track_id: Optional[int] = None
+    encord_track_uuid: Optional[str] = None
+    rotation: Optional[float] = None
+    classifications: Optional[Dict[str,Any]] = None
+    manual_annotation: Optional[bool] = None
+
+    def to_dict(self) -> Dict[str,Any]:
+        return {
+            "area": self.area,
+            "bbox": list(self.bbox),
+            "category_id": self.category_id,
+            "image_id": self.image_id,
+            "iscrowd": self.is_crowd,
+            "segmentation": self.segmentation,
+            "keypoints": self.keypoints,
+            "num_keypoints": self.num_keypoints,
+            "id": self.id_,
+            "attributes": {
+                k: v
+                for k, v in {
+                    "track_id": self.track_id,
+                    "encord_track_uuid": self.encord_track_uuid,
+                    "rotation": self.rotation,
+                    "classifications": self.classifications,
+                    "manual_annotation": self.manual_annotation,
+                }.items()
+                if v is not None
+            },
+        }
+
+
+@dataclass
+class Size:
+    width: int
+    height: int
+
+
+def get_polygon_from_dict(
+    polygon_dict: Dict[str, Any],
+    w: int,
+    h: int,
+) -> List[Tuple[float, float]]:
+    return [
+        (
+            polygon_dict[str(i)]["x"] * w,
+            polygon_dict[str(i)]["y"] * h,
+        )
+        for i in range(len(polygon_dict))
+    ]
+
+
+class CocoExporter:
+    """
+    This class is intentionally designed in a modular fashion to facilitate extensibility.
+    You are encouraged to subclass this exporter and modify any of the custom functions.
+    While return types are provided for convenience, they can also be subclassed to suit your specific requirements.
+    All functions that could be static are intentionally not made static, allowing you the option to access the `self`
+    object at any time.
+    """
+
+    def __init__(
+        self,
+        labels_list: List[Dict[str,Any]],
+        ontology: OntologyStructure,
+        include_videos: bool = True,
+    ) -> None:
+        self._labels_list = labels_list
+        self._ontology = ontology
+        self._coco_json: Dict[str,Any] = {}
+        self._current_annotation_id = 0
+        self._object_hash_to_track_id_map: Dict[str, int] = {}
+        self._coco_categories_id_to_ontology_object_map: Dict = {}  # TODO: do we need this?
+        self._feature_hash_to_coco_category_id_map: Dict[str, int] = {}
+        self._data_hash_to_image_id_map: Dict[Tuple[str, int], int] = {}
+        """Map of (data_hash, frame_offset) to the image id"""
+
+        self._feature_hash_to_attribute_map: Optional[Dict[str, Attribute]] = None
+        self._id_and_object_hash_to_answers_map: Optional[Dict[Tuple[int, str], Dict]] = None
+        self._include_videos = include_videos
+
+    def export(self) -> Dict[str,Any]:
+        self._coco_json["info"] = self.get_info()
+        self._coco_json["categories"] = self.get_categories()
+        self._coco_json["images"] = self.get_images()
+        self._coco_json["annotations"] = [x.to_dict() for x in self.get_all_annotations()]
+
+        return self._coco_json
+
+    def get_info(self) -> Dict[str,Optional[str]]:
+        return {
+            "description": self.get_description(),
+            "contributor": None,  # TODO: these fields also need a response
+            "date_created": None,
+            # TODO: there is something in the labels, alternatively can start to return more from the SDK
+            "url": None,
+            "version": None,
+            "year": None,
+        }
+
+    def get_description(self) -> Optional[str]:
+        if len(self._labels_list) == 0:
+            res: Optional[str] = None
+        else:
+            res = str(self._labels_list[0]["data_title"])
+
+        return res
+
+    def get_categories(self) -> List[Dict]:
+        """This does not translate classifications as they are not part of the Coco spec."""
+        categories = []
+        for object_ in self._ontology.objects:
+            categories.append(self.get_category(object_))
+
+        return categories
+
+    def get_category(self, object_: Object) -> Dict[str, Any]:
+        super_category = self.get_super_category(object_)
+        ret: Dict[str, Any] = {
+            "supercategory": super_category,
+            "id": self.add_to_object_map_and_get_next_id(object_),
+            "name": self.get_category_name(object_),
+        }
+
+        if super_category == "point":
+            # TODO: we will have to do something similar for skeletons.
+            ret["keypoints"] = "keypoint"
+            ret["skeleton"] = []
+
+        return ret
+
+    def get_super_category(self, object_: Object) -> str:
+        return object_.shape.value
+
+    def add_to_object_map_and_get_next_id(self, object_: Object) -> int:
+        id_ = len(self._coco_categories_id_to_ontology_object_map) + 1
+        # Let the category id start at 1, not 0. Segmentation masks that use COCO annotations often create a bitmask
+        # with this category id. The bitmask must be above 0. See this link:
+        # https://cocodataset.org/#stuff-eval
+        self._coco_categories_id_to_ontology_object_map[id_] = object_
+        self._feature_hash_to_coco_category_id_map[object_.feature_node_hash] = id_
+
+        return id_
+
+    def get_category_name(self, object_: Object) -> str:
+        return object_.name
+
+    def get_images(self) -> List:
+        """All the data is in the specific label_row"""
+        images = []
+
+        for labels in self._labels_list:
+            for data_unit in labels["data_units"].values():
+                data_type = data_unit["data_type"]
+                if "application/dicom" in data_type:
+                    images.extend(self.get_dicom(data_unit))
+                elif "video" not in data_type:
+                    images.append(self.get_image(data_unit))
+                else:
+                    images.extend(self.get_video_images(data_unit))
+
+        return images
+
+    def get_dicom(self, data_unit: Dict) -> List:
+        return [
+            self._dicom_label_to_coco_image(
+                int(key), data_unit["data_hash"], data_unit["width"], data_unit["height"], label
+            )
+            for key, label in data_unit["labels"].items()
+        ]
+
+    def get_image(self, data_unit: Dict) -> Dict:
+        # TODO: we probably want a map of this image id to image hash in our DB, including the image_group hash.
+
+        """
+        TODO: next up: here we need to branch off and create the videos
+        * coco_url, height, width will be the same
+        * id will be continuous
+        * file_name will be also continuous according to all the images that are being extracted from the video.
+        Do all the frames, and the ones without annotations will just have no corresponding annotations. We can
+        still later have an option to exclude them and delete the produced images.
+        """
+        image_id = len(self._data_hash_to_image_id_map)
+        data_hash = data_unit["data_hash"]
+        self._data_hash_to_image_id_map[(data_hash, 0)] = image_id
+
+        return {
+            "coco_url": data_unit["data_link"],
+            "id": image_id,
+            "image_title": data_unit["data_title"],
+            "file_name": f'images/{data_unit["data_hash"]}.{data_unit["data_title"].split(".")[-1]}',
+            "height": data_unit["height"],
+            "width": data_unit["width"],
+        }
+
+    def get_video_images(self, data_unit: Dict) -> List[Dict]:
+        if not self._include_videos:
+            return []
+
+        video_title = data_unit["data_title"]
+        data_hash = data_unit["data_hash"]
+
+        images = []
+        coco_url = data_unit["data_link"]
+        height = data_unit["height"]
+        width = data_unit["width"]
+
+        for frame_num in data_unit["labels"].keys():
+            images.append(
+                self.get_video_image(
+                    data_hash,
+                    video_title,
+                    coco_url,
+                    height,
+                    width,
+                    int(frame_num),
+                )
+            )
+
+        return images
+
+    def _dicom_label_to_coco_image(
+        self, frame: int, data_hash: str, series_width: int, series_height: int, dicom_label: Dict
+    ) -> Dict:
+        image_id = len(self._data_hash_to_image_id_map)
+        # ideally this should be verify_arg, but currently we can't be sure that the metadata is on every frame
+        metadata = dicom_label.get("metadata")
+        self._data_hash_to_image_id_map[(data_hash, frame)] = image_id
+        if metadata:
+            file_name = f"dicom/{data_hash}/{metadata.dicom_instance_uid}"
+            if metadata.multiframe_frame_number is not None:
+                file_name += f"/{metadata.multiframe_frame_number}"
+
+            return {
+                "coco_url": metadata.file_uri,
+                "id": image_id,
+                "file_name": file_name,
+                "height": metadata.height,
+                "width": metadata.width,
+            }
+        else:
+            return {
+                "coco_url": "",
+                "id": image_id,
+                "file_name": f"dicom/{data_hash}/{frame}",
+                "height": series_height,
+                "width": series_width,
+            }
+
+    def get_video_image(
+        self,
+        data_hash: str,
+        video_title: str,
+        coco_url: str,
+        height: int,
+        width: int,
+        frame_num: int,
+    ) -> Dict:
+        image_id = len(self._data_hash_to_image_id_map)
+        self._data_hash_to_image_id_map[(data_hash, frame_num)] = image_id
+
+        return {
+            "coco_url": coco_url,
+            "id": image_id,
+            "video_title": video_title,
+            "file_name": f"videos/{data_hash}/{frame_num}.jpg",
+            "height": height,
+            "width": width,
+        }
+
+    def get_all_annotations(self) -> List[CocoAnnotation]:
+        annotations = []
+
+        # TODO: need to make sure at least one image
+        for labels in self._labels_list:
+            object_answers = labels["object_answers"]
+            object_actions = labels["object_actions"]
+
+            for data_unit in labels["data_units"].values():
+                data_hash = data_unit["data_hash"]
+
+                if "video" in data_unit["data_type"]:
+                    if not self._include_videos:
+                        continue
+                    for frame_num, frame_item in data_unit["labels"].items():
+                        image_id = self.get_image_id(data_hash, int(frame_num))
+                        objects = frame_item["objects"]
+                        annotations.extend(
+                            self.get_annotations(
+                                objects,
+                                image_id,
+                                object_answers,
+                                object_actions,
+                            )
+                        )
+
+                elif "application/dicom" in data_unit["data_type"]:
+                    # copy pasta:
+                    for frame_num, frame_item in data_unit["labels"].items():
+                        image_id = self.get_image_id(data_hash, int(frame_num))
+                        objects = frame_item["objects"]
+                        annotations.extend(
+                            self.get_annotations(
+                                objects,
+                                image_id,
+                                object_answers,
+                                object_actions,
+                            )
+                        )
+
+                else:
+                    image_id = self.get_image_id(data_hash)
+                    objects = data_unit["labels"].get("objects") or []
+                    annotations.extend(
+                        self.get_annotations(
+                            objects,
+                            image_id,
+                            object_answers,
+                            object_actions,
+                        )
+                    )
+
+        return annotations
+
+    def get_annotations(
+        self,
+        objects: List[Dict],
+        image_id: int,
+        object_answers: Dict,
+        object_actions: Dict,
+    ) -> List[CocoAnnotation]:
+        annotations = []
+
+        for object_ in objects:
+            shape = object_["shape"]
+
+            for image_data in self._coco_json["images"]:
+                if image_data["id"] == image_id:
+                    size = Size(width=image_data["width"], height=image_data["height"])
+
+            if shape == Shape.BOUNDING_BOX.value:
+                annotations.append(
+                    self.get_bounding_box(
+                        object_,
+                        image_id,
+                        size,
+                        object_answers,
+                        object_actions,
+                    )
+                )
+            elif shape == Shape.ROTATABLE_BOUNDING_BOX.value:
+                annotations.append(
+                    self.get_rotatable_bounding_box(
+                        object_,
+                        image_id,
+                        size,
+                        object_answers,
+                        object_actions,
+                    )
+                )
+            elif shape == Shape.POLYGON.value:
+                annotations.append(
+                    self.get_polygon(
+                        object_,
+                        image_id,
+                        size,
+                        object_answers,
+                        object_actions,
+                    )
+                )
+            elif shape == Shape.POLYLINE.value:
+                annotations.append(
+                    self.get_polyline(
+                        object_,
+                        image_id,
+                        size,
+                        object_answers,
+                        object_actions,
+                    )
+                )
+            elif shape == Shape.BITMASK.value:
+                annotations.append(
+                    self.get_bitmask(
+                        object_,
+                        image_id,
+                        size,
+                        object_answers,
+                        object_actions,
+                    )
+                )
+            elif shape == Shape.POINT.value:
+                annotations.append(
+                    self.get_point(
+                        object_,
+                        image_id,
+                        size,
+                        object_answers,
+                        object_actions,
+                    )
+                )
+            elif shape == Shape.SKELETON.value:
+                annotations.append(
+                    self.get_skeleton(
+                        object_,
+                        image_id,
+                        size,
+                        object_answers,
+                        object_actions,
+                    )
+                )
+
+        return annotations
+
+    def get_bounding_box(
+        self,
+        object_: Dict,
+        image_id: int,
+        size: Size,
+        object_answers: Dict,
+        object_actions: Dict,
+    ) -> CocoAnnotation:
+        x, y = (
+            object_["boundingBox"]["x"] * size.width,
+            object_["boundingBox"]["y"] * size.height,
+        )
+        w, h = (
+            object_["boundingBox"]["w"] * size.width,
+            object_["boundingBox"]["h"] * size.height,
+        )
+        area = w * h
+        segmentation = [[x, y, x + w, y, x + w, y + h, x, y + h]]
+        bbox = (x, y, w, h)
+        category_id = self.get_category_id(object_)
+        id_, is_crowd, track_id, encord_track_uuid, manual_annotation = self.get_coco_annotation_default_fields(object_)
+
+        classifications = self.get_flat_classifications(
+            object_, image_id, object_answers, object_actions
+        )
+
+        return CocoAnnotation(
+            area=area,
+            bbox=bbox,
+            category_id=category_id,
+            id_=id_,
+            image_id=image_id,
+            is_crowd=is_crowd,
+            segmentation=segmentation,
+            keypoints=None,
+            num_keypoints=None,
+            track_id=track_id,
+            encord_track_uuid=encord_track_uuid,
+            rotation=None,
+            classifications=classifications,
+            manual_annotation=manual_annotation,
+        )
+
+    def get_rotatable_bounding_box(
+        self,
+        object_: Dict,
+        image_id: int,
+        size: Size,
+        object_answers: Dict,
+        object_actions: Dict,
+    ) -> CocoAnnotation:
+        x, y = (
+            object_["rotatableBoundingBox"]["x"] * size.width,
+            object_["rotatableBoundingBox"]["y"] * size.height,
+        )
+        w, h = (
+            object_["rotatableBoundingBox"]["w"] * size.width,
+            object_["rotatableBoundingBox"]["h"] * size.height,
+        )
+
+        area = w * h
+        segmentation = [[x, y, x + w, y, x + w, y + h, x, y + h]]
+        bbox = (x, y, w, h)
+        category_id = self.get_category_id(object_)
+        id_, is_crowd, track_id, encord_track_uuid, manual_annotation = self.get_coco_annotation_default_fields(object_)
+
+        rotation = object_["rotatableBoundingBox"]["theta"]
+
+        classifications = self.get_flat_classifications(
+            object_, image_id, object_answers, object_actions
+        )
+
+        return CocoAnnotation(
+            area=area,
+            bbox=bbox,
+            category_id=category_id,
+            id_=id_,
+            image_id=image_id,
+            is_crowd=is_crowd,
+            segmentation=segmentation,
+            keypoints=None,
+            num_keypoints=None,
+            track_id=track_id,
+            encord_track_uuid=encord_track_uuid,
+            rotation=rotation,
+            classifications=classifications,
+            manual_annotation=manual_annotation,
+        )
+
+    def get_polygon(
+        self,
+        object_: Dict,
+        image_id: int,
+        size: Size,
+        object_answers: Dict,
+        object_actions: Dict,
+    ) -> CocoAnnotation:
+        polygon = get_polygon_from_dict(object_["polygon"], size.width, size.height)
+        segmentation = [list(chain(*polygon))]
+        _polygon = Polygon(polygon)
+        area: float = _polygon.area
+        x, y, x_max, y_max = _polygon.bounds
+        w, h = x_max - x, y_max - y
+
+        bbox = (x, y, w, h)
+        category_id = self.get_category_id(object_)
+        id_, is_crowd, track_id, encord_track_uuid, manual_annotation = self.get_coco_annotation_default_fields(object_)
+
+        classifications = self.get_flat_classifications(
+            object_,
+            image_id,
+            object_answers,
+            object_actions,
+        )
+
+        return CocoAnnotation(
+            area=area,
+            bbox=bbox,
+            category_id=category_id,
+            id_=id_,
+            image_id=image_id,
+            is_crowd=is_crowd,
+            segmentation=segmentation,
+            keypoints=None,
+            num_keypoints=None,
+            track_id=track_id,
+            encord_track_uuid=encord_track_uuid,
+            rotation=None,
+            classifications=classifications,
+            manual_annotation=manual_annotation,
+        )
+
+    def get_polyline(
+        self,
+        object_: Dict,
+        image_id: int,
+        size: Size,
+        object_answers: Dict,
+        object_actions: Dict,
+    ) -> CocoAnnotation:
+        """Polylines are technically not supported in COCO, but here we use a trick to allow a representation."""
+        polygon = get_polygon_from_dict(object_["polyline"], size.width, size.height)
+        polyline_coordinate = self.join_polyline_from_polygon(list(chain(*polygon)))
+        segmentation = [polyline_coordinate]
+        area = 0
+        bbox = self.get_bbox_for_polyline(polygon)
+        category_id = self.get_category_id(object_)
+        id_, is_crowd, track_id, encord_track_uuid, manual_annotation = self.get_coco_annotation_default_fields(object_)
+
+        classifications = self.get_flat_classifications(
+            object_, image_id, object_answers, object_actions
+        )
+
+        return CocoAnnotation(
+            area=area,
+            bbox=bbox,
+            category_id=category_id,
+            id_=id_,
+            image_id=image_id,
+            is_crowd=is_crowd,
+            segmentation=segmentation,
+            keypoints=None,
+            num_keypoints=None,
+            track_id=track_id,
+            encord_track_uuid=encord_track_uuid,
+            rotation=None,
+            classifications=classifications,
+            manual_annotation=manual_annotation,
+        )
+
+    def get_bbox_for_polyline(
+        self,
+        polygon: List[Tuple[float, float]],
+    ) -> Tuple[float, float, float, float]:
+        if len(polygon) == 2:
+            # We have the edge case of a single edge polygon.
+            first_point = polygon[0]
+            second_point = polygon[1]
+            x = float(min(first_point[0], second_point[0]))
+            y = float(min(first_point[1], second_point[1]))
+            w = float(abs(first_point[0] - second_point[0]))
+            h = float(abs(first_point[1] - second_point[1]))
+            return x, y, w, h
+        else:
+            shapely_polygon = Polygon(polygon)
+            x, y, x_max, y_max = shapely_polygon.bounds  # type: ignore[attr-defined]
+            w, h = x_max - x, y_max - y
+
+            return x, y, w, h
+
+    @staticmethod
+    def join_polyline_from_polygon(
+        polygon: List[float],
+    ) -> List[float]:
+        """
+        Essentially a trick to represent a polyline in coco. We pretend for this to be a polygon and join every
+        coordinate from the end back to the beginning, so it will essentially be an area-less polygon.
+        This function technically changes the input polygon in place.
+        """
+        if len(polygon) % 2 != 0:
+            raise RuntimeError("The polygon has an unaccepted shape.")
+
+        idx = len(polygon) - 2
+        while idx >= 0:
+            y_coordinate = polygon[idx]
+            x_coordinate = polygon[idx + 1]
+            polygon.append(y_coordinate)
+            polygon.append(x_coordinate)
+            idx -= 2
+
+        return polygon
+
+    def get_bitmask(
+        self,
+        object_: Dict,
+        image_id: int,
+        size: Size,
+        object_answers: Dict,
+        object_actions: Dict,
+    ) -> CocoAnnotation:
+        bitmask = object_["bitmask"]
+        # Note: It's essential to transpose the input and output coordinates when using pycocotools' functions,
+        # in order to address the distinction between treating masks as C-contiguous (row-major order, Encord's
+        # implementation) versus pycocotools' expectation of Fortran-contiguous (column-major order, COCO's API
+        # implementation) data.
+
+        # Obtain the COCO compatible RLE string (convert from row-major to column-major order)
+        transposed_segmentation = dict(counts=bitmask["rleString"], size=[bitmask["width"], bitmask["height"]])
+        mask = np.asfortranarray(cocomask.decode(transposed_segmentation).T)
+        segmentation = cocomask.encode(mask)
+        bbox = tuple(cocomask.toBbox(segmentation))
+        area = float(cocomask.area(segmentation))
+        # Convert RLE string from bytes (which is not a JSON serializable type) to a string format
+        segmentation["counts"] = segmentation["counts"].decode("ascii")
+
+        category_id = self.get_category_id(object_)
+        id_, _, track_id, encord_track_uuid, manual_annotation = self.get_coco_annotation_default_fields(object_)
+        is_crowd = 1
+
+        classifications: Optional[Dict] = self.get_flat_classifications(
+            object_, image_id, object_answers, object_actions
+        )
+
+        return CocoAnnotation(
+            area=area,
+            bbox=bbox,
+            category_id=category_id,
+            id_=id_,
+            image_id=image_id,
+            is_crowd=is_crowd,
+            segmentation=segmentation,
+            keypoints=None,
+            num_keypoints=None,
+            track_id=track_id,
+            encord_track_uuid=encord_track_uuid,
+            rotation=None,
+            classifications=classifications,
+            manual_annotation=manual_annotation,
+        )
+
+    def get_point(
+        self,
+        object_: Dict,
+        image_id: int,
+        size: Size,
+        object_answers: Dict,
+        object_actions: Dict,
+    ) -> CocoAnnotation:
+        x, y = (
+            object_["point"]["0"]["x"] * size.width,
+            object_["point"]["0"]["y"] * size.height,
+        )
+        w, h = 0, 0
+        area = 0
+        segmentation = [[x, y]]
+        keypoints = [x, y, 2]
+        num_keypoints = 1
+
+        bbox = (x, y, w, h)
+        category_id = self.get_category_id(object_)
+        id_, is_crowd, track_id, encord_track_uuid, manual_annotation = self.get_coco_annotation_default_fields(object_)
+
+        classifications: Optional[Dict] = self.get_flat_classifications(
+            object_, image_id, object_answers, object_actions
+        )
+
+        return CocoAnnotation(
+            area=area,
+            bbox=bbox,
+            category_id=category_id,
+            id_=id_,
+            image_id=image_id,
+            is_crowd=is_crowd,
+            segmentation=segmentation,
+            keypoints=keypoints,
+            num_keypoints=num_keypoints,
+            track_id=track_id,
+            encord_track_uuid=encord_track_uuid,
+            rotation=None,
+            classifications=classifications,
+            manual_annotation=manual_annotation,
+        )
+
+    def get_skeleton(
+        self,
+        object_: Dict,
+        image_id: int,
+        size: Size,
+        object_answers: Dict,
+        object_actions: Dict,
+    ) -> CocoAnnotation:
+        area = 0
+        segmentation: List = []
+        keypoints = []
+
+        for point in object_["skeleton"].values():
+            keypoints += [
+                point["x"] * size.width,
+                point["y"] * size.height,
+                2,
+            ]
+
+        num_keypoints = len(keypoints) // 3
+        xs, ys = (
+            keypoints[::3],
+            keypoints[1::3],
+        )
+        x, y, x_max, y_max = min(xs), min(ys), max(xs), max(ys)
+        w, h = x_max - x, y_max - y
+
+        bbox = (x, y, w, h)
+        category_id = self.get_category_id(object_)
+        id_, is_crowd, track_id, encord_track_uuid, manual_annotation = self.get_coco_annotation_default_fields(object_)
+
+        classifications: Optional[Dict] = self.get_flat_classifications(
+            object_, image_id, object_answers, object_actions
+        )
+
+        return CocoAnnotation(
+            area=area,
+            bbox=bbox,
+            category_id=category_id,
+            id_=id_,
+            image_id=image_id,
+            is_crowd=is_crowd,
+            segmentation=segmentation,
+            keypoints=keypoints,
+            num_keypoints=num_keypoints,
+            track_id=track_id,
+            encord_track_uuid=encord_track_uuid,
+            rotation=None,
+            classifications=classifications,
+            manual_annotation=manual_annotation,
+        )
+
+    def get_flat_classifications(
+        self, object_: Dict, image_id: int, object_answers: Dict, object_actions: Dict
+    ) -> Dict[str,Any]:
+        object_hash = object_["objectHash"]
+        feature_hash = object_["featureHash"]
+
+        feature_hash_to_attribute_map: Dict[str, Attribute] = self.get_feature_hash_to_flat_object_attribute_map()
+        id_and_object_hash_to_answers_map = self.get_id_and_object_hash_to_answers_map(object_actions)
+
+        classifications = self.get_flat_static_classifications(
+            object_hash, feature_hash, object_answers, feature_hash_to_attribute_map
+        )
+        dynamic_classifications = self.get_flat_dynamic_classifications(
+            object_hash,
+            feature_hash,
+            image_id,
+            id_and_object_hash_to_answers_map,
+        )
+        classifications.update(dynamic_classifications)
+
+        return classifications
+
+    def get_feature_hash_to_flat_object_attribute_map(self) -> Dict[str, Attribute]:
+        if self._feature_hash_to_attribute_map is not None:
+            return self._feature_hash_to_attribute_map
+
+        ret: Dict[str, Attribute] = {}
+
+        for object_ in self._ontology.objects:
+            for attribute in object_.attributes:
+                ret[attribute.feature_node_hash] = attribute
+
+        self._feature_hash_to_attribute_map = ret
+
+        return ret
+
+    def get_flat_static_classifications(
+        self,
+        object_hash: str,
+        object_feature_hash: str,
+        object_answers: Dict[str,Any],
+        feature_hash_to_attribute_map: Dict[str, Attribute],
+    ) -> Dict[str,Any]:
+        ret = {}
+        classifications = object_answers[object_hash]["classifications"]
+        for classification in classifications:
+            feature_hash = classification["featureHash"]
+            if feature_hash not in feature_hash_to_attribute_map:
+                # This will be a deeply nested attribute
+                continue
+
+            attribute = feature_hash_to_attribute_map[feature_hash]
+            answers = classification["answers"]
+
+            if attribute.get_property_type() == PropertyType.TEXT:
+                ret.update(self.get_text_answer(attribute, answers))
+            elif attribute.get_property_type() == PropertyType.RADIO:
+                ret.update(self.get_radio_answer(attribute, answers))
+            elif attribute.get_property_type() == PropertyType.CHECKLIST:
+                ret.update(self.get_checklist_answer(attribute, answers))
+
+        self.add_unselected_attributes(object_feature_hash, ret, match_dynamic_attributes=False)
+
+        return ret
+
+    def get_id_and_object_hash_to_answers_map(
+        self,
+        object_actions: Dict[str,Any],
+    ) -> Dict[Tuple[int, str], Dict]:
+        if self._id_and_object_hash_to_answers_map is not None:
+            return self._id_and_object_hash_to_answers_map
+
+        ret: Dict[Tuple[int, str], Dict[str,Any]] = defaultdict(Dict)
+        feature_hash_to_attribute_map = self.get_feature_hash_to_flat_object_attribute_map()
+        for object_hash, payload in object_actions.items():
+            for action in payload["actions"]:
+                feature_hash = action["featureHash"]
+                if feature_hash not in feature_hash_to_attribute_map:
+                    # This will be a deeply nested attribute
+                    continue
+
+                attribute = feature_hash_to_attribute_map[feature_hash]
+                answers = action["answers"]
+                answers_dict: Dict[str,Any] = {}
+
+                if attribute.get_property_type() == PropertyType.TEXT:
+                    answers_dict.update(self.get_text_answer(attribute, answers))
+                elif attribute.get_property_type() == PropertyType.RADIO:
+                    answers_dict.update(self.get_radio_answer(attribute, answers))
+                elif attribute.get_property_type() == PropertyType.CHECKLIST:
+                    answers_dict.update(self.get_checklist_answer(attribute, answers))
+
+                for sub_range in action["range"]:
+                    for i in range(sub_range[0], sub_range[1] + 1):
+                        ret[(i, object_hash)].update(answers_dict)
+
+        self._id_and_object_hash_to_answers_map = ret
+
+        return ret
+
+    def get_flat_dynamic_classifications(
+        self,
+        object_hash: str,
+        feature_hash: str,
+        image_id: int,
+        id_and_object_hash_to_answers_map: Dict[Tuple[int, str], Dict[str,Any]],
+    ) -> Dict[str,Any]:
+        ret = {}
+        id_and_object_hash = (image_id, object_hash)
+
+        if id_and_object_hash in id_and_object_hash_to_answers_map:
+            ret = id_and_object_hash_to_answers_map[(image_id, object_hash)]
+
+        self.add_unselected_attributes(feature_hash, ret, match_dynamic_attributes=True)
+
+        return ret
+
+    def add_unselected_attributes(
+        self, feature_hash: str, attributes_dict: Dict[str,Optional[bool]], match_dynamic_attributes: bool
+    ) -> None:
+        """
+        Attributes which have never been selected will not show up in the actions map. They will need to be
+        added separately. NOTE: this assumes uniqueness of features. Quite an edge case but if it ever comes
+        up it needs to be solved somewhere here.
+        """
+        # TODO: This could be improved
+        all_attributes = self.get_attributes_for_feature_hash(feature_hash)
+        for attribute in all_attributes:
+            is_matching_attribute = attribute.dynamic == match_dynamic_attributes
+            if is_matching_attribute:
+                if attribute.get_property_type() == PropertyType.CHECKLIST:
+                    for option in attribute.options:  # type: ignore[union-attr]
+                        if option.label not in attributes_dict:
+                            # We need to add the default of False.
+                            attributes_dict[option.label] = False
+                else:
+                    if attribute.name not in attributes_dict:
+                        attributes_dict[attribute.name] = None
+
+    def get_attributes_for_feature_hash(self, feature_hash: str) -> List[Attribute]:
+        ret = []
+
+        for object_ in self._ontology.objects:
+            if object_.feature_node_hash == feature_hash:
+                for attribute in object_.attributes:
+                    ret.append(attribute)
+                break
+
+        return ret
+
+    def get_radio_answer(self, attribute: Attribute, answers: List[Dict[str,str]]) -> Dict[str,str]:
+        answer = answers[0]  # radios only have one answer by definition
+        return {attribute.name: answer["name"]}
+
+    def get_checklist_answer(self, attribute: Attribute, answers: Dict[str,Any]) -> Dict[str,bool]:
+        ret: Dict[str,bool] = {}
+        found_checklist_answers: set[str] = set()
+
+        for answer in answers:
+            found_checklist_answers.add(answer["name"])
+
+        for option in attribute.options:  # type: ignore[union-attr]
+            label = option.label
+            ret[label] = label in found_checklist_answers
+
+        return ret
+
+    def get_text_answer(self, attribute: Attribute, answers: str) -> Dict[str,Any]:
+        return {attribute.name: answers}
+
+    def get_category_id(self, object_: Dict[str,Any]) -> int:
+        feature_hash = object_["featureHash"]
+        try:
+            return self._feature_hash_to_coco_category_id_map[feature_hash]
+        except KeyError:
+            raise EncordException(
+                f"The feature_hash `{feature_hash}` was not found in the provided ontology. Please "
+                f"ensure that the ontology matches the labels provided."
+            ) from None
+
+    def get_coco_annotation_default_fields(
+        self, object_: Dict[str,Any]
+    ) -> Tuple[
+        int,
+        int,
+        Optional[int],
+        Optional[str],
+        Optional[bool],
+    ]:
+        id_ = self.next_annotation_id()
+        is_crowd = 0
+
+        track_id = self.get_and_set_track_id(object_hash=object_["objectHash"])
+        encord_track_uuid = object_["objectHash"]
+        manual_annotation = object_["manualAnnotation"]
+
+        return id_, is_crowd, track_id, encord_track_uuid, manual_annotation
+
+    def next_annotation_id(self) -> int:
+        next_ = self._current_annotation_id
+        self._current_annotation_id += 1
+
+        return next_
+
+    def get_and_set_track_id(self, object_hash: str) -> int:
+        if object_hash in self._object_hash_to_track_id_map:
+            return self._object_hash_to_track_id_map[object_hash]
+        else:
+            next_track_id = len(self._object_hash_to_track_id_map)
+            self._object_hash_to_track_id_map[object_hash] = next_track_id
+            return next_track_id
+
+    def get_image_id(self, data_hash: str, frame_num: int = 0) -> int:
+        return self._data_hash_to_image_id_map[(data_hash, frame_num)]

--- a/poetry.lock
+++ b/poetry.lock
@@ -223,6 +223,80 @@ files = [
 ]
 
 [[package]]
+name = "contourpy"
+version = "1.1.1"
+description = "Python library for calculating contours of 2D quadrilateral grids"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "contourpy-1.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:46e24f5412c948d81736509377e255f6040e94216bf1a9b5ea1eaa9d29f6ec1b"},
+    {file = "contourpy-1.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e48694d6a9c5a26ee85b10130c77a011a4fedf50a7279fa0bdaf44bafb4299d"},
+    {file = "contourpy-1.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a66045af6cf00e19d02191ab578a50cb93b2028c3eefed999793698e9ea768ae"},
+    {file = "contourpy-1.1.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4ebf42695f75ee1a952f98ce9775c873e4971732a87334b099dde90b6af6a916"},
+    {file = "contourpy-1.1.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f6aec19457617ef468ff091669cca01fa7ea557b12b59a7908b9474bb9674cf0"},
+    {file = "contourpy-1.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:462c59914dc6d81e0b11f37e560b8a7c2dbab6aca4f38be31519d442d6cde1a1"},
+    {file = "contourpy-1.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6d0a8efc258659edc5299f9ef32d8d81de8b53b45d67bf4bfa3067f31366764d"},
+    {file = "contourpy-1.1.1-cp310-cp310-win32.whl", hash = "sha256:d6ab42f223e58b7dac1bb0af32194a7b9311065583cc75ff59dcf301afd8a431"},
+    {file = "contourpy-1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:549174b0713d49871c6dee90a4b499d3f12f5e5f69641cd23c50a4542e2ca1eb"},
+    {file = "contourpy-1.1.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:407d864db716a067cc696d61fa1ef6637fedf03606e8417fe2aeed20a061e6b2"},
+    {file = "contourpy-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfe80c017973e6a4c367e037cb31601044dd55e6bfacd57370674867d15a899b"},
+    {file = "contourpy-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e30aaf2b8a2bac57eb7e1650df1b3a4130e8d0c66fc2f861039d507a11760e1b"},
+    {file = "contourpy-1.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3de23ca4f381c3770dee6d10ead6fff524d540c0f662e763ad1530bde5112532"},
+    {file = "contourpy-1.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:566f0e41df06dfef2431defcfaa155f0acfa1ca4acbf8fd80895b1e7e2ada40e"},
+    {file = "contourpy-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b04c2f0adaf255bf756cf08ebef1be132d3c7a06fe6f9877d55640c5e60c72c5"},
+    {file = "contourpy-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d0c188ae66b772d9d61d43c6030500344c13e3f73a00d1dc241da896f379bb62"},
+    {file = "contourpy-1.1.1-cp311-cp311-win32.whl", hash = "sha256:0683e1ae20dc038075d92e0e0148f09ffcefab120e57f6b4c9c0f477ec171f33"},
+    {file = "contourpy-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:8636cd2fc5da0fb102a2504fa2c4bea3cbc149533b345d72cdf0e7a924decc45"},
+    {file = "contourpy-1.1.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:560f1d68a33e89c62da5da4077ba98137a5e4d3a271b29f2f195d0fba2adcb6a"},
+    {file = "contourpy-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:24216552104ae8f3b34120ef84825400b16eb6133af2e27a190fdc13529f023e"},
+    {file = "contourpy-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56de98a2fb23025882a18b60c7f0ea2d2d70bbbcfcf878f9067234b1c4818442"},
+    {file = "contourpy-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:07d6f11dfaf80a84c97f1a5ba50d129d9303c5b4206f776e94037332e298dda8"},
+    {file = "contourpy-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f1eaac5257a8f8a047248d60e8f9315c6cff58f7803971170d952555ef6344a7"},
+    {file = "contourpy-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19557fa407e70f20bfaba7d55b4d97b14f9480856c4fb65812e8a05fe1c6f9bf"},
+    {file = "contourpy-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:081f3c0880712e40effc5f4c3b08feca6d064cb8cfbb372ca548105b86fd6c3d"},
+    {file = "contourpy-1.1.1-cp312-cp312-win32.whl", hash = "sha256:059c3d2a94b930f4dafe8105bcdc1b21de99b30b51b5bce74c753686de858cb6"},
+    {file = "contourpy-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f44d78b61740e4e8c71db1cf1fd56d9050a4747681c59ec1094750a658ceb970"},
+    {file = "contourpy-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:70e5a10f8093d228bb2b552beeb318b8928b8a94763ef03b858ef3612b29395d"},
+    {file = "contourpy-1.1.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8394e652925a18ef0091115e3cc191fef350ab6dc3cc417f06da66bf98071ae9"},
+    {file = "contourpy-1.1.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5bd5680f844c3ff0008523a71949a3ff5e4953eb7701b28760805bc9bcff217"},
+    {file = "contourpy-1.1.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:66544f853bfa85c0d07a68f6c648b2ec81dafd30f272565c37ab47a33b220684"},
+    {file = "contourpy-1.1.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e0c02b75acfea5cab07585d25069207e478d12309557f90a61b5a3b4f77f46ce"},
+    {file = "contourpy-1.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41339b24471c58dc1499e56783fedc1afa4bb018bcd035cfb0ee2ad2a7501ef8"},
+    {file = "contourpy-1.1.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:f29fb0b3f1217dfe9362ec55440d0743fe868497359f2cf93293f4b2701b8251"},
+    {file = "contourpy-1.1.1-cp38-cp38-win32.whl", hash = "sha256:f9dc7f933975367251c1b34da882c4f0e0b2e24bb35dc906d2f598a40b72bfc7"},
+    {file = "contourpy-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:498e53573e8b94b1caeb9e62d7c2d053c263ebb6aa259c81050766beb50ff8d9"},
+    {file = "contourpy-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ba42e3810999a0ddd0439e6e5dbf6d034055cdc72b7c5c839f37a7c274cb4eba"},
+    {file = "contourpy-1.1.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6c06e4c6e234fcc65435223c7b2a90f286b7f1b2733058bdf1345d218cc59e34"},
+    {file = "contourpy-1.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca6fab080484e419528e98624fb5c4282148b847e3602dc8dbe0cb0669469887"},
+    {file = "contourpy-1.1.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:93df44ab351119d14cd1e6b52a5063d3336f0754b72736cc63db59307dabb718"},
+    {file = "contourpy-1.1.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eafbef886566dc1047d7b3d4b14db0d5b7deb99638d8e1be4e23a7c7ac59ff0f"},
+    {file = "contourpy-1.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:efe0fab26d598e1ec07d72cf03eaeeba8e42b4ecf6b9ccb5a356fde60ff08b85"},
+    {file = "contourpy-1.1.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f08e469821a5e4751c97fcd34bcb586bc243c39c2e39321822060ba902eac49e"},
+    {file = "contourpy-1.1.1-cp39-cp39-win32.whl", hash = "sha256:bfc8a5e9238232a45ebc5cb3bfee71f1167064c8d382cadd6076f0d51cff1da0"},
+    {file = "contourpy-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:c84fdf3da00c2827d634de4fcf17e3e067490c4aea82833625c4c8e6cdea0887"},
+    {file = "contourpy-1.1.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:229a25f68046c5cf8067d6d6351c8b99e40da11b04d8416bf8d2b1d75922521e"},
+    {file = "contourpy-1.1.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a10dab5ea1bd4401c9483450b5b0ba5416be799bbd50fc7a6cc5e2a15e03e8a3"},
+    {file = "contourpy-1.1.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:4f9147051cb8fdb29a51dc2482d792b3b23e50f8f57e3720ca2e3d438b7adf23"},
+    {file = "contourpy-1.1.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a75cc163a5f4531a256f2c523bd80db509a49fc23721b36dd1ef2f60ff41c3cb"},
+    {file = "contourpy-1.1.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b53d5769aa1f2d4ea407c65f2d1d08002952fac1d9e9d307aa2e1023554a163"},
+    {file = "contourpy-1.1.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:11b836b7dbfb74e049c302bbf74b4b8f6cb9d0b6ca1bf86cfa8ba144aedadd9c"},
+    {file = "contourpy-1.1.1.tar.gz", hash = "sha256:96ba37c2e24b7212a77da85004c38e7c4d155d3e72a45eeaf22c1f03f607e8ab"},
+]
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.16,<2.0", markers = "python_version <= \"3.11\""},
+    {version = ">=1.26.0rc1,<2.0", markers = "python_version >= \"3.12\""},
+]
+
+[package.extras]
+bokeh = ["bokeh", "selenium"]
+docs = ["furo", "sphinx (>=7.2)", "sphinx-copybutton"]
+mypy = ["contourpy[bokeh,docs]", "docutils-stubs", "mypy (==1.4.1)", "types-Pillow"]
+test = ["Pillow", "contourpy[test-no-images]", "matplotlib"]
+test-no-images = ["pytest", "pytest-cov", "wurlitzer"]
+
+[[package]]
 name = "cryptography"
 version = "42.0.8"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
@@ -275,6 +349,21 @@ sdist = ["build"]
 ssh = ["bcrypt (>=3.1.5)"]
 test = ["certifi", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
 test-randomorder = ["pytest-randomly"]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+description = "Composable style cycles"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30"},
+    {file = "cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c"},
+]
+
+[package.extras]
+docs = ["ipython", "matplotlib", "numpydoc", "sphinx"]
+tests = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
 name = "deepdiff"
@@ -335,6 +424,79 @@ docs = ["furo (>=2023.5.20)", "sphinx (>=7.0.1)", "sphinx-autodoc-typehints (>=1
 testing = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "diff-cover (>=7.5)", "pytest (>=7.3.1)", "pytest-cov (>=4.1)", "pytest-mock (>=3.10)", "pytest-timeout (>=2.1)"]
 
 [[package]]
+name = "fonttools"
+version = "4.55.3"
+description = "Tools to manipulate font files"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "fonttools-4.55.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1dcc07934a2165ccdc3a5a608db56fb3c24b609658a5b340aee4ecf3ba679dc0"},
+    {file = "fonttools-4.55.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f7d66c15ba875432a2d2fb419523f5d3d347f91f48f57b8b08a2dfc3c39b8a3f"},
+    {file = "fonttools-4.55.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27e4ae3592e62eba83cd2c4ccd9462dcfa603ff78e09110680a5444c6925d841"},
+    {file = "fonttools-4.55.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:62d65a3022c35e404d19ca14f291c89cc5890032ff04f6c17af0bd1927299674"},
+    {file = "fonttools-4.55.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d342e88764fb201286d185093781bf6628bbe380a913c24adf772d901baa8276"},
+    {file = "fonttools-4.55.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:dd68c87a2bfe37c5b33bcda0fba39b65a353876d3b9006fde3adae31f97b3ef5"},
+    {file = "fonttools-4.55.3-cp310-cp310-win32.whl", hash = "sha256:1bc7ad24ff98846282eef1cbeac05d013c2154f977a79886bb943015d2b1b261"},
+    {file = "fonttools-4.55.3-cp310-cp310-win_amd64.whl", hash = "sha256:b54baf65c52952db65df39fcd4820668d0ef4766c0ccdf32879b77f7c804d5c5"},
+    {file = "fonttools-4.55.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8c4491699bad88efe95772543cd49870cf756b019ad56294f6498982408ab03e"},
+    {file = "fonttools-4.55.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5323a22eabddf4b24f66d26894f1229261021dacd9d29e89f7872dd8c63f0b8b"},
+    {file = "fonttools-4.55.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5480673f599ad410695ca2ddef2dfefe9df779a9a5cda89503881e503c9c7d90"},
+    {file = "fonttools-4.55.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da9da6d65cd7aa6b0f806556f4985bcbf603bf0c5c590e61b43aa3e5a0f822d0"},
+    {file = "fonttools-4.55.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e894b5bd60d9f473bed7a8f506515549cc194de08064d829464088d23097331b"},
+    {file = "fonttools-4.55.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:aee3b57643827e237ff6ec6d28d9ff9766bd8b21e08cd13bff479e13d4b14765"},
+    {file = "fonttools-4.55.3-cp311-cp311-win32.whl", hash = "sha256:eb6ca911c4c17eb51853143624d8dc87cdcdf12a711fc38bf5bd21521e79715f"},
+    {file = "fonttools-4.55.3-cp311-cp311-win_amd64.whl", hash = "sha256:6314bf82c54c53c71805318fcf6786d986461622dd926d92a465199ff54b1b72"},
+    {file = "fonttools-4.55.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:f9e736f60f4911061235603a6119e72053073a12c6d7904011df2d8fad2c0e35"},
+    {file = "fonttools-4.55.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a8aa2c5e5b8b3bcb2e4538d929f6589a5c6bdb84fd16e2ed92649fb5454f11c"},
+    {file = "fonttools-4.55.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:07f8288aacf0a38d174445fc78377a97fb0b83cfe352a90c9d9c1400571963c7"},
+    {file = "fonttools-4.55.3-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8d5e8916c0970fbc0f6f1bece0063363bb5857a7f170121a4493e31c3db3314"},
+    {file = "fonttools-4.55.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ae3b6600565b2d80b7c05acb8e24d2b26ac407b27a3f2e078229721ba5698427"},
+    {file = "fonttools-4.55.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:54153c49913f45065c8d9e6d0c101396725c5621c8aee744719300f79771d75a"},
+    {file = "fonttools-4.55.3-cp312-cp312-win32.whl", hash = "sha256:827e95fdbbd3e51f8b459af5ea10ecb4e30af50221ca103bea68218e9615de07"},
+    {file = "fonttools-4.55.3-cp312-cp312-win_amd64.whl", hash = "sha256:e6e8766eeeb2de759e862004aa11a9ea3d6f6d5ec710551a88b476192b64fd54"},
+    {file = "fonttools-4.55.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a430178ad3e650e695167cb53242dae3477b35c95bef6525b074d87493c4bf29"},
+    {file = "fonttools-4.55.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:529cef2ce91dc44f8e407cc567fae6e49a1786f2fefefa73a294704c415322a4"},
+    {file = "fonttools-4.55.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e75f12c82127486fac2d8bfbf5bf058202f54bf4f158d367e41647b972342ca"},
+    {file = "fonttools-4.55.3-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:859c358ebf41db18fb72342d3080bce67c02b39e86b9fbcf1610cca14984841b"},
+    {file = "fonttools-4.55.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:546565028e244a701f73df6d8dd6be489d01617863ec0c6a42fa25bf45d43048"},
+    {file = "fonttools-4.55.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:aca318b77f23523309eec4475d1fbbb00a6b133eb766a8bdc401faba91261abe"},
+    {file = "fonttools-4.55.3-cp313-cp313-win32.whl", hash = "sha256:8c5ec45428edaa7022f1c949a632a6f298edc7b481312fc7dc258921e9399628"},
+    {file = "fonttools-4.55.3-cp313-cp313-win_amd64.whl", hash = "sha256:11e5de1ee0d95af4ae23c1a138b184b7f06e0b6abacabf1d0db41c90b03d834b"},
+    {file = "fonttools-4.55.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:caf8230f3e10f8f5d7593eb6d252a37caf58c480b19a17e250a63dad63834cf3"},
+    {file = "fonttools-4.55.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b586ab5b15b6097f2fb71cafa3c98edfd0dba1ad8027229e7b1e204a58b0e09d"},
+    {file = "fonttools-4.55.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8c2794ded89399cc2169c4d0bf7941247b8d5932b2659e09834adfbb01589aa"},
+    {file = "fonttools-4.55.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf4fe7c124aa3f4e4c1940880156e13f2f4d98170d35c749e6b4f119a872551e"},
+    {file = "fonttools-4.55.3-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:86721fbc389ef5cc1e2f477019e5069e8e4421e8d9576e9c26f840dbb04678de"},
+    {file = "fonttools-4.55.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:89bdc5d88bdeec1b15af790810e267e8332d92561dce4f0748c2b95c9bdf3926"},
+    {file = "fonttools-4.55.3-cp38-cp38-win32.whl", hash = "sha256:bc5dbb4685e51235ef487e4bd501ddfc49be5aede5e40f4cefcccabc6e60fb4b"},
+    {file = "fonttools-4.55.3-cp38-cp38-win_amd64.whl", hash = "sha256:cd70de1a52a8ee2d1877b6293af8a2484ac82514f10b1c67c1c5762d38073e56"},
+    {file = "fonttools-4.55.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:bdcc9f04b36c6c20978d3f060e5323a43f6222accc4e7fcbef3f428e216d96af"},
+    {file = "fonttools-4.55.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c3ca99e0d460eff46e033cd3992a969658c3169ffcd533e0a39c63a38beb6831"},
+    {file = "fonttools-4.55.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22f38464daa6cdb7b6aebd14ab06609328fe1e9705bb0fcc7d1e69de7109ee02"},
+    {file = "fonttools-4.55.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed63959d00b61959b035c7d47f9313c2c1ece090ff63afea702fe86de00dbed4"},
+    {file = "fonttools-4.55.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:5e8d657cd7326eeaba27de2740e847c6b39dde2f8d7cd7cc56f6aad404ddf0bd"},
+    {file = "fonttools-4.55.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:fb594b5a99943042c702c550d5494bdd7577f6ef19b0bc73877c948a63184a32"},
+    {file = "fonttools-4.55.3-cp39-cp39-win32.whl", hash = "sha256:dc5294a3d5c84226e3dbba1b6f61d7ad813a8c0238fceea4e09aa04848c3d851"},
+    {file = "fonttools-4.55.3-cp39-cp39-win_amd64.whl", hash = "sha256:aedbeb1db64496d098e6be92b2e63b5fac4e53b1b92032dfc6988e1ea9134a4d"},
+    {file = "fonttools-4.55.3-py3-none-any.whl", hash = "sha256:f412604ccbeee81b091b420272841e5ec5ef68967a9790e80bffd0e30b8e2977"},
+    {file = "fonttools-4.55.3.tar.gz", hash = "sha256:3983313c2a04d6cc1fe9251f8fc647754cf49a61dac6cb1e7249ae67afaafc45"},
+]
+
+[package.extras]
+all = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "fs (>=2.2.0,<3)", "lxml (>=4.0)", "lz4 (>=1.7.4.2)", "matplotlib", "munkres", "pycairo", "scipy", "skia-pathops (>=0.5.0)", "sympy", "uharfbuzz (>=0.23.0)", "unicodedata2 (>=15.1.0)", "xattr", "zopfli (>=0.1.4)"]
+graphite = ["lz4 (>=1.7.4.2)"]
+interpolatable = ["munkres", "pycairo", "scipy"]
+lxml = ["lxml (>=4.0)"]
+pathops = ["skia-pathops (>=0.5.0)"]
+plot = ["matplotlib"]
+repacker = ["uharfbuzz (>=0.23.0)"]
+symfont = ["sympy"]
+type1 = ["xattr"]
+ufo = ["fs (>=2.2.0,<3)"]
+unicode = ["unicodedata2 (>=15.1.0)"]
+woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
+
+[[package]]
 name = "identify"
 version = "2.5.24"
 description = "File identification library for Python"
@@ -360,6 +522,28 @@ files = [
 ]
 
 [[package]]
+name = "importlib-resources"
+version = "6.4.5"
+description = "Read resources from Python packages"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "importlib_resources-6.4.5-py3-none-any.whl", hash = "sha256:ac29d5f956f01d5e4bb63102a5a19957f1b9175e45649977264a1416783bb717"},
+    {file = "importlib_resources-6.4.5.tar.gz", hash = "sha256:980862a1d16c9e147a59603677fa2aa5fd82b87f223b6cb870695bcfce830065"},
+]
+
+[package.dependencies]
+zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["jaraco.test (>=5.4)", "pytest (>=6,!=8.1.*)", "zipp (>=3.17)"]
+type = ["pytest-mypy"]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -369,6 +553,197 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
+
+[[package]]
+name = "kiwisolver"
+version = "1.4.7"
+description = "A fast implementation of the Cassowary constraint solver"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "kiwisolver-1.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8a9c83f75223d5e48b0bc9cb1bf2776cf01563e00ade8775ffe13b0b6e1af3a6"},
+    {file = "kiwisolver-1.4.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:58370b1ffbd35407444d57057b57da5d6549d2d854fa30249771775c63b5fe17"},
+    {file = "kiwisolver-1.4.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:aa0abdf853e09aff551db11fce173e2177d00786c688203f52c87ad7fcd91ef9"},
+    {file = "kiwisolver-1.4.7-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8d53103597a252fb3ab8b5845af04c7a26d5e7ea8122303dd7a021176a87e8b9"},
+    {file = "kiwisolver-1.4.7-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:88f17c5ffa8e9462fb79f62746428dd57b46eb931698e42e990ad63103f35e6c"},
+    {file = "kiwisolver-1.4.7-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88a9ca9c710d598fd75ee5de59d5bda2684d9db36a9f50b6125eaea3969c2599"},
+    {file = "kiwisolver-1.4.7-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f4d742cb7af1c28303a51b7a27aaee540e71bb8e24f68c736f6f2ffc82f2bf05"},
+    {file = "kiwisolver-1.4.7-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e28c7fea2196bf4c2f8d46a0415c77a1c480cc0724722f23d7410ffe9842c407"},
+    {file = "kiwisolver-1.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e968b84db54f9d42046cf154e02911e39c0435c9801681e3fc9ce8a3c4130278"},
+    {file = "kiwisolver-1.4.7-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0c18ec74c0472de033e1bebb2911c3c310eef5649133dd0bedf2a169a1b269e5"},
+    {file = "kiwisolver-1.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8f0ea6da6d393d8b2e187e6a5e3fb81f5862010a40c3945e2c6d12ae45cfb2ad"},
+    {file = "kiwisolver-1.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:f106407dda69ae456dd1227966bf445b157ccc80ba0dff3802bb63f30b74e895"},
+    {file = "kiwisolver-1.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:84ec80df401cfee1457063732d90022f93951944b5b58975d34ab56bb150dfb3"},
+    {file = "kiwisolver-1.4.7-cp310-cp310-win32.whl", hash = "sha256:71bb308552200fb2c195e35ef05de12f0c878c07fc91c270eb3d6e41698c3bcc"},
+    {file = "kiwisolver-1.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:44756f9fd339de0fb6ee4f8c1696cfd19b2422e0d70b4cefc1cc7f1f64045a8c"},
+    {file = "kiwisolver-1.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:78a42513018c41c2ffd262eb676442315cbfe3c44eed82385c2ed043bc63210a"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d2b0e12a42fb4e72d509fc994713d099cbb15ebf1103545e8a45f14da2dfca54"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2a8781ac3edc42ea4b90bc23e7d37b665d89423818e26eb6df90698aa2287c95"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:46707a10836894b559e04b0fd143e343945c97fd170d69a2d26d640b4e297935"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ef97b8df011141c9b0f6caf23b29379f87dd13183c978a30a3c546d2c47314cb"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ab58c12a2cd0fc769089e6d38466c46d7f76aced0a1f54c77652446733d2d02"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:803b8e1459341c1bb56d1c5c010406d5edec8a0713a0945851290a7930679b51"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f9a9e8a507420fe35992ee9ecb302dab68550dedc0da9e2880dd88071c5fb052"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18077b53dc3bb490e330669a99920c5e6a496889ae8c63b58fbc57c3d7f33a18"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6af936f79086a89b3680a280c47ea90b4df7047b5bdf3aa5c524bbedddb9e545"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:3abc5b19d24af4b77d1598a585b8a719beb8569a71568b66f4ebe1fb0449460b"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:933d4de052939d90afbe6e9d5273ae05fb836cc86c15b686edd4b3560cc0ee36"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:65e720d2ab2b53f1f72fb5da5fb477455905ce2c88aaa671ff0a447c2c80e8e3"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3bf1ed55088f214ba6427484c59553123fdd9b218a42bbc8c6496d6754b1e523"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-win32.whl", hash = "sha256:4c00336b9dd5ad96d0a558fd18a8b6f711b7449acce4c157e7343ba92dd0cf3d"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:929e294c1ac1e9f615c62a4e4313ca1823ba37326c164ec720a803287c4c499b"},
+    {file = "kiwisolver-1.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:e33e8fbd440c917106b237ef1a2f1449dfbb9b6f6e1ce17c94cd6a1e0d438376"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:5360cc32706dab3931f738d3079652d20982511f7c0ac5711483e6eab08efff2"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:942216596dc64ddb25adb215c3c783215b23626f8d84e8eff8d6d45c3f29f75a"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:48b571ecd8bae15702e4f22d3ff6a0f13e54d3d00cd25216d5e7f658242065ee"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ad42ba922c67c5f219097b28fae965e10045ddf145d2928bfac2eb2e17673640"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:612a10bdae23404a72941a0fc8fa2660c6ea1217c4ce0dbcab8a8f6543ea9e7f"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9e838bba3a3bac0fe06d849d29772eb1afb9745a59710762e4ba3f4cb8424483"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:22f499f6157236c19f4bbbd472fa55b063db77a16cd74d49afe28992dff8c258"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:693902d433cf585133699972b6d7c42a8b9f8f826ebcaf0132ff55200afc599e"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4e77f2126c3e0b0d055f44513ed349038ac180371ed9b52fe96a32aa071a5107"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:657a05857bda581c3656bfc3b20e353c232e9193eb167766ad2dc58b56504948"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4bfa75a048c056a411f9705856abfc872558e33c055d80af6a380e3658766038"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:34ea1de54beef1c104422d210c47c7d2a4999bdecf42c7b5718fbe59a4cac383"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:90da3b5f694b85231cf93586dad5e90e2d71b9428f9aad96952c99055582f520"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-win32.whl", hash = "sha256:18e0cca3e008e17fe9b164b55735a325140a5a35faad8de92dd80265cd5eb80b"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:58cb20602b18f86f83a5c87d3ee1c766a79c0d452f8def86d925e6c60fbf7bfb"},
+    {file = "kiwisolver-1.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:f5a8b53bdc0b3961f8b6125e198617c40aeed638b387913bf1ce78afb1b0be2a"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2e6039dcbe79a8e0f044f1c39db1986a1b8071051efba3ee4d74f5b365f5226e"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a1ecf0ac1c518487d9d23b1cd7139a6a65bc460cd101ab01f1be82ecf09794b6"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ab9ccab2b5bd5702ab0803676a580fffa2aa178c2badc5557a84cc943fcf750"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f816dd2277f8d63d79f9c8473a79fe54047bc0467754962840782c575522224d"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf8bcc23ceb5a1b624572a1623b9f79d2c3b337c8c455405ef231933a10da379"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dea0bf229319828467d7fca8c7c189780aa9ff679c94539eed7532ebe33ed37c"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c06a4c7cf15ec739ce0e5971b26c93638730090add60e183530d70848ebdd34"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:913983ad2deb14e66d83c28b632fd35ba2b825031f2fa4ca29675e665dfecbe1"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5337ec7809bcd0f424c6b705ecf97941c46279cf5ed92311782c7c9c2026f07f"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4c26ed10c4f6fa6ddb329a5120ba3b6db349ca192ae211e882970bfc9d91420b"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c619b101e6de2222c1fcb0531e1b17bbffbe54294bfba43ea0d411d428618c27"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:073a36c8273647592ea332e816e75ef8da5c303236ec0167196793eb1e34657a"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3ce6b2b0231bda412463e152fc18335ba32faf4e8c23a754ad50ffa70e4091ee"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-win32.whl", hash = "sha256:f4c9aee212bc89d4e13f58be11a56cc8036cabad119259d12ace14b34476fd07"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:8a3ec5aa8e38fc4c8af308917ce12c536f1c88452ce554027e55b22cbbfbff76"},
+    {file = "kiwisolver-1.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:76c8094ac20ec259471ac53e774623eb62e6e1f56cd8690c67ce6ce4fcb05650"},
+    {file = "kiwisolver-1.4.7-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5d5abf8f8ec1f4e22882273c423e16cae834c36856cac348cfbfa68e01c40f3a"},
+    {file = "kiwisolver-1.4.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:aeb3531b196ef6f11776c21674dba836aeea9d5bd1cf630f869e3d90b16cfade"},
+    {file = "kiwisolver-1.4.7-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b7d755065e4e866a8086c9bdada157133ff466476a2ad7861828e17b6026e22c"},
+    {file = "kiwisolver-1.4.7-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08471d4d86cbaec61f86b217dd938a83d85e03785f51121e791a6e6689a3be95"},
+    {file = "kiwisolver-1.4.7-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bbfcb7165ce3d54a3dfbe731e470f65739c4c1f85bb1018ee912bae139e263b"},
+    {file = "kiwisolver-1.4.7-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d34eb8494bea691a1a450141ebb5385e4b69d38bb8403b5146ad279f4b30fa3"},
+    {file = "kiwisolver-1.4.7-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9242795d174daa40105c1d86aba618e8eab7bf96ba8c3ee614da8302a9f95503"},
+    {file = "kiwisolver-1.4.7-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a0f64a48bb81af7450e641e3fe0b0394d7381e342805479178b3d335d60ca7cf"},
+    {file = "kiwisolver-1.4.7-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:8e045731a5416357638d1700927529e2b8ab304811671f665b225f8bf8d8f933"},
+    {file = "kiwisolver-1.4.7-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:4322872d5772cae7369f8351da1edf255a604ea7087fe295411397d0cfd9655e"},
+    {file = "kiwisolver-1.4.7-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:e1631290ee9271dffe3062d2634c3ecac02c83890ada077d225e081aca8aab89"},
+    {file = "kiwisolver-1.4.7-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:edcfc407e4eb17e037bca59be0e85a2031a2ac87e4fed26d3e9df88b4165f92d"},
+    {file = "kiwisolver-1.4.7-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:4d05d81ecb47d11e7f8932bd8b61b720bf0b41199358f3f5e36d38e28f0532c5"},
+    {file = "kiwisolver-1.4.7-cp38-cp38-win32.whl", hash = "sha256:b38ac83d5f04b15e515fd86f312479d950d05ce2368d5413d46c088dda7de90a"},
+    {file = "kiwisolver-1.4.7-cp38-cp38-win_amd64.whl", hash = "sha256:d83db7cde68459fc803052a55ace60bea2bae361fc3b7a6d5da07e11954e4b09"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3f9362ecfca44c863569d3d3c033dbe8ba452ff8eed6f6b5806382741a1334bd"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e8df2eb9b2bac43ef8b082e06f750350fbbaf2887534a5be97f6cf07b19d9583"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f32d6edbc638cde7652bd690c3e728b25332acbadd7cad670cc4a02558d9c417"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e2e6c39bd7b9372b0be21456caab138e8e69cc0fc1190a9dfa92bd45a1e6e904"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:dda56c24d869b1193fcc763f1284b9126550eaf84b88bbc7256e15028f19188a"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79849239c39b5e1fd906556c474d9b0439ea6792b637511f3fe3a41158d89ca8"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5e3bc157fed2a4c02ec468de4ecd12a6e22818d4f09cde2c31ee3226ffbefab2"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3da53da805b71e41053dc670f9a820d1157aae77b6b944e08024d17bcd51ef88"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8705f17dfeb43139a692298cb6637ee2e59c0194538153e83e9ee0c75c2eddde"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:82a5c2f4b87c26bb1a0ef3d16b5c4753434633b83d365cc0ddf2770c93829e3c"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:ce8be0466f4c0d585cdb6c1e2ed07232221df101a4c6f28821d2aa754ca2d9e2"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:409afdfe1e2e90e6ee7fc896f3df9a7fec8e793e58bfa0d052c8a82f99c37abb"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:5b9c3f4ee0b9a439d2415012bd1b1cc2df59e4d6a9939f4d669241d30b414327"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-win32.whl", hash = "sha256:a79ae34384df2b615eefca647a2873842ac3b596418032bef9a7283675962644"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-win_amd64.whl", hash = "sha256:cf0438b42121a66a3a667de17e779330fc0f20b0d97d59d2f2121e182b0505e4"},
+    {file = "kiwisolver-1.4.7-cp39-cp39-win_arm64.whl", hash = "sha256:764202cc7e70f767dab49e8df52c7455e8de0df5d858fa801a11aa0d882ccf3f"},
+    {file = "kiwisolver-1.4.7-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:94252291e3fe68001b1dd747b4c0b3be12582839b95ad4d1b641924d68fd4643"},
+    {file = "kiwisolver-1.4.7-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5b7dfa3b546da08a9f622bb6becdb14b3e24aaa30adba66749d38f3cc7ea9706"},
+    {file = "kiwisolver-1.4.7-pp310-pypy310_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bd3de6481f4ed8b734da5df134cd5a6a64fe32124fe83dde1e5b5f29fe30b1e6"},
+    {file = "kiwisolver-1.4.7-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a91b5f9f1205845d488c928e8570dcb62b893372f63b8b6e98b863ebd2368ff2"},
+    {file = "kiwisolver-1.4.7-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40fa14dbd66b8b8f470d5fc79c089a66185619d31645f9b0773b88b19f7223c4"},
+    {file = "kiwisolver-1.4.7-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:eb542fe7933aa09d8d8f9d9097ef37532a7df6497819d16efe4359890a2f417a"},
+    {file = "kiwisolver-1.4.7-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:bfa1acfa0c54932d5607e19a2c24646fb4c1ae2694437789129cf099789a3b00"},
+    {file = "kiwisolver-1.4.7-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:eee3ea935c3d227d49b4eb85660ff631556841f6e567f0f7bda972df6c2c9935"},
+    {file = "kiwisolver-1.4.7-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f3160309af4396e0ed04db259c3ccbfdc3621b5559b5453075e5de555e1f3a1b"},
+    {file = "kiwisolver-1.4.7-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a17f6a29cf8935e587cc8a4dbfc8368c55edc645283db0ce9801016f83526c2d"},
+    {file = "kiwisolver-1.4.7-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:10849fb2c1ecbfae45a693c070e0320a91b35dd4bcf58172c023b994283a124d"},
+    {file = "kiwisolver-1.4.7-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:ac542bf38a8a4be2dc6b15248d36315ccc65f0743f7b1a76688ffb6b5129a5c2"},
+    {file = "kiwisolver-1.4.7-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:8b01aac285f91ca889c800042c35ad3b239e704b150cfd3382adfc9dcc780e39"},
+    {file = "kiwisolver-1.4.7-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:48be928f59a1f5c8207154f935334d374e79f2b5d212826307d072595ad76a2e"},
+    {file = "kiwisolver-1.4.7-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f37cfe618a117e50d8c240555331160d73d0411422b59b5ee217843d7b693608"},
+    {file = "kiwisolver-1.4.7-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:599b5c873c63a1f6ed7eead644a8a380cfbdf5db91dcb6f85707aaab213b1674"},
+    {file = "kiwisolver-1.4.7-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:801fa7802e5cfabe3ab0c81a34c323a319b097dfb5004be950482d882f3d7225"},
+    {file = "kiwisolver-1.4.7-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:0c6c43471bc764fad4bc99c5c2d6d16a676b1abf844ca7c8702bdae92df01ee0"},
+    {file = "kiwisolver-1.4.7.tar.gz", hash = "sha256:9893ff81bd7107f7b685d3017cc6583daadb4fc26e4a888350df530e41980a60"},
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.7.5"
+description = "Python plotting package"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "matplotlib-3.7.5-cp310-cp310-macosx_10_12_universal2.whl", hash = "sha256:4a87b69cb1cb20943010f63feb0b2901c17a3b435f75349fd9865713bfa63925"},
+    {file = "matplotlib-3.7.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:d3ce45010fefb028359accebb852ca0c21bd77ec0f281952831d235228f15810"},
+    {file = "matplotlib-3.7.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fbea1e762b28400393d71be1a02144aa16692a3c4c676ba0178ce83fc2928fdd"},
+    {file = "matplotlib-3.7.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec0e1adc0ad70ba8227e957551e25a9d2995e319c29f94a97575bb90fa1d4469"},
+    {file = "matplotlib-3.7.5-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6738c89a635ced486c8a20e20111d33f6398a9cbebce1ced59c211e12cd61455"},
+    {file = "matplotlib-3.7.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1210b7919b4ed94b5573870f316bca26de3e3b07ffdb563e79327dc0e6bba515"},
+    {file = "matplotlib-3.7.5-cp310-cp310-win32.whl", hash = "sha256:068ebcc59c072781d9dcdb82f0d3f1458271c2de7ca9c78f5bd672141091e9e1"},
+    {file = "matplotlib-3.7.5-cp310-cp310-win_amd64.whl", hash = "sha256:f098ffbaab9df1e3ef04e5a5586a1e6b1791380698e84938d8640961c79b1fc0"},
+    {file = "matplotlib-3.7.5-cp311-cp311-macosx_10_12_universal2.whl", hash = "sha256:f65342c147572673f02a4abec2d5a23ad9c3898167df9b47c149f32ce61ca078"},
+    {file = "matplotlib-3.7.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:4ddf7fc0e0dc553891a117aa083039088d8a07686d4c93fb8a810adca68810af"},
+    {file = "matplotlib-3.7.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0ccb830fc29442360d91be48527809f23a5dcaee8da5f4d9b2d5b867c1b087b8"},
+    {file = "matplotlib-3.7.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efc6bb28178e844d1f408dd4d6341ee8a2e906fc9e0fa3dae497da4e0cab775d"},
+    {file = "matplotlib-3.7.5-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3b15c4c2d374f249f324f46e883340d494c01768dd5287f8bc00b65b625ab56c"},
+    {file = "matplotlib-3.7.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d028555421912307845e59e3de328260b26d055c5dac9b182cc9783854e98fb"},
+    {file = "matplotlib-3.7.5-cp311-cp311-win32.whl", hash = "sha256:fe184b4625b4052fa88ef350b815559dd90cc6cc8e97b62f966e1ca84074aafa"},
+    {file = "matplotlib-3.7.5-cp311-cp311-win_amd64.whl", hash = "sha256:084f1f0f2f1010868c6f1f50b4e1c6f2fb201c58475494f1e5b66fed66093647"},
+    {file = "matplotlib-3.7.5-cp312-cp312-macosx_10_12_universal2.whl", hash = "sha256:34bceb9d8ddb142055ff27cd7135f539f2f01be2ce0bafbace4117abe58f8fe4"},
+    {file = "matplotlib-3.7.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:c5a2134162273eb8cdfd320ae907bf84d171de948e62180fa372a3ca7cf0f433"},
+    {file = "matplotlib-3.7.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:039ad54683a814002ff37bf7981aa1faa40b91f4ff84149beb53d1eb64617980"},
+    {file = "matplotlib-3.7.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d742ccd1b09e863b4ca58291728db645b51dab343eebb08d5d4b31b308296ce"},
+    {file = "matplotlib-3.7.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:743b1c488ca6a2bc7f56079d282e44d236bf375968bfd1b7ba701fd4d0fa32d6"},
+    {file = "matplotlib-3.7.5-cp312-cp312-win_amd64.whl", hash = "sha256:fbf730fca3e1f23713bc1fae0a57db386e39dc81ea57dc305c67f628c1d7a342"},
+    {file = "matplotlib-3.7.5-cp38-cp38-macosx_10_12_universal2.whl", hash = "sha256:cfff9b838531698ee40e40ea1a8a9dc2c01edb400b27d38de6ba44c1f9a8e3d2"},
+    {file = "matplotlib-3.7.5-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:1dbcca4508bca7847fe2d64a05b237a3dcaec1f959aedb756d5b1c67b770c5ee"},
+    {file = "matplotlib-3.7.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4cdf4ef46c2a1609a50411b66940b31778db1e4b73d4ecc2eaa40bd588979b13"},
+    {file = "matplotlib-3.7.5-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:167200ccfefd1674b60e957186dfd9baf58b324562ad1a28e5d0a6b3bea77905"},
+    {file = "matplotlib-3.7.5-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:53e64522934df6e1818b25fd48cf3b645b11740d78e6ef765fbb5fa5ce080d02"},
+    {file = "matplotlib-3.7.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3e3bc79b2d7d615067bd010caff9243ead1fc95cf735c16e4b2583173f717eb"},
+    {file = "matplotlib-3.7.5-cp38-cp38-win32.whl", hash = "sha256:6b641b48c6819726ed47c55835cdd330e53747d4efff574109fd79b2d8a13748"},
+    {file = "matplotlib-3.7.5-cp38-cp38-win_amd64.whl", hash = "sha256:f0b60993ed3488b4532ec6b697059897891927cbfc2b8d458a891b60ec03d9d7"},
+    {file = "matplotlib-3.7.5-cp39-cp39-macosx_10_12_universal2.whl", hash = "sha256:090964d0afaff9c90e4d8de7836757e72ecfb252fb02884016d809239f715651"},
+    {file = "matplotlib-3.7.5-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:9fc6fcfbc55cd719bc0bfa60bde248eb68cf43876d4c22864603bdd23962ba25"},
+    {file = "matplotlib-3.7.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5e7cc3078b019bb863752b8b60e8b269423000f1603cb2299608231996bd9d54"},
+    {file = "matplotlib-3.7.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e4e9a868e8163abaaa8259842d85f949a919e1ead17644fb77a60427c90473c"},
+    {file = "matplotlib-3.7.5-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fa7ebc995a7d747dacf0a717d0eb3aa0f0c6a0e9ea88b0194d3a3cd241a1500f"},
+    {file = "matplotlib-3.7.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3785bfd83b05fc0e0c2ae4c4a90034fe693ef96c679634756c50fe6efcc09856"},
+    {file = "matplotlib-3.7.5-cp39-cp39-win32.whl", hash = "sha256:29b058738c104d0ca8806395f1c9089dfe4d4f0f78ea765c6c704469f3fffc81"},
+    {file = "matplotlib-3.7.5-cp39-cp39-win_amd64.whl", hash = "sha256:fd4028d570fa4b31b7b165d4a685942ae9cdc669f33741e388c01857d9723eab"},
+    {file = "matplotlib-3.7.5-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:2a9a3f4d6a7f88a62a6a18c7e6a84aedcaf4faf0708b4ca46d87b19f1b526f88"},
+    {file = "matplotlib-3.7.5-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9b3fd853d4a7f008a938df909b96db0b454225f935d3917520305b90680579c"},
+    {file = "matplotlib-3.7.5-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0ad550da9f160737d7890217c5eeed4337d07e83ca1b2ca6535078f354e7675"},
+    {file = "matplotlib-3.7.5-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:20da7924a08306a861b3f2d1da0d1aa9a6678e480cf8eacffe18b565af2813e7"},
+    {file = "matplotlib-3.7.5-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b45c9798ea6bb920cb77eb7306409756a7fab9db9b463e462618e0559aecb30e"},
+    {file = "matplotlib-3.7.5-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a99866267da1e561c7776fe12bf4442174b79aac1a47bd7e627c7e4d077ebd83"},
+    {file = "matplotlib-3.7.5-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b6aa62adb6c268fc87d80f963aca39c64615c31830b02697743c95590ce3fbb"},
+    {file = "matplotlib-3.7.5-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:e530ab6a0afd082d2e9c17eb1eb064a63c5b09bb607b2b74fa41adbe3e162286"},
+    {file = "matplotlib-3.7.5.tar.gz", hash = "sha256:1e5c971558ebc811aa07f54c7b7c677d78aa518ef4c390e14673a09e0860184a"},
+]
+
+[package.dependencies]
+contourpy = ">=1.0.1"
+cycler = ">=0.10"
+fonttools = ">=4.22.0"
+importlib-resources = {version = ">=3.2.0", markers = "python_version < \"3.10\""}
+kiwisolver = ">=1.0.1"
+numpy = ">=1.20,<2"
+packaging = ">=20.0"
+pillow = ">=6.2.0"
+pyparsing = ">=2.3.1"
+python-dateutil = ">=2.7"
 
 [[package]]
 name = "mypy"
@@ -610,6 +985,103 @@ files = [
 ]
 
 [[package]]
+name = "pillow"
+version = "10.4.0"
+description = "Python Imaging Library (Fork)"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "pillow-10.4.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:4d9667937cfa347525b319ae34375c37b9ee6b525440f3ef48542fcf66f2731e"},
+    {file = "pillow-10.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:543f3dc61c18dafb755773efc89aae60d06b6596a63914107f75459cf984164d"},
+    {file = "pillow-10.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7928ecbf1ece13956b95d9cbcfc77137652b02763ba384d9ab508099a2eca856"},
+    {file = "pillow-10.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4d49b85c4348ea0b31ea63bc75a9f3857869174e2bf17e7aba02945cd218e6f"},
+    {file = "pillow-10.4.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:6c762a5b0997f5659a5ef2266abc1d8851ad7749ad9a6a5506eb23d314e4f46b"},
+    {file = "pillow-10.4.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:a985e028fc183bf12a77a8bbf36318db4238a3ded7fa9df1b9a133f1cb79f8fc"},
+    {file = "pillow-10.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:812f7342b0eee081eaec84d91423d1b4650bb9828eb53d8511bcef8ce5aecf1e"},
+    {file = "pillow-10.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ac1452d2fbe4978c2eec89fb5a23b8387aba707ac72810d9490118817d9c0b46"},
+    {file = "pillow-10.4.0-cp310-cp310-win32.whl", hash = "sha256:bcd5e41a859bf2e84fdc42f4edb7d9aba0a13d29a2abadccafad99de3feff984"},
+    {file = "pillow-10.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:ecd85a8d3e79cd7158dec1c9e5808e821feea088e2f69a974db5edf84dc53141"},
+    {file = "pillow-10.4.0-cp310-cp310-win_arm64.whl", hash = "sha256:ff337c552345e95702c5fde3158acb0625111017d0e5f24bf3acdb9cc16b90d1"},
+    {file = "pillow-10.4.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:0a9ec697746f268507404647e531e92889890a087e03681a3606d9b920fbee3c"},
+    {file = "pillow-10.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfe91cb65544a1321e631e696759491ae04a2ea11d36715eca01ce07284738be"},
+    {file = "pillow-10.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5dc6761a6efc781e6a1544206f22c80c3af4c8cf461206d46a1e6006e4429ff3"},
+    {file = "pillow-10.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e84b6cc6a4a3d76c153a6b19270b3526a5a8ed6b09501d3af891daa2a9de7d6"},
+    {file = "pillow-10.4.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:bbc527b519bd3aa9d7f429d152fea69f9ad37c95f0b02aebddff592688998abe"},
+    {file = "pillow-10.4.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:76a911dfe51a36041f2e756b00f96ed84677cdeb75d25c767f296c1c1eda1319"},
+    {file = "pillow-10.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:59291fb29317122398786c2d44427bbd1a6d7ff54017075b22be9d21aa59bd8d"},
+    {file = "pillow-10.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:416d3a5d0e8cfe4f27f574362435bc9bae57f679a7158e0096ad2beb427b8696"},
+    {file = "pillow-10.4.0-cp311-cp311-win32.whl", hash = "sha256:7086cc1d5eebb91ad24ded9f58bec6c688e9f0ed7eb3dbbf1e4800280a896496"},
+    {file = "pillow-10.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:cbed61494057c0f83b83eb3a310f0bf774b09513307c434d4366ed64f4128a91"},
+    {file = "pillow-10.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:f5f0c3e969c8f12dd2bb7e0b15d5c468b51e5017e01e2e867335c81903046a22"},
+    {file = "pillow-10.4.0-cp312-cp312-macosx_10_10_x86_64.whl", hash = "sha256:673655af3eadf4df6b5457033f086e90299fdd7a47983a13827acf7459c15d94"},
+    {file = "pillow-10.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:866b6942a92f56300012f5fbac71f2d610312ee65e22f1aa2609e491284e5597"},
+    {file = "pillow-10.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29dbdc4207642ea6aad70fbde1a9338753d33fb23ed6956e706936706f52dd80"},
+    {file = "pillow-10.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf2342ac639c4cf38799a44950bbc2dfcb685f052b9e262f446482afaf4bffca"},
+    {file = "pillow-10.4.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f5b92f4d70791b4a67157321c4e8225d60b119c5cc9aee8ecf153aace4aad4ef"},
+    {file = "pillow-10.4.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:86dcb5a1eb778d8b25659d5e4341269e8590ad6b4e8b44d9f4b07f8d136c414a"},
+    {file = "pillow-10.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:780c072c2e11c9b2c7ca37f9a2ee8ba66f44367ac3e5c7832afcfe5104fd6d1b"},
+    {file = "pillow-10.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:37fb69d905be665f68f28a8bba3c6d3223c8efe1edf14cc4cfa06c241f8c81d9"},
+    {file = "pillow-10.4.0-cp312-cp312-win32.whl", hash = "sha256:7dfecdbad5c301d7b5bde160150b4db4c659cee2b69589705b6f8a0c509d9f42"},
+    {file = "pillow-10.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:1d846aea995ad352d4bdcc847535bd56e0fd88d36829d2c90be880ef1ee4668a"},
+    {file = "pillow-10.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:e553cad5179a66ba15bb18b353a19020e73a7921296a7979c4a2b7f6a5cd57f9"},
+    {file = "pillow-10.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8bc1a764ed8c957a2e9cacf97c8b2b053b70307cf2996aafd70e91a082e70df3"},
+    {file = "pillow-10.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6209bb41dc692ddfee4942517c19ee81b86c864b626dbfca272ec0f7cff5d9fb"},
+    {file = "pillow-10.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bee197b30783295d2eb680b311af15a20a8b24024a19c3a26431ff83eb8d1f70"},
+    {file = "pillow-10.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ef61f5dd14c300786318482456481463b9d6b91ebe5ef12f405afbba77ed0be"},
+    {file = "pillow-10.4.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:297e388da6e248c98bc4a02e018966af0c5f92dfacf5a5ca22fa01cb3179bca0"},
+    {file = "pillow-10.4.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e4db64794ccdf6cb83a59d73405f63adbe2a1887012e308828596100a0b2f6cc"},
+    {file = "pillow-10.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd2880a07482090a3bcb01f4265f1936a903d70bc740bfcb1fd4e8a2ffe5cf5a"},
+    {file = "pillow-10.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b35b21b819ac1dbd1233317adeecd63495f6babf21b7b2512d244ff6c6ce309"},
+    {file = "pillow-10.4.0-cp313-cp313-win32.whl", hash = "sha256:551d3fd6e9dc15e4c1eb6fc4ba2b39c0c7933fa113b220057a34f4bb3268a060"},
+    {file = "pillow-10.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:030abdbe43ee02e0de642aee345efa443740aa4d828bfe8e2eb11922ea6a21ea"},
+    {file = "pillow-10.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:5b001114dd152cfd6b23befeb28d7aee43553e2402c9f159807bf55f33af8a8d"},
+    {file = "pillow-10.4.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:8d4d5063501b6dd4024b8ac2f04962d661222d120381272deea52e3fc52d3736"},
+    {file = "pillow-10.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7c1ee6f42250df403c5f103cbd2768a28fe1a0ea1f0f03fe151c8741e1469c8b"},
+    {file = "pillow-10.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b15e02e9bb4c21e39876698abf233c8c579127986f8207200bc8a8f6bb27acf2"},
+    {file = "pillow-10.4.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a8d4bade9952ea9a77d0c3e49cbd8b2890a399422258a77f357b9cc9be8d680"},
+    {file = "pillow-10.4.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:43efea75eb06b95d1631cb784aa40156177bf9dd5b4b03ff38979e048258bc6b"},
+    {file = "pillow-10.4.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:950be4d8ba92aca4b2bb0741285a46bfae3ca699ef913ec8416c1b78eadd64cd"},
+    {file = "pillow-10.4.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:d7480af14364494365e89d6fddc510a13e5a2c3584cb19ef65415ca57252fb84"},
+    {file = "pillow-10.4.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:73664fe514b34c8f02452ffb73b7a92c6774e39a647087f83d67f010eb9a0cf0"},
+    {file = "pillow-10.4.0-cp38-cp38-win32.whl", hash = "sha256:e88d5e6ad0d026fba7bdab8c3f225a69f063f116462c49892b0149e21b6c0a0e"},
+    {file = "pillow-10.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:5161eef006d335e46895297f642341111945e2c1c899eb406882a6c61a4357ab"},
+    {file = "pillow-10.4.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:0ae24a547e8b711ccaaf99c9ae3cd975470e1a30caa80a6aaee9a2f19c05701d"},
+    {file = "pillow-10.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:298478fe4f77a4408895605f3482b6cc6222c018b2ce565c2b6b9c354ac3229b"},
+    {file = "pillow-10.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:134ace6dc392116566980ee7436477d844520a26a4b1bd4053f6f47d096997fd"},
+    {file = "pillow-10.4.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:930044bb7679ab003b14023138b50181899da3f25de50e9dbee23b61b4de2126"},
+    {file = "pillow-10.4.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:c76e5786951e72ed3686e122d14c5d7012f16c8303a674d18cdcd6d89557fc5b"},
+    {file = "pillow-10.4.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:b2724fdb354a868ddf9a880cb84d102da914e99119211ef7ecbdc613b8c96b3c"},
+    {file = "pillow-10.4.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:dbc6ae66518ab3c5847659e9988c3b60dc94ffb48ef9168656e0019a93dbf8a1"},
+    {file = "pillow-10.4.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:06b2f7898047ae93fad74467ec3d28fe84f7831370e3c258afa533f81ef7f3df"},
+    {file = "pillow-10.4.0-cp39-cp39-win32.whl", hash = "sha256:7970285ab628a3779aecc35823296a7869f889b8329c16ad5a71e4901a3dc4ef"},
+    {file = "pillow-10.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:961a7293b2457b405967af9c77dcaa43cc1a8cd50d23c532e62d48ab6cdd56f5"},
+    {file = "pillow-10.4.0-cp39-cp39-win_arm64.whl", hash = "sha256:32cda9e3d601a52baccb2856b8ea1fc213c90b340c542dcef77140dfa3278a9e"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:5b4815f2e65b30f5fbae9dfffa8636d992d49705723fe86a3661806e069352d4"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:8f0aef4ef59694b12cadee839e2ba6afeab89c0f39a3adc02ed51d109117b8da"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f4727572e2918acaa9077c919cbbeb73bd2b3ebcfe033b72f858fc9fbef0026"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff25afb18123cea58a591ea0244b92eb1e61a1fd497bf6d6384f09bc3262ec3e"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:dc3e2db6ba09ffd7d02ae9141cfa0ae23393ee7687248d46a7507b75d610f4f5"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:02a2be69f9c9b8c1e97cf2713e789d4e398c751ecfd9967c18d0ce304efbf885"},
+    {file = "pillow-10.4.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:0755ffd4a0c6f267cccbae2e9903d95477ca2f77c4fcf3a3a09570001856c8a5"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:a02364621fe369e06200d4a16558e056fe2805d3468350df3aef21e00d26214b"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:1b5dea9831a90e9d0721ec417a80d4cbd7022093ac38a568db2dd78363b00908"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b885f89040bb8c4a1573566bbb2f44f5c505ef6e74cec7ab9068c900047f04b"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87dd88ded2e6d74d31e1e0a99a726a6765cda32d00ba72dc37f0651f306daaa8"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:2db98790afc70118bd0255c2eeb465e9767ecf1f3c25f9a1abb8ffc8cfd1fe0a"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:f7baece4ce06bade126fb84b8af1c33439a76d8a6fd818970215e0560ca28c27"},
+    {file = "pillow-10.4.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:cfdd747216947628af7b259d274771d84db2268ca062dd5faf373639d00113a3"},
+    {file = "pillow-10.4.0.tar.gz", hash = "sha256:166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06"},
+]
+
+[package.extras]
+docs = ["furo", "olefile", "sphinx (>=7.3)", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxext-opengraph"]
+fpx = ["olefile"]
+mic = ["olefile"]
+tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
+typing = ["typing-extensions"]
+xmp = ["defusedxml"]
+
+[[package]]
 name = "platformdirs"
 version = "3.8.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -656,6 +1128,39 @@ identify = ">=1.0.0"
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
+
+[[package]]
+name = "pycocotools"
+version = "2.0.7"
+description = "Official APIs for the MS-COCO dataset"
+optional = true
+python-versions = ">=3.5"
+files = [
+    {file = "pycocotools-2.0.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a6683a002fcb4500edbcec94bdf48be69f578a9aa5c638db38614df1f45cc935"},
+    {file = "pycocotools-2.0.7-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d517ec315e53ef8df9f6b0899ebc4c79bd61fd715383861949bb1c3fca2c6d5"},
+    {file = "pycocotools-2.0.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eb5d46900375adaba88eedb5cbc29d8cbcf43e82505d67378df1c3b720a8c5f"},
+    {file = "pycocotools-2.0.7-cp310-cp310-win_amd64.whl", hash = "sha256:363a6be808125306ace1a163c0b9ba479ee08eceec1fbd3889a88bd8245f73dc"},
+    {file = "pycocotools-2.0.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:623b941bbafecbfee574aedbf3cb257f7a879f4fdb79394e6d3fb9c76e7ad6cf"},
+    {file = "pycocotools-2.0.7-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ac4f30bac1503c780072053e6922971392fa3628b2e6967192bfca1f14736e2"},
+    {file = "pycocotools-2.0.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:121017ca87e2eec4e9081636d1a79519b50f473959defc5671c2d1ce0eec482e"},
+    {file = "pycocotools-2.0.7-cp311-cp311-win_amd64.whl", hash = "sha256:4a8ec6f439638120e11f49120e1ddb6c66e0b1f293d7884207d02703a73d25a1"},
+    {file = "pycocotools-2.0.7-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1a675728e459d72be6e3bb3546672bb37c7daffdc2e5335aa7b834aece2b560"},
+    {file = "pycocotools-2.0.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6541340f26bae32e044eedc5d8ccdac5bd0cb64eb2b0a342dac859b696edd0aa"},
+    {file = "pycocotools-2.0.7-cp37-cp37m-win_amd64.whl", hash = "sha256:8def3c46349e919999d6d5a1d6b7e587e6891524cc28f8b4a11e463bf0914621"},
+    {file = "pycocotools-2.0.7-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:6469089b9b36a1f645dc9ee830f29d261e99b4b3be73cb260688fd8b6d02760c"},
+    {file = "pycocotools-2.0.7-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1dbc429018149dc34e206ea32ee6297ff30b55a8615a3f7f4c6e3842f9df73db"},
+    {file = "pycocotools-2.0.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66864bec8b30d47faa946bb55c8e8d6b7acb9fba0c17ff6aaa37abd78cda962a"},
+    {file = "pycocotools-2.0.7-cp38-cp38-win_amd64.whl", hash = "sha256:625388f52e543f6f798f75f1ec125fe519580f22e72ccbd75eee0355ce336e18"},
+    {file = "pycocotools-2.0.7-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:73dc251ae4a06b7c10747ca7e2d29faabb4f13e5fc43760945966845581e79ae"},
+    {file = "pycocotools-2.0.7-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e6f7bfa1c5fb206a614bf2382c923d56092219a12dfd0fec3b5f83c13e29e00"},
+    {file = "pycocotools-2.0.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b29086b6ce7b73e4ddaf3045006f5c059f344a2720605cd4474814017ff2af53"},
+    {file = "pycocotools-2.0.7-cp39-cp39-win_amd64.whl", hash = "sha256:254506c0eecabb3abbde17640f82103c0c04d53148ae920657664cab9cd649fc"},
+    {file = "pycocotools-2.0.7.tar.gz", hash = "sha256:da8b7815196eebf0adabf67fcc459126cbc6498bbc6ab1fd144c371465d86879"},
+]
+
+[package.dependencies]
+matplotlib = ">=2.1.0"
+numpy = "*"
 
 [[package]]
 name = "pycparser"
@@ -777,6 +1282,20 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
+
+[[package]]
+name = "pyparsing"
+version = "3.1.4"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+optional = true
+python-versions = ">=3.6.8"
+files = [
+    {file = "pyparsing-3.1.4-py3-none-any.whl", hash = "sha256:a6a7ee4235a3f944aa1fa2249307708f893fe5717dc603503c6c7969c070fb7c"},
+    {file = "pyparsing-3.1.4.tar.gz", hash = "sha256:f86ec8d1a83f11977c9a6ea7598e8c27fc5cddfa5b07ea2241edbbde1d7bc032"},
+]
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pyright"
@@ -957,6 +1476,64 @@ testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[l
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
+name = "shapely"
+version = "2.0.6"
+description = "Manipulation and analysis of geometric objects"
+optional = true
+python-versions = ">=3.7"
+files = [
+    {file = "shapely-2.0.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:29a34e068da2d321e926b5073539fd2a1d4429a2c656bd63f0bd4c8f5b236d0b"},
+    {file = "shapely-2.0.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c84c3f53144febf6af909d6b581bc05e8785d57e27f35ebaa5c1ab9baba13b"},
+    {file = "shapely-2.0.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ad2fae12dca8d2b727fa12b007e46fbc522148a584f5d6546c539f3464dccde"},
+    {file = "shapely-2.0.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3304883bd82d44be1b27a9d17f1167fda8c7f5a02a897958d86c59ec69b705e"},
+    {file = "shapely-2.0.6-cp310-cp310-win32.whl", hash = "sha256:3ec3a0eab496b5e04633a39fa3d5eb5454628228201fb24903d38174ee34565e"},
+    {file = "shapely-2.0.6-cp310-cp310-win_amd64.whl", hash = "sha256:28f87cdf5308a514763a5c38de295544cb27429cfa655d50ed8431a4796090c4"},
+    {file = "shapely-2.0.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5aeb0f51a9db176da9a30cb2f4329b6fbd1e26d359012bb0ac3d3c7781667a9e"},
+    {file = "shapely-2.0.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9a7a78b0d51257a367ee115f4d41ca4d46edbd0dd280f697a8092dd3989867b2"},
+    {file = "shapely-2.0.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f32c23d2f43d54029f986479f7c1f6e09c6b3a19353a3833c2ffb226fb63a855"},
+    {file = "shapely-2.0.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3dc9fb0eb56498912025f5eb352b5126f04801ed0e8bdbd867d21bdbfd7cbd0"},
+    {file = "shapely-2.0.6-cp311-cp311-win32.whl", hash = "sha256:d93b7e0e71c9f095e09454bf18dad5ea716fb6ced5df3cb044564a00723f339d"},
+    {file = "shapely-2.0.6-cp311-cp311-win_amd64.whl", hash = "sha256:c02eb6bf4cfb9fe6568502e85bb2647921ee49171bcd2d4116c7b3109724ef9b"},
+    {file = "shapely-2.0.6-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:cec9193519940e9d1b86a3b4f5af9eb6910197d24af02f247afbfb47bcb3fab0"},
+    {file = "shapely-2.0.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83b94a44ab04a90e88be69e7ddcc6f332da7c0a0ebb1156e1c4f568bbec983c3"},
+    {file = "shapely-2.0.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:537c4b2716d22c92036d00b34aac9d3775e3691f80c7aa517c2c290351f42cd8"},
+    {file = "shapely-2.0.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fea108334be345c283ce74bf064fa00cfdd718048a8af7343c59eb40f59726"},
+    {file = "shapely-2.0.6-cp312-cp312-win32.whl", hash = "sha256:42fd4cd4834747e4990227e4cbafb02242c0cffe9ce7ef9971f53ac52d80d55f"},
+    {file = "shapely-2.0.6-cp312-cp312-win_amd64.whl", hash = "sha256:665990c84aece05efb68a21b3523a6b2057e84a1afbef426ad287f0796ef8a48"},
+    {file = "shapely-2.0.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:42805ef90783ce689a4dde2b6b2f261e2c52609226a0438d882e3ced40bb3013"},
+    {file = "shapely-2.0.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6d2cb146191a47bd0cee8ff5f90b47547b82b6345c0d02dd8b25b88b68af62d7"},
+    {file = "shapely-2.0.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3fdef0a1794a8fe70dc1f514440aa34426cc0ae98d9a1027fb299d45741c381"},
+    {file = "shapely-2.0.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c665a0301c645615a107ff7f52adafa2153beab51daf34587170d85e8ba6805"},
+    {file = "shapely-2.0.6-cp313-cp313-win32.whl", hash = "sha256:0334bd51828f68cd54b87d80b3e7cee93f249d82ae55a0faf3ea21c9be7b323a"},
+    {file = "shapely-2.0.6-cp313-cp313-win_amd64.whl", hash = "sha256:d37d070da9e0e0f0a530a621e17c0b8c3c9d04105655132a87cfff8bd77cc4c2"},
+    {file = "shapely-2.0.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fa7468e4f5b92049c0f36d63c3e309f85f2775752e076378e36c6387245c5462"},
+    {file = "shapely-2.0.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed5867e598a9e8ac3291da6cc9baa62ca25706eea186117034e8ec0ea4355653"},
+    {file = "shapely-2.0.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81d9dfe155f371f78c8d895a7b7f323bb241fb148d848a2bf2244f79213123fe"},
+    {file = "shapely-2.0.6-cp37-cp37m-win32.whl", hash = "sha256:fbb7bf02a7542dba55129062570211cfb0defa05386409b3e306c39612e7fbcc"},
+    {file = "shapely-2.0.6-cp37-cp37m-win_amd64.whl", hash = "sha256:837d395fac58aa01aa544495b97940995211e3e25f9aaf87bc3ba5b3a8cd1ac7"},
+    {file = "shapely-2.0.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c6d88ade96bf02f6bfd667ddd3626913098e243e419a0325ebef2bbd481d1eb6"},
+    {file = "shapely-2.0.6-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8b3b818c4407eaa0b4cb376fd2305e20ff6df757bf1356651589eadc14aab41b"},
+    {file = "shapely-2.0.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bbc783529a21f2bd50c79cef90761f72d41c45622b3e57acf78d984c50a5d13"},
+    {file = "shapely-2.0.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2423f6c0903ebe5df6d32e0066b3d94029aab18425ad4b07bf98c3972a6e25a1"},
+    {file = "shapely-2.0.6-cp38-cp38-win32.whl", hash = "sha256:2de00c3bfa80d6750832bde1d9487e302a6dd21d90cb2f210515cefdb616e5f5"},
+    {file = "shapely-2.0.6-cp38-cp38-win_amd64.whl", hash = "sha256:3a82d58a1134d5e975f19268710e53bddd9c473743356c90d97ce04b73e101ee"},
+    {file = "shapely-2.0.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:392f66f458a0a2c706254f473290418236e52aa4c9b476a072539d63a2460595"},
+    {file = "shapely-2.0.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:eba5bae271d523c938274c61658ebc34de6c4b33fdf43ef7e938b5776388c1be"},
+    {file = "shapely-2.0.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7060566bc4888b0c8ed14b5d57df8a0ead5c28f9b69fb6bed4476df31c51b0af"},
+    {file = "shapely-2.0.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b02154b3e9d076a29a8513dffcb80f047a5ea63c897c0cd3d3679f29363cf7e5"},
+    {file = "shapely-2.0.6-cp39-cp39-win32.whl", hash = "sha256:44246d30124a4f1a638a7d5419149959532b99dfa25b54393512e6acc9c211ac"},
+    {file = "shapely-2.0.6-cp39-cp39-win_amd64.whl", hash = "sha256:2b542d7f1dbb89192d3512c52b679c822ba916f93479fa5d4fc2fe4fa0b3c9e8"},
+    {file = "shapely-2.0.6.tar.gz", hash = "sha256:997f6159b1484059ec239cacaa53467fd8b5564dabe186cd84ac2944663b0bf6"},
+]
+
+[package.dependencies]
+numpy = ">=1.14,<3"
+
+[package.extras]
+docs = ["matplotlib", "numpydoc (==1.1.*)", "sphinx", "sphinx-book-theme", "sphinx-remove-toctrees"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1073,7 +1650,29 @@ platformdirs = ">=3.5.1,<4"
 docs = ["furo (>=2023.5.20)", "proselint (>=0.13)", "sphinx (>=7.0.1)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.3.1)", "pytest-env (>=0.8.1)", "pytest-freezer (>=0.4.6)", "pytest-mock (>=3.10)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=67.8)", "time-machine (>=2.9)"]
 
+[[package]]
+name = "zipp"
+version = "3.20.2"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350"},
+    {file = "zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=2.2)"]
+test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
+type = ["pytest-mypy"]
+
+[extras]
+coco = ["pycocotools", "shapely"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "6faf04b9ddb7ff497a295e0d7a92670f4f19924dbf997a48e94229ee7057414f"
+content-hash = "9f298290a098bbe5076054e29c2590350a0bd5db2d71e1693906d330957de648"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,11 @@ cryptography = ">=3.4.8"
 tqdm = "^4.32.1"
 pydantic = ">=1.10.14"
 orjson = ">=2"
+pycocotools = {version = "^2.0.7", optional = true}
+shapely = {version = "^2.0.4", optional = true}
+
+[tool.poetry.extras]
+coco = ["pycocotools", "shapely"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.1"

--- a/tests/objects/data/data_1.py
+++ b/tests/objects/data/data_1.py
@@ -1,4 +1,6 @@
-labels = {
+from typing import Any, Dict
+
+labels: Dict[str, Any] = {
     "label_hash": "1b4398aa-1d4d-4873-8470-2ac9fa373ac0",
     "branch_name": "main",
     "created_at": "2023-02-09 14:12:03",
@@ -167,7 +169,7 @@ labels = {
     "label_status": "LABELLED",
 }
 
-ontology = {
+ontology: Dict[str, Any] = {
     "objects": [
         {"id": "1", "name": "Epiglottis ", "color": "#D33115", "shape": "bounding_box", "featureNodeHash": "249c9370"},
         {"id": "2", "name": "Larynx", "color": "#E27300", "shape": "bounding_box", "featureNodeHash": "e3c87d43"},

--- a/tests/test_coco_export.py
+++ b/tests/test_coco_export.py
@@ -1,13 +1,14 @@
+from typing import Any, Dict
 from unittest.mock import patch
 
 import pytest
 
 from encord.objects.ontology_structure import OntologyStructure
-from tests.objects.data.data_1 import ontology as BASE_ONTOLOGY_DICT
 from tests.objects.data.data_1 import labels as BASE_LABEL_DICT
+from tests.objects.data.data_1 import ontology as BASE_ONTOLOGY_DICT
 
 ontology_structure = OntologyStructure.from_dict(BASE_ONTOLOGY_DICT)
-EXPECTED_COCO_RESULT = {
+EXPECTED_COCO_RESULT: Dict[str, Any] = {
     "info": {
         "description": "failing_video_new.mp4",
         "contributor": None,
@@ -251,6 +252,5 @@ def test_coco_exporter_with_coco_extra():
         from encord.utilities.coco.exporter import CocoExporter
     except ImportError:
         return
-
     output = CocoExporter([BASE_LABEL_DICT], ontology_structure).export()
     assert output == EXPECTED_COCO_RESULT

--- a/tests/test_coco_export.py
+++ b/tests/test_coco_export.py
@@ -1,0 +1,256 @@
+from unittest.mock import patch
+
+import pytest
+
+from encord.objects.ontology_structure import OntologyStructure
+from tests.objects.data.data_1 import ontology as BASE_ONTOLOGY_DICT
+from tests.objects.data.data_1 import labels as BASE_LABEL_DICT
+
+ontology_structure = OntologyStructure.from_dict(BASE_ONTOLOGY_DICT)
+EXPECTED_COCO_RESULT = {
+    "info": {
+        "description": "failing_video_new.mp4",
+        "contributor": None,
+        "date_created": None,
+        "url": None,
+        "version": None,
+        "year": None,
+    },
+    "categories": [
+        {"supercategory": "bounding_box", "id": 1, "name": "Epiglottis "},
+        {"supercategory": "bounding_box", "id": 2, "name": "Larynx"},
+        {"supercategory": "bounding_box", "id": 3, "name": "Oesophagus "},
+        {"supercategory": "polyline", "id": 4, "name": "Z-line "},
+        {"supercategory": "bounding_box", "id": 5, "name": "Stomach"},
+        {"supercategory": "bounding_box", "id": 6, "name": "Antrum "},
+        {"supercategory": "polygon", "id": 7, "name": "Incisura "},
+        {"supercategory": "bounding_box", "id": 8, "name": "D1"},
+        {"supercategory": "bounding_box", "id": 9, "name": "D2"},
+        {"supercategory": "bounding_box", "id": 10, "name": "LES"},
+        {"supercategory": "bounding_box", "id": 11, "name": "Pyloric opening "},
+        {"supercategory": "bounding_box", "id": 12, "name": "Fundus "},
+        {"supercategory": "point", "id": 13, "name": "point", "keypoints": "keypoint", "skeleton": []},
+    ],
+    "images": [
+        {
+            "coco_url": "cord-videos-dev/lFW59RQ9jcT4vHZeG14m8QWJKug1/cd63592b-a9e4-47d7-8563-aaed75c5afdc",
+            "id": 0,
+            "video_title": "failing_video_new.mp4",
+            "file_name": "videos/cd63592b-a9e4-47d7-8563-aaed75c5afdc/0.jpg",
+            "height": 480,
+            "width": 640,
+        },
+        {
+            "coco_url": "cord-videos-dev/lFW59RQ9jcT4vHZeG14m8QWJKug1/cd63592b-a9e4-47d7-8563-aaed75c5afdc",
+            "id": 1,
+            "video_title": "failing_video_new.mp4",
+            "file_name": "videos/cd63592b-a9e4-47d7-8563-aaed75c5afdc/1.jpg",
+            "height": 480,
+            "width": 640,
+        },
+        {
+            "coco_url": "cord-videos-dev/lFW59RQ9jcT4vHZeG14m8QWJKug1/cd63592b-a9e4-47d7-8563-aaed75c5afdc",
+            "id": 2,
+            "video_title": "failing_video_new.mp4",
+            "file_name": "videos/cd63592b-a9e4-47d7-8563-aaed75c5afdc/2.jpg",
+            "height": 480,
+            "width": 640,
+        },
+        {
+            "coco_url": "cord-videos-dev/lFW59RQ9jcT4vHZeG14m8QWJKug1/cd63592b-a9e4-47d7-8563-aaed75c5afdc",
+            "id": 3,
+            "video_title": "failing_video_new.mp4",
+            "file_name": "videos/cd63592b-a9e4-47d7-8563-aaed75c5afdc/3.jpg",
+            "height": 480,
+            "width": 640,
+        },
+    ],
+    "annotations": [
+        {
+            "area": 2601.9041279999997,
+            "bbox": [189.696, 120.768, 54.976, 47.327999999999996],
+            "category_id": 1,
+            "image_id": 0,
+            "iscrowd": 0,
+            "segmentation": [[189.696, 120.768, 244.672, 120.768, 244.672, 168.096, 189.696, 168.096]],
+            "keypoints": None,
+            "num_keypoints": None,
+            "id": 0,
+            "attributes": {
+                "track_id": 0,
+                "encord_track_uuid": "428fba2b",
+                "classifications": {},
+                "manual_annotation": True,
+            },
+        },
+        {
+            "area": 0.0,
+            "bbox": [271.552, 165.984, 0.0, 0.0],
+            "category_id": 13,
+            "image_id": 0,
+            "iscrowd": 0,
+            "segmentation": [[271.552, 165.984]],
+            "keypoints": [271.552, 165.984, 2.0],
+            "num_keypoints": 1,
+            "id": 1,
+            "attributes": {
+                "track_id": 1,
+                "encord_track_uuid": "82724bb2",
+                "classifications": {},
+                "manual_annotation": True,
+            },
+        },
+        {
+            "area": 999.9974399999999,
+            "bbox": [195.32800000000003, 238.512, 40.064, 24.959999999999997],
+            "category_id": 1,
+            "image_id": 0,
+            "iscrowd": 0,
+            "segmentation": [
+                [
+                    195.32800000000003,
+                    238.512,
+                    235.39200000000002,
+                    238.512,
+                    235.39200000000002,
+                    263.472,
+                    195.32800000000003,
+                    263.472,
+                ]
+            ],
+            "keypoints": None,
+            "num_keypoints": None,
+            "id": 2,
+            "attributes": {
+                "track_id": 2,
+                "encord_track_uuid": "u8BIOLmY",
+                "classifications": {},
+                "manual_annotation": True,
+            },
+        },
+        {
+            "area": 2768.498688,
+            "bbox": [340.032, 283.872, 63.104, 43.872],
+            "category_id": 1,
+            "image_id": 0,
+            "iscrowd": 0,
+            "segmentation": [
+                [340.032, 283.872, 403.13599999999997, 283.872, 403.13599999999997, 327.744, 340.032, 327.744]
+            ],
+            "keypoints": None,
+            "num_keypoints": None,
+            "id": 3,
+            "attributes": {
+                "track_id": 3,
+                "encord_track_uuid": "/ghwDXVK",
+                "classifications": {},
+                "manual_annotation": True,
+            },
+        },
+        {
+            "area": 2538.319872,
+            "bbox": [169.024, 116.016, 54.016000000000005, 46.992],
+            "category_id": 1,
+            "image_id": 1,
+            "iscrowd": 0,
+            "segmentation": [
+                [169.024, 116.016, 223.04000000000002, 116.016, 223.04000000000002, 163.008, 169.024, 163.008]
+            ],
+            "keypoints": None,
+            "num_keypoints": None,
+            "id": 4,
+            "attributes": {
+                "track_id": 0,
+                "encord_track_uuid": "428fba2b",
+                "classifications": {},
+                "manual_annotation": False,
+            },
+        },
+        {
+            "area": 999.9974399999999,
+            "bbox": [195.32800000000003, 238.512, 40.064, 24.959999999999997],
+            "category_id": 1,
+            "image_id": 1,
+            "iscrowd": 0,
+            "segmentation": [
+                [
+                    195.32800000000003,
+                    238.512,
+                    235.39200000000002,
+                    238.512,
+                    235.39200000000002,
+                    263.472,
+                    195.32800000000003,
+                    263.472,
+                ]
+            ],
+            "keypoints": None,
+            "num_keypoints": None,
+            "id": 5,
+            "attributes": {
+                "track_id": 2,
+                "encord_track_uuid": "u8BIOLmY",
+                "classifications": {},
+                "manual_annotation": True,
+            },
+        },
+        {
+            "area": 2538.319872,
+            "bbox": [169.024, 114.0, 54.016000000000005, 46.992],
+            "category_id": 1,
+            "image_id": 2,
+            "iscrowd": 0,
+            "segmentation": [
+                [169.024, 114.0, 223.04000000000002, 114.0, 223.04000000000002, 160.992, 169.024, 160.992]
+            ],
+            "keypoints": None,
+            "num_keypoints": None,
+            "id": 6,
+            "attributes": {
+                "track_id": 0,
+                "encord_track_uuid": "428fba2b",
+                "classifications": {},
+                "manual_annotation": False,
+            },
+        },
+        {
+            "area": 2538.319872,
+            "bbox": [171.968, 114.0, 54.016000000000005, 46.992],
+            "category_id": 1,
+            "image_id": 3,
+            "iscrowd": 0,
+            "segmentation": [
+                [171.968, 114.0, 225.98399999999998, 114.0, 225.98399999999998, 160.992, 171.968, 160.992]
+            ],
+            "keypoints": None,
+            "num_keypoints": None,
+            "id": 7,
+            "attributes": {
+                "track_id": 0,
+                "encord_track_uuid": "428fba2b",
+                "classifications": {},
+                "manual_annotation": False,
+            },
+        },
+    ],
+}
+
+
+def test_coco_exporter_without_coco_extra():
+    # Simulate the absence of `pycocotools` and `shapely` packages
+    with patch.dict("sys.modules", {"pycocotools": None, "shapely": None}):
+        with pytest.raises(ImportError, match="The 'pycocotools' and 'shapely' packages are required"):
+            from encord.utilities.coco.exporter import CocoExporter
+
+            output = CocoExporter([BASE_LABEL_DICT], ontology_structure).export()
+            assert output == EXPECTED_COCO_RESULT
+
+
+def test_coco_exporter_with_coco_extra():
+    try:
+        from encord.utilities.coco.exporter import CocoExporter
+    except ImportError:
+        return
+
+    output = CocoExporter([BASE_LABEL_DICT], ontology_structure).export()
+    assert output == EXPECTED_COCO_RESULT


### PR DESCRIPTION
# Introduction and Explanation
COCO Exporter. Directly pulling code from BE and swapping out models to use SDK side models. Wired into project.export_label_rows_to_COCO.

# JIRA

https://linear.app/encord/issue/EC-3689/coco-exporter-and-importer-for-sdk

# Documentation
This will require documentation and the function itself should require a docstring.

# Tests
Small unit test included on this side. Can also include an integration test of project method in BE.
# Known issues
Open for debate around location of code and interface implementation.
MAJOR Dependencies introduced: I just followed the BE code which includes a dependency on pycocotools and on Shapely. pycocotools probably necessary and not that large. Conceptually Shapely could be worked around but this is a moderate sized dependency so should be considered.