### PR TITLE
Add structured upload error reporting to the Storage, too

### DIFF
--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -1013,7 +1013,7 @@ class DataUnitError(BaseDTO):
     """Opaque ID of the process. Please quote this when contacting Encord support."""
 
     action_description: str
-    """Human-readable description of the action that failed (e.g. 'Uploading DICOM series'."""
+    """Human-readable description of the action that failed (e.g. 'Uploading DICOM series')."""
 
 
 class DatasetDataLongPolling(BaseDTO):

--- a/encord/orm/storage.py
+++ b/encord/orm/storage.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from encord.http.v2.api_client import ApiClient
 from encord.orm.analytics import CamelStrEnum
 from encord.orm.base_dto import BaseDTO, Field
-from encord.orm.dataset import LongPollingStatus
+from encord.orm.dataset import DataUnitError, LongPollingStatus
 
 try:
     from typing import Literal
@@ -142,6 +142,9 @@ class UploadLongPollingState(BaseDTO):
 
     units_error_count: int
     """Number of upload job units that have error status."""
+
+    unit_errors: List[DataUnitError]
+    """Structured list of per-item upload errors. See :class:`DataUnitError` for more details."""
 
 
 class CustomerProvidedVideoMetadata(BaseDTO):


### PR DESCRIPTION
# Introduction and Explanation

A follow-up to #582 , but on the 'Storage' side.

# JIRA

Fixes https://linear.app/encord/issue/EC-3894/report-folder-upload-errors-to-the-sdk-in-a-reasonably-machine

# Documentation

The docstrings.

# Tests

Coming in the BE+tests PR: https://github.com/encord-team/cord-backend/pull/3367
