### PR TITLE
Setup the second users's SSH key

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -12,6 +12,9 @@ inputs:
   private-key:
     description: 'Private key for integration tests'
     required: true
+  private-key-non-org:
+    description: 'Private key of the second (non-org) user for integration tests'
+    required: true
   poetry-version:
     description: 'Poetry version to use'
     default: 1.5.0
@@ -52,6 +55,7 @@ runs:
         run: |
           cd ${{ inputs.integration-tests-location }}
           export PRIVATE_KEY="${{ inputs.private-key }}"
+          export PRIVATE_KEY_NON_ORG='${{ inputs.private-key-non-org }}'
           export CORD_ENV="${{ inputs.environment }}"
           source $(poetry env info --path)/bin/activate
           poetry add git+${{ inputs.sdk-repository-url }}

--- a/.github/workflows/sdk-pr.yml
+++ b/.github/workflows/sdk-pr.yml
@@ -15,6 +15,7 @@ env:
 
   INTEGRATION_TEST_REPORT_PYTHON_3_11: integration-test-report-python3_11.xml
   INTEGRATION_TESTS_PRIVATE_KEY: ${{ secrets.SDK_TESTS_PRIVATE_KEY }}
+  INTEGRATION_TESTS_PRIVATE_KEY_NON_ORG: ${{ secrets.SDK_TESTS_PRIVATE_KEY_NON_ORG }}
 
 concurrency:
   group: cord-client-${{ github.ref }}-pr
@@ -95,6 +96,7 @@ jobs:
           integration-tests-location: ./encord-backend/projects/sdk-integration-tests
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_11 }}
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
+          private-key-non-org: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY_NON_ORG }}
           sdk-repository-url: https://github.com/encord-team/encord-client-python@${{ github.sha }}
 
       - name: Publish integration test report Python 3.11

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -20,6 +20,7 @@ env:
 
   INTEGRATION_TEST_REPORT_PYTHON_3_11: integration-test-report-python3_11.xml
   INTEGRATION_TESTS_PRIVATE_KEY: ${{ secrets.SDK_TESTS_PRIVATE_KEY }}
+  INTEGRATION_TESTS_PRIVATE_KEY_NON_ORG: ${{ secrets.SDK_TESTS_PRIVATE_KEY_NON_ORG }}
 
   BACKEND_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
   BACKEND_REPO: cord-team/cord-backend
@@ -186,6 +187,7 @@ jobs:
           integration-tests-location: ./encord-backend/projects/sdk-integration-tests
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_11 }}
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
+          private-key-non-org: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY_NON_ORG }}
           sdk-repository-url: https://github.com/encord-team/encord-client-python@${{ github.sha }}
 
 


### PR DESCRIPTION
# Introduction and Explanation

Follow the change in tests themselves, see https://github.com/encord-team/cord-backend/pull/3443 and its follow-up fixes.

# JIRA

Related to https://linear.app/encord/issue/EC-564/check-public-api-access-controls-in-the-sdk-tests (but doesn't quite 'fix' that yet)
