### PR TITLE
Add embedding client metadata type

### DIFF
--- a/encord/orm/client_metadata_schema.py
+++ b/encord/orm/client_metadata_schema.py
@@ -13,6 +13,7 @@ class ClientMetadataSchemaTypes(StringEnum):
     DATETIME = "datetime"
     GEOSPATIAL = "geospatial"
     ENUM = "enum"
+    EMBEDDING = "embedding"
 
 
 class ClientMetadataSchema(BaseDTO):


### PR DESCRIPTION
# Introduction and Explanation
To be storing custom embeddings in the client metadata, need to add a Embeddings tag to the ClientMetadataSchema. 

# Documentation
Will require documentation if the validation methods are included.
