### PR TITLE
Let users get storage items by UUIDs in bulk

### DIFF
--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -402,6 +402,10 @@ class DataRow(dict, Formatter):
 
     @property
     def backing_item_uuid(self) -> UUID:
+        """
+        The id of the :class:`encord.storage.StorageItem` that underlies this data row.
+        See also :meth:`encord.user_client.EncordUserClient.get_storage_item`.
+        """
         backing_item_uuid: Optional[UUID] = self.get("backing_item_uuid")
         if not backing_item_uuid:
             raise NotImplementedError("Storage API is not yet implemented by the service")

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -838,6 +838,23 @@ class EncordUserClient:
         """
         return StorageItem._get_item(self._api_client, item_uuid, sign_url)
 
+    def get_storage_items(self, item_uuids: List[UUID], sign_url: bool = False) -> List[StorageItem]:
+        """
+        Get storage items by their UUIDs, in bulk. Useful for retrieving multiple items at once, e.g. when getting
+        items pointed to by :attr:`encord.orm.dataset.DataRow.backing_item_uuid` for all data rows of a dataset.
+
+        Args:
+            item_uuids: list of UUIDs of items to retrieve.
+
+        Returns:
+            A list of storage items. See :class:`encord.storage.StorageItem` for details.
+
+        Raises:
+            :class:`encord.exceptions.AuthorizationError` : If some the items with the given UUIDs do not exist or
+                the user does not have access to them.
+        """
+        return StorageItem._get_items(self._api_client, item_uuids, sign_url)
+
     def list_storage_folders(
         self,
         *,

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -828,6 +828,7 @@ class EncordUserClient:
 
         Args:
             item_uuid: The UUID of the item to retrieve.
+            sign_url: If `True`, pre-fetch a signed URL for the item (otherwise the URL will be signed on demand).
 
         Returns:
             The storage item. See :class:`encord.storage.StorageItem` for details.
@@ -845,6 +846,7 @@ class EncordUserClient:
 
         Args:
             item_uuids: list of UUIDs of items to retrieve.
+            sign_url: If `True`, pre-fetch a signed URLs for the items (otherwise the URLs will be signed on demand).
 
         Returns:
             A list of storage items. See :class:`encord.storage.StorageItem` for details.

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -850,7 +850,7 @@ class EncordUserClient:
             A list of storage items. See :class:`encord.storage.StorageItem` for details.
 
         Raises:
-            :class:`encord.exceptions.AuthorizationError` : If some the items with the given UUIDs do not exist or
+            :class:`encord.exceptions.AuthorizationError` : If some of the items with the given UUIDs do not exist or
                 the user does not have access to them.
         """
         return StorageItem._get_items(self._api_client, item_uuids, sign_url)


### PR DESCRIPTION
# Introduction and Explanation

A bit of optimisation, e.g. when one has to go from 'dataset' to 'items in the "storage"'

# JIRA

Fixes https://linear.app/encord/issue/EC-3906/expose-a-bulk-get-storage-items-from-the-encorduserclient

# Documentation

Docstrings

# Tests

As usual, in the separate PR here https://github.com/encord-team/cord-backend/pull/3342

