### PR TITLE
Skip duplicated when linking items to dataset (and add option)

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -587,12 +587,16 @@ class EncordClientDataset(EncordClient):
         else:
             raise encord.exceptions.EncordException("Image upload failed.")
 
-    def link_items(self, item_uuids: List[uuid.UUID]) -> List[DataRow]:
-        return self._querier.basic_setter(
+    def link_items(self, item_uuids: List[uuid.UUID], duplicates_behavior: str) -> List[DataRow]:
+        data_row_dicts = self._querier.basic_setter(
             DatasetLinkItems,
             uid=self._querier.resource_id,
-            payload={"item_uuids": [str(item_uuid) for item_uuid in item_uuids]},
+            payload={
+                "item_uuids": [str(item_uuid) for item_uuid in item_uuids],
+                "duplicates_behavior": duplicates_behavior,
+            },
         )
+        return DataRow.from_dict_list(data_row_dicts)
 
     def delete_image_group(self, data_hash: str):
         """

--- a/encord/client.py
+++ b/encord/client.py
@@ -81,6 +81,7 @@ from encord.orm.cloud_integration import CloudIntegration
 from encord.orm.dataset import (
     DEFAULT_DATASET_ACCESS_SETTINGS,
     AddPrivateDataResponse,
+    DataLinkDuplicatesBehavior,
     DataRow,
     DataRows,
     DatasetAccessSettings,
@@ -587,13 +588,26 @@ class EncordClientDataset(EncordClient):
         else:
             raise encord.exceptions.EncordException("Image upload failed.")
 
-    def link_items(self, item_uuids: List[uuid.UUID], duplicates_behavior: str) -> List[DataRow]:
+    def link_items(
+        self,
+        item_uuids: List[uuid.UUID],
+        duplicates_behavior: DataLinkDuplicatesBehavior = DataLinkDuplicatesBehavior.SKIP,
+    ) -> List[DataRow]:
+        """
+        Link storage items to the dataset, creating new data rows.
+
+        Args:
+            item_uuids: List of item UUIDs to link to the dataset
+            duplicates_behaviour: The behavior to follow when encountering duplicates. Defaults to `SKIP`. See also
+                :class:`encord.orm.dataset.DataLinkDuplicatesBehavior`
+        """
+
         data_row_dicts = self._querier.basic_setter(
             DatasetLinkItems,
             uid=self._querier.resource_id,
             payload={
                 "item_uuids": [str(item_uuid) for item_uuid in item_uuids],
-                "duplicates_behavior": duplicates_behavior,
+                "duplicates_behavior": duplicates_behavior.value,
             },
         )
         return DataRow.from_dict_list(data_row_dicts)

--- a/encord/dataset.py
+++ b/encord/dataset.py
@@ -334,7 +334,7 @@ class Dataset:
             duplicates_behaviour: The behavior to follow when encountering duplicates. Defaults to `SKIP`. See also
                 :class:`encord.orm.dataset.DataLinkDuplicatesBehavior`
         """
-        return self._client.link_items(item_uuids, duplicates_behavior.value)
+        return self._client.link_items(item_uuids, duplicates_behavior)
 
     def delete_image_group(self, data_hash: str):
         """

--- a/encord/dataset.py
+++ b/encord/dataset.py
@@ -9,6 +9,7 @@ from encord.http.utils import CloudUploadSettings
 from encord.orm.cloud_integration import CloudIntegration
 from encord.orm.dataset import (
     AddPrivateDataResponse,
+    DataLinkDuplicatesBehavior,
     DataRow,
     DatasetAccessSettings,
     DatasetDataLongPolling,
@@ -320,8 +321,20 @@ class Dataset:
         folder_uuid = folder.uuid if isinstance(folder, StorageFolder) else folder
         return self._client.upload_image(file_path, title, cloud_upload_settings, folder_uuid)
 
-    def link_items(self, item_uuids: List[UUID]) -> List[DataRow]:
-        return self._client.link_items(item_uuids)
+    def link_items(
+        self,
+        item_uuids: List[UUID],
+        duplicates_behavior: DataLinkDuplicatesBehavior = DataLinkDuplicatesBehavior.SKIP,
+    ) -> List[DataRow]:
+        """
+        Link storage items to the dataset, creating new data rows.
+
+        Args:
+            item_uuids: List of item UUIDs to link to the dataset
+            duplicates_behaviour: The behavior to follow when encountering duplicates. Defaults to `SKIP`. See also
+                :class:`encord.orm.dataset.DataLinkDuplicatesBehavior`
+        """
+        return self._client.link_items(item_uuids, duplicates_behavior.value)
 
     def delete_image_group(self, data_hash: str):
         """

--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -49,6 +49,12 @@ class DatasetUsers:
     pass
 
 
+class DataLinkDuplicatesBehavior(Enum):
+    DUPLICATE = "DUPLICATE"
+    FAIL = "FAIL"
+    SKIP = "SKIP"
+
+
 @dataclasses.dataclass(frozen=True)
 class DataClientMetadata:
     payload: dict


### PR DESCRIPTION
# Introduction and Explanation

Currently, the 'link storage items to a dataset' method creates new data units even if these items were previously linked, creating duplicates.

Allow the customer to specify the behaviour (skip, fail, allow) and change the default to 'skip'.

# JIRA

Fixes https://linear.app/encord/issue/EC-3875/sdk-bug-generates-duplicates-when-calling-datasetlink-items-method

# Documentation

Added some docstrings

# Tests

Coming with the BE PR
