### PR TITLE
Improve type annotations

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -441,7 +441,7 @@ class EncordClientDataset(EncordClient):
 
     def upload_video(
         self,
-        file_path: str,
+        file_path: Union[str, Path],
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
         title: Optional[str] = None,
         folder_uuid: Optional[uuid.UUID] = None,
@@ -464,7 +464,7 @@ class EncordClientDataset(EncordClient):
 
     def create_image_group(
         self,
-        file_paths: Iterable[str],
+        file_paths: Iterable[Union[str, Path]],
         max_workers: Optional[int] = None,
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
         title: Optional[str] = None,
@@ -509,7 +509,7 @@ class EncordClientDataset(EncordClient):
 
     def create_dicom_series(
         self,
-        file_paths: List[str],
+        file_paths: typing.Collection[Union[Path, str]],
         title: Optional[str] = None,
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
         folder_uuid: Optional[uuid.UUID] = None,
@@ -1004,7 +1004,7 @@ class EncordClientProject(EncordClient):
         }
         return self._querier.basic_setter(LabelRow, uid=uids, payload=multirequest_payload, retryable=True)
 
-    def create_label_row(self, uid, *, get_signed_url=False):
+    def create_label_row(self, uid, *, get_signed_url=False) -> typing.Any:
         """
         This function is documented in :meth:`encord.project.Project.create_label_row`.
         """

--- a/encord/dataset.py
+++ b/encord/dataset.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, TextIO, Union
+from typing import Collection, Dict, Iterable, List, Optional, TextIO, Union
 from uuid import UUID
 
 from encord.client import EncordClientDataset
@@ -177,7 +177,7 @@ class Dataset:
 
     def upload_video(
         self,
-        file_path: str,
+        file_path: Union[str, Path],
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
         title: Optional[str] = None,
         folder: Optional[Union[UUID, StorageFolder]] = None,
@@ -211,7 +211,7 @@ class Dataset:
 
     def create_image_group(
         self,
-        file_paths: Iterable[str],
+        file_paths: Iterable[Union[str, Path]],
         max_workers: Optional[int] = None,
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
         title: Optional[str] = None,
@@ -260,7 +260,7 @@ class Dataset:
 
     def create_dicom_series(
         self,
-        file_paths: List[str],
+        file_paths: Collection[Union[Path, str]],
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
         title: Optional[str] = None,
         folder: Optional[Union[UUID, StorageFolder]] = None,

--- a/encord/http/utils.py
+++ b/encord/http/utils.py
@@ -2,6 +2,7 @@ import logging
 import mimetypes
 import os.path
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterable, List, Optional, Type, Union
 from uuid import UUID
 
@@ -59,7 +60,7 @@ def _get_content_type(orm_class: Union[Type[Images], Type[Video], Type[DicomSeri
 
 
 def upload_to_signed_url_list(
-    file_paths: Iterable[str],
+    file_paths: Iterable[Union[str, Path]],
     config: BaseConfig,
     querier: Querier,
     orm_class: Union[Type[Images], Type[Video], Type[DicomSeries]],
@@ -69,6 +70,7 @@ def upload_to_signed_url_list(
     failed_uploads = []
     successful_uploads = []
     for file_path in tqdm(file_paths):
+        file_path = str(file_path)
         content_type = _get_content_type(orm_class, file_path)
         file_name = os.path.basename(file_path)
         signed_url = _get_signed_url(file_name, orm_class, querier)
@@ -144,7 +146,7 @@ def _get_signed_url(
 
 
 def _upload_single_file(
-    file_path: str,
+    file_path: Union[str, Path],
     signed_url: dict,
     content_type: Optional[str],
     *,

--- a/encord/storage.py
+++ b/encord/storage.py
@@ -5,7 +5,7 @@ import time
 from datetime import datetime
 from math import ceil
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, TextIO, Union
+from typing import Any, Collection, Dict, Iterable, List, Optional, Sequence, TextIO, Union
 from uuid import UUID
 
 import requests
@@ -118,7 +118,7 @@ class StorageFolder:
         for item in paged_items:
             yield StorageItem(self._api_client, item)
 
-    def delete(self):
+    def delete(self) -> None:
         self._api_client.delete(f"storage/folders/{self.uuid}", params=None, result_type=None)
 
     def upload_image(
@@ -272,7 +272,7 @@ class StorageFolder:
 
     def create_dicom_series(
         self,
-        file_paths: List[str],
+        file_paths: Sequence[Union[str, Path]],
         title: Optional[str] = None,
         client_metadata: Optional[Dict[str, Any]] = None,
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
@@ -346,7 +346,7 @@ class StorageFolder:
 
     def create_image_group(
         self,
-        file_paths: List[str],
+        file_paths: Collection[Union[Path, str]],
         title: Optional[str] = None,
         client_metadata: Optional[Dict[str, Any]] = None,
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
@@ -385,7 +385,7 @@ class StorageFolder:
 
     def create_image_sequence(
         self,
-        file_paths: List[str],
+        file_paths: Collection[Union[Path, str]],
         title: Optional[str] = None,
         client_metadata: Optional[Dict[str, Any]] = None,
         cloud_upload_settings: CloudUploadSettings = CloudUploadSettings(),
@@ -425,7 +425,7 @@ class StorageFolder:
 
     def _create_image_group_or_sequence(
         self,
-        file_paths: List[str],
+        file_paths: Collection[Union[Path, str]],
         title: Optional[str],
         create_video: bool,
         client_metadata: Optional[Dict[str, Any]],
@@ -671,7 +671,7 @@ class StorageFolder:
     def move_items_to_folder(
         self,
         target_folder: Union["StorageFolder", UUID],
-        items_to_move: List[Union[UUID, "StorageItem"]],
+        items_to_move: Sequence[Union[UUID, "StorageItem"]],
         allow_mirror_dataset_changes: bool = False,
     ) -> None:
         """
@@ -1128,7 +1128,7 @@ class StorageItem:
             result_type=orm_storage.StorageItem,
         )
 
-    def delete(self, remove_unused_frames=True):
+    def delete(self, remove_unused_frames=True) -> None:
         """
         Delete the item from the storage.
 

--- a/encord/utilities/label_utilities.py
+++ b/encord/utilities/label_utilities.py
@@ -27,7 +27,7 @@ from encord.constants.string_constants import (
 from encord.orm.label_row import LabelRow
 
 
-def construct_answer_dictionaries(label_row):
+def construct_answer_dictionaries(label_row) -> LabelRow:
     """
     Adds answer object and classification answer dictionaries from a label row if they do not exist.
     Integrity checks are conducted upon saving of labels.


### PR DESCRIPTION
# Introduction and Explanation

No functional changes, just type annotations. The aim is to switch the SDK tests to depend on the `HEAD` SDK and for mypy checks to pass on that combination.

See the PR to the SDK tests as a follow-up: https://github.com/encord-team/cord-backend/pull/3333

