### PR TITLE
Adding docstrings for Workflow stages and tasks

### DIFF
--- a/encord/workflow/stages/annotation.py
+++ b/encord/workflow/stages/annotation.py
@@ -32,6 +32,12 @@ class _AnnotationTasksQueryParams(TasksQueryParams):
 class AnnotationStage(WorkflowStageBase):
     stage_type: Literal[WorkflowStageType.ANNOTATION] = WorkflowStageType.ANNOTATION
 
+    """
+    An Annotate stage in a non-Consensus Project.
+
+    You can use this stage in Consensus and non-Consensus Projects.
+    """
+
     def get_tasks(
         self,
         *,
@@ -40,6 +46,17 @@ class AnnotationStage(WorkflowStageBase):
         dataset_hash: Union[List[UUID], UUID, List[str], str, None] = None,
         data_title: Optional[str] = None,
     ) -> Iterable[AnnotationTask]:
+        """
+        **Params**
+
+        - name: Name of the stage.
+        - uuid: Unique identifier for the stage.
+        - type_: The type of stage.
+
+        **Returns
+
+        Returns Annotatoin Workflow stages from non-Consensus and Consensus Projects.
+        """
         params = _AnnotationTasksQueryParams(
             user_emails=ensure_list(assignee),
             data_hashes=ensure_uuid_list(data_hash),
@@ -71,6 +88,23 @@ class AnnotationTask(WorkflowTask):
     data_title: str
     label_branch_name: str
     assignee: Optional[str]
+
+    """
+    Tasks in non-Consensus Annotate stage.
+
+    **Params**
+
+    - assignee: User assigned to a task.
+    - data_hash: Unique ID for the data unit.
+    - data_title: Name of the data unit.
+    - label_branch_name: Name of the label branch
+
+    Allowed actions:
+
+    - submit: Submits a task for review.
+    - assign: Assigns a task to a user.
+    - release: Releases a task from the current user.
+    """
 
     def submit(self, *, bundle: Optional[Bundle] = None) -> None:
         workflow_client, stage_uuid = self._get_client_data()

--- a/encord/workflow/stages/consensus_annotation.py
+++ b/encord/workflow/stages/consensus_annotation.py
@@ -32,6 +32,10 @@ class _AnnotationTasksQueryParams(TasksQueryParams):
 class ConsensusAnnotationStage(WorkflowStageBase):
     stage_type: Literal[WorkflowStageType.CONSENSUS_ANNOTATION] = WorkflowStageType.CONSENSUS_ANNOTATION
 
+    """
+    The Annotate stage in a Consensus Project.
+    """
+
     def get_tasks(
         self,
         *,
@@ -40,6 +44,25 @@ class ConsensusAnnotationStage(WorkflowStageBase):
         dataset_hash: Union[List[UUID], UUID, List[str], str, None] = None,
         data_title: Optional[str] = None,
     ) -> Iterable[ConsensusAnnotationTask]:
+        """
+        **Params**
+
+        - assignee: User assigned to a task.
+        - data_hash: Unique ID for the data unit.
+        - dataset_hash: Unique ID for the dataset that the data unit belongs to.
+        - data_title: Name of the data unit.
+
+        **Returns**
+
+        Returns tasks in the stage with the following information:
+
+        - uuid: Unique identifier for the task.
+        - created_at: Time and date the task was created.
+        - updated_at: Time and date the task was last edited.
+        - data_hash: Unique identifier for the data unit.
+        - data_title: Name/title of the data unit.
+        - subtasks: A list of subtasks that follow the task format for AnotationTask.
+        """
         params = _AnnotationTasksQueryParams(
             user_emails=ensure_list(assignee),
             data_hashes=ensure_uuid_list(data_hash),
@@ -55,6 +78,20 @@ class ConsensusAnnotationStage(WorkflowStageBase):
 
 
 class ConsensusAnnotationTask(WorkflowTask):
+    """
+    Tasks in the Annotate stage of a Consensus Project.
+
+    **Params**
+
+    - data_hash: Unique ID for the data unit.
+    - data_title: Name of the data unit.
+    - subtasks: List[AnnotationTask] = Field(default_factory=list): Tasks from individual annotators in a Consensus Project.
+
+    Returns
+
+    Returns nothing.
+    """
+
     data_hash: UUID
     data_title: str
     subtasks: List[AnnotationTask] = Field(default_factory=list)

--- a/encord/workflow/stages/consensus_annotation.py
+++ b/encord/workflow/stages/consensus_annotation.py
@@ -54,7 +54,7 @@ class ConsensusAnnotationStage(WorkflowStageBase):
 
         **Returns**
 
-        Returns tasks in the stage with the following information:
+        Returns a list of ConsensusAnnotationTask classes, with the following information:
 
         - uuid: Unique identifier for the task.
         - created_at: Time and date the task was created.
@@ -86,10 +86,6 @@ class ConsensusAnnotationTask(WorkflowTask):
     - data_hash: Unique ID for the data unit.
     - data_title: Name of the data unit.
     - subtasks: List[AnnotationTask] = Field(default_factory=list): Tasks from individual annotators in a Consensus Project.
-
-    Returns
-
-    Returns nothing.
     """
 
     data_hash: UUID

--- a/encord/workflow/stages/consensus_review.py
+++ b/encord/workflow/stages/consensus_review.py
@@ -33,7 +33,7 @@ class ConsensusReviewStage(WorkflowStageBase):
     stage_type: Literal[WorkflowStageType.CONSENSUS_REVIEW] = WorkflowStageType.CONSENSUS_REVIEW
 
     """
-    The Review stage for Consensus Projects.
+    The Review stage for Consensus Workflows.
 
     ❗️ CRITICAL INFORMATION: To move (approve or reject) tasks in a REVIEW stage, you MUST assign yourself as the user assigned to the task.
     """

--- a/encord/workflow/stages/consensus_review.py
+++ b/encord/workflow/stages/consensus_review.py
@@ -32,6 +32,12 @@ class _ReviewTasksQueryParams(TasksQueryParams):
 class ConsensusReviewStage(WorkflowStageBase):
     stage_type: Literal[WorkflowStageType.CONSENSUS_REVIEW] = WorkflowStageType.CONSENSUS_REVIEW
 
+    """
+    The Review stage for Consensus Projects.
+
+    ❗️ CRITICAL INFORMATION: To move (approve or reject) tasks in a REVIEW stage, you MUST assign yourself as the user assigned to the task.
+    """
+
     def get_tasks(
         self,
         *,
@@ -47,6 +53,26 @@ class ConsensusReviewStage(WorkflowStageBase):
             data_title_contains=data_title,
         )
 
+        """
+        **Params**
+
+        - assignee: User assigned to a task.
+        - data_hash: Unique ID for the data unit.
+        - dataset_hash: Unique ID for the dataset that the data unit belongs to.
+        - data_title: Name of the data unit.
+
+        **Returns**
+
+        Returns tasks in the stage with the following information:
+
+        - uuid: Unique identifier for the task.
+        - created_at: Time and date the task was created.
+        - updated_at: Time and date the task was last edited.
+        - assignee: The user currently assigned to the task. The value is None if no one is assigned to the task.
+        - data_hash: Unique identifier for the data unit.
+        - data_title: Name/title of the data unit.
+        - options: List of ConsensusReviewOptions. ConsensusReviewOptions are the labels avaialble for each subtask. ConsensusReviewOptions include the following information: annotator, label_branch_name, label_hash.
+        """
         for task in self._workflow_client.get_tasks(self.uuid, params, type_=ConsensusReviewTask):
             task._stage_uuid = self.uuid
             task._workflow_client = self._workflow_client
@@ -81,6 +107,28 @@ class ConsensusReviewTask(WorkflowTask):
     data_hash: UUID
     data_title: str
     options: List[ConsensusReviewOption]
+
+    """
+    Tasks in the Review stage of a Consensus Project.
+
+    **Params**
+
+    - assignee: User assigned to a task.
+    - data_hash: Unique ID for the data unit.
+    - data_title: Name of the data unit.
+    - options: Specify the labels for the task.
+
+    Allowed actions:
+
+    - approve: Approves a task
+    - reject: Rejects a task.
+    - assign: Assigns a task to a user.
+    - release: Releases a task from the current user.
+
+    **Returns**
+
+    Returns nothing.
+    """
 
     def approve(self, *, bundle: Optional[Bundle] = None) -> None:
         workflow_client, stage_uuid = self._get_client_data()

--- a/encord/workflow/stages/final.py
+++ b/encord/workflow/stages/final.py
@@ -76,8 +76,4 @@ class FinalStageTask(WorkflowTask):
 
     - dataset_hash: Unique ID for the dataset that the data unit belongs to.
     - data_title: Name of the data unit.
-
-    **Returns**
-
-    Returns nothing.
     """

--- a/encord/workflow/stages/final.py
+++ b/encord/workflow/stages/final.py
@@ -29,6 +29,10 @@ class _FinalTasksQueryParams(TasksQueryParams):
 class FinalStage(WorkflowStageBase):
     stage_type: Literal[WorkflowStageType.DONE] = WorkflowStageType.DONE
 
+    """
+    Final stage for a task in Consensus and non-Consensus Projects. The final stages are COMPLETE or ARCHIVE.
+    """
+
     def get_tasks(
         self,
         data_hash: Union[List[UUID], UUID, List[str], str, None] = None,
@@ -41,9 +45,39 @@ class FinalStage(WorkflowStageBase):
             data_title_contains=data_title,
         )
 
+        """
+        **Parameters**
+
+        - data_hash: Unique ID for the data unit.
+        - dataset_hash: Unique ID for the dataset that the data unit belongs to.
+        - data_title: Name of the data unit.
+
+        **Returns**
+
+        Returns tasks in the stage with the following information:
+
+        - uuid: Unique identifier for the task.
+        - created_at: Time and date the task was created.
+        - updated_at: Time and date the task was last edited.
+        - data_hash: Unique identifier for the data unit.
+        - data_title: Name/title of the data unit.
+        """
         yield from self._workflow_client.get_tasks(self.uuid, params, type_=FinalStageTask)
 
 
 class FinalStageTask(WorkflowTask):
     data_hash: UUID
     data_title: str
+
+    """
+    Tasks in a FinalStage can only be queried. No actions can be taken on the task.
+
+    **Parameters**
+
+    - dataset_hash: Unique ID for the dataset that the data unit belongs to.
+    - data_title: Name of the data unit.
+
+    **Returns**
+
+    Returns nothing.
+    """

--- a/encord/workflow/stages/review.py
+++ b/encord/workflow/stages/review.py
@@ -31,6 +31,14 @@ class _ReviewTasksQueryParams(TasksQueryParams):
 class ReviewStage(WorkflowStageBase):
     stage_type: Literal[WorkflowStageType.REVIEW] = WorkflowStageType.REVIEW
 
+    """
+    The Review stage for non-Consensus Projects.
+
+    You can use this stage for Consensus and non-Consensus Projects.
+
+    ❗️ CRITICAL INFORMATION: To move (approve or reject) tasks in a REVIEW stage, you MUST assign yourself as the user assigned to the task.
+    """
+
     def get_tasks(
         self,
         *,
@@ -45,6 +53,26 @@ class ReviewStage(WorkflowStageBase):
             dataset_hashes=ensure_uuid_list(dataset_hash),
             data_title_contains=data_title,
         )
+
+        """
+        **Parameters**
+
+        - assignee: User assigned to a task.
+        - data_hash: Unique ID for the data unit.
+        - dataset_hash: Unique ID for the dataset that the data unit belongs to.
+        - data_title: Name of the data unit.
+
+        **Returns**
+
+        Returns tasks in the stage with the following information:
+
+        - uuid: Unique identifier for the task.
+        - created_at: Time and date the task was created.
+        - updated_at: Time and date the task was last edited.
+        - assignee: The user currently assigned to the task. The value is None if no one is assigned to the task.
+        - data_hash: Unique identifier for the data unit.
+        - data_title: Name/title of the data unit.
+        """
         for task in self._workflow_client.get_tasks(self.uuid, params, type_=ReviewTask):
             task._stage_uuid = self.uuid
             task._workflow_client = self._workflow_client
@@ -74,6 +102,27 @@ class ReviewTask(WorkflowTask):
     assignee: Optional[str]
     data_hash: UUID
     data_title: str
+
+    """
+    Tasks in non-Consensus Review stages.
+
+    **Params**
+
+    - assignee: Optional[str]
+    - data_hash: UUID
+    - data_title: str
+
+    Allowed actions:
+
+    - approve: Approves a task
+    - reject: Rejects a task.
+    - assign: Assigns a task to a user.
+    - release: Releases a task from the current user.
+
+    **Returns**
+
+    Returns nothing.
+    """
 
     def approve(self, *, bundle: Optional[Bundle] = None) -> None:
         workflow_client, stage_uuid = self._get_client_data()

--- a/encord/workflow/stages/review.py
+++ b/encord/workflow/stages/review.py
@@ -32,9 +32,9 @@ class ReviewStage(WorkflowStageBase):
     stage_type: Literal[WorkflowStageType.REVIEW] = WorkflowStageType.REVIEW
 
     """
-    The Review stage for non-Consensus Projects.
+    The Review stage for Workflows.
 
-    You can use this stage for Consensus and non-Consensus Projects.
+    This stage can appear in Consensus and non-Consensus Workflows.
 
     ❗️ CRITICAL INFORMATION: To move (approve or reject) tasks in a REVIEW stage, you MUST assign yourself as the user assigned to the task.
     """
@@ -64,7 +64,7 @@ class ReviewStage(WorkflowStageBase):
 
         **Returns**
 
-        Returns tasks in the stage with the following information:
+        Returns annotation tasks for the stage:
 
         - uuid: Unique identifier for the task.
         - created_at: Time and date the task was created.
@@ -118,10 +118,6 @@ class ReviewTask(WorkflowTask):
     - reject: Rejects a task.
     - assign: Assigns a task to a user.
     - release: Releases a task from the current user.
-
-    **Returns**
-
-    Returns nothing.
     """
 
     def approve(self, *, bundle: Optional[Bundle] = None) -> None:

--- a/encord/workflow/workflow.py
+++ b/encord/workflow/workflow.py
@@ -65,6 +65,10 @@ def _ensure_uuid(v: str | UUID) -> UUID:
 class Workflow:
     stages: List[WorkflowStage] = []
 
+    """
+    Workflow class in Projects.
+    """
+
     def __init__(self, api_client: ApiClient, project_hash: UUID, workflow_orm: WorkflowDTO):
         workflow_client = WorkflowClient(api_client, project_hash)
 
@@ -77,6 +81,17 @@ class Workflow:
         uuid: Optional[UUID | str] = None,
         type_: Optional[Type[WorkflowStageT]] = None,
     ) -> WorkflowStageT:
+        """
+        **Params**
+
+        - name: Name of the stage.
+        - uuid: Unique identifier for the stage.
+        - type_: The type of stage.
+
+        **Returns**
+
+        Returns Workflow stages from non-Consensus and Consensus Projects.
+        """
         for stage in self.stages:
             if (uuid is not None and stage.uuid == _ensure_uuid(uuid)) or (name is not None and stage.title == name):
                 if type_ is not None and not isinstance(stage, type_):

--- a/encord/workflow/workflow.py
+++ b/encord/workflow/workflow.py
@@ -90,7 +90,7 @@ class Workflow:
 
         **Returns**
 
-        Returns Workflow stages from non-Consensus and Consensus Projects.
+        Returns Workflow stages (`type_`) from non-Consensus and Consensus Projects.
         """
         for stage in self.stages:
             if (uuid is not None and stage.uuid == _ensure_uuid(uuid)) or (name is not None and stage.title == name):


### PR DESCRIPTION
The current Python for Workflow stages and tasks are missing docstrings. This adds the content that is in the SDK Ref docs.

