### PR TITLE
fix: stoping printing to stdout and start logging so users can disable

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -692,9 +692,9 @@ class EncordClientDataset(EncordClient):
             payload=payload,
         )["process_hash"]
 
-        print(f"add_private_data_to_dataset job started with upload_job_id={process_hash}.")
-        print("SDK process can be terminated, this will not affect successful job execution.")
-        print("You can follow the progress in the web app via notifications.")
+        logger.info(f"add_private_data_to_dataset job started with upload_job_id={process_hash}.")
+        logger.info("SDK process can be terminated, this will not affect successful job execution.")
+        logger.info("You can follow the progress in the web app via notifications.")
 
         return process_hash
 
@@ -727,7 +727,7 @@ class EncordClientDataset(EncordClient):
                 )
 
                 if res.status == LongPollingStatus.DONE:
-                    print(f"add_private_data_to_dataset job completed with upload_job_id={upload_job_id}.")
+                    logger.info(f"add_private_data_to_dataset job completed with upload_job_id={upload_job_id}.")
 
                 polling_elapsed_seconds = ceil(time.perf_counter() - polling_start_timestamp)
                 polling_available_seconds = max(0, timeout_seconds - polling_elapsed_seconds)
@@ -739,9 +739,9 @@ class EncordClientDataset(EncordClient):
                 files_total_count = res.units_pending_count + res.units_done_count + res.units_error_count
 
                 if files_finished_count != files_total_count:
-                    print(f"Processed {files_finished_count}/{files_total_count} files")
+                    logger.info(f"Processed {files_finished_count}/{files_total_count} files")
                 else:
-                    print("Processed all files, dataset data linking and task creation is performed, please wait")
+                    logger.info("Processed all files, dataset data linking and task creation is performed, please wait")
 
                 failed_requests_count = 0
             except (requests.exceptions.RequestException, encord.exceptions.RequestException):

--- a/encord/storage.py
+++ b/encord/storage.py
@@ -11,6 +11,7 @@ category: "64e481b57b6027003f20aaa0"
 """
 
 import json
+import logging
 import mimetypes
 import os
 import time
@@ -49,6 +50,8 @@ from encord.orm.storage import (
     StorageItemType,
     UploadSignedUrlsPayload,
 )
+
+logger = logging.getLogger(__name__)
 
 STORAGE_BUNDLE_CREATE_LIMIT = 1000
 
@@ -902,9 +905,9 @@ class StorageFolder:
             result_type=UUID,
         )
 
-        print(f"add_data_to_folder job started with upload_job_id={upload_job_id}.")
-        print("SDK process can be terminated, this will not affect successful job execution.")
-        print("You can follow the progress in the web app via notifications.")
+        logger.info(f"add_data_to_folder job started with upload_job_id={upload_job_id}.")
+        logger.info("SDK process can be terminated, this will not affect successful job execution.")
+        logger.info("You can follow the progress in the web app via notifications.")
 
         return upload_job_id
 
@@ -925,7 +928,7 @@ class StorageFolder:
                 )
 
                 if res.status == LongPollingStatus.DONE:
-                    print(f"add_private_data_to_dataset job completed with upload_job_id={upload_job_id}.")
+                    logger.info(f"add_private_data_to_dataset job completed with upload_job_id={upload_job_id}.")
 
                 polling_elapsed_seconds = ceil(time.perf_counter() - polling_start_timestamp)
                 polling_available_seconds = max(0, timeout_seconds - polling_elapsed_seconds)
@@ -937,9 +940,9 @@ class StorageFolder:
                 files_total_count = res.units_pending_count + res.units_done_count + res.units_error_count
 
                 if files_finished_count != files_total_count:
-                    print(f"Processed {files_finished_count}/{files_total_count} files")
+                    logger.info(f"Processed {files_finished_count}/{files_total_count} files")
                 else:
-                    print("Processed all files, dataset data linking and task creation is performed, please wait")
+                    logger.info("Processed all files, dataset data linking and task creation is performed, please wait")
 
                 failed_requests_count = 0
             except (requests.exceptions.RequestException, encord.exceptions.RequestException):


### PR DESCRIPTION
# Introduction and Explanation
From uploading 10 files to storage, this was all the stuff that was printed. 
<img width="1910" alt="image" src="https://github.com/encord-team/encord-client-python/assets/93145535/aff96ef3-0f84-4b9d-9995-1103346ee6ce">

I think that it's better to log it so users can disable prints via logging.

# Tests
No logic has changed. Just the way we print things to the console.