### PR TITLE
Support bulk updates of storage items

### DIFF
--- a/encord/orm/storage.py
+++ b/encord/orm/storage.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
 from datetime import datetime
 from enum import auto
 from typing import Dict, List, Optional, Union
 from uuid import UUID
 
+from encord.http.v2.api_client import ApiClient
 from encord.orm.analytics import CamelStrEnum
 from encord.orm.base_dto import BaseDTO, Field
 from encord.orm.dataset import LongPollingStatus
@@ -357,6 +361,19 @@ class GetChildItemsParams(BaseDTO):
 class GetItemsBulkPayload(BaseDTO):
     item_uuids: List[UUID]
     sign_urls: bool = False
+
+
+class PatchItemsBulkPayload(BaseDTO):
+    item_patches: Dict[str, PatchItemPayload]
+
+
+@dataclass
+class BundledPatchItemPayload:
+    item_patches: Dict[str, PatchItemPayload]
+
+    def add(self, other: BundledPatchItemPayload) -> BundledPatchItemPayload:
+        self.item_patches.update(other.item_patches)
+        return self
 
 
 class ReencodeVideoItemsRequest(BaseDTO):


### PR DESCRIPTION
# Introduction and Explanation

What is says on the tin; using the same `with Bundle() as bundle:` mechanics we already have for some other operations.

# JIRA

Fixes https://linear.app/encord/issue/EC-3873/sdk-support-bulk-metadata-updates

# Documentation

Updated the docstring. We likely need a "recipe" document here, too.

# Tests

SDK integration tests coming in the separate PR: 

# Known issues

Relies on a bit of unhealthy magic, that with the `get_bound_partial` not-quite-a-decorator
