### PR TITLE
Retry on a 502 (even when retries are disabled)

### DIFF
--- a/encord/http/querier.py
+++ b/encord/http/querier.py
@@ -243,7 +243,7 @@ def create_new_session(
         status=max_retries,  # type: ignore
         other=max_retries,  # type: ignore
         allowed_methods=["POST", "PUT", "GET"],  # type: ignore  # post is there since we use it for idempotent ops too.
-        status_forcelist=[413, 429, 500, 503],
+        status_forcelist=[413, 429, 500, 502, 503],
         backoff_factor=backoff_factor,
     )
 

--- a/encord/http/querier.py
+++ b/encord/http/querier.py
@@ -237,28 +237,15 @@ class Querier:
 def create_new_session(
     max_retries: Optional[int], backoff_factor: float, connect_retries
 ) -> Generator[Session, None, None]:
-    if max_retries:
-        retry_policy = Retry(
-            connect=connect_retries,
-            read=max_retries,
-            status=max_retries,
-            other=max_retries,
-            allowed_methods=["POST", "PUT", "GET"],  # type: ignore
-            # post is there since we use it for idempotent ops too.
-            status_forcelist=[413, 429, 500, 502, 503],
-            backoff_factor=backoff_factor,
-        )
-    else:
-        retry_policy = Retry(
-            connect=connect_retries,
-            read=0,
-            status=1,
-            other=0,
-            allowed_methods=["POST", "PUT", "GET"],  # type: ignore
-            # post is there since we use it for idempotent ops too.
-            status_forcelist=[429, 502, 503],
-            backoff_factor=backoff_factor,
-        )
+    retry_policy = Retry(
+        connect=connect_retries,
+        read=max_retries,
+        status=max_retries,  # type: ignore
+        other=max_retries,  # type: ignore
+        allowed_methods=["POST", "PUT", "GET"],  # type: ignore  # post is there since we use it for idempotent ops too.
+        status_forcelist=[413, 429, 500, 503],
+        backoff_factor=backoff_factor,
+    )
 
     with Session() as session:
         session.mount("http://", HTTPAdapter(max_retries=retry_policy))


### PR DESCRIPTION
# Introduction and Explanation

Somehow the 502 code was not in 'allowed retries', even though it is kinda *the* code to retry, at least on GCP.

~~Also, somewhat controversially, force a single retry on 429 and 502 when the caller has disabled the retries overall.~~ Let's not do this.

Should make SDK integration tests more reliable and life in general a bit easier?
