### PR TITLE
Make 'move stuff from mirror folder deleted from mirror dataset' more explicit

### DIFF
--- a/encord/orm/storage.py
+++ b/encord/orm/storage.py
@@ -338,6 +338,7 @@ class DeleteItemsResponse(BaseDTO):
 class MoveItemsPayload(BaseDTO):
     item_uuids: List[UUID]
     new_parent_uuid: UUID
+    allow_synced_dataset_move: bool = False
 
 
 class MoveFoldersPayload(BaseDTO):


### PR DESCRIPTION
# Introduction and Explanation

Force users to specify a special ugly bool parameter when a 'move' operation can delete data units from datasets.

# JIRA

Fixes https://linear.app/encord/issue/EC-3094/dont-allow-moving-items-via-sdk-when-theres-a-synced-dataset-involved

# Documentation

Docstrings are updated

# Tests

Coming with the BE implementation in a separate PR https://github.com/encord-team/cord-backend/pull/3330
