### PR TITLE
create_storage_folder description should be optional

### DIFF
--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -787,7 +787,7 @@ class EncordUserClient:
     def create_storage_folder(
         self,
         name: str,
-        description: Optional[str],
+        description: Optional[str] = None,
         client_metadata: Optional[Dict[str, Any]] = None,
         parent_folder: Optional[Union[StorageFolder, UUID]] = None,
     ) -> StorageFolder:


### PR DESCRIPTION
Optional means optional.
Checked in the codebase against regex "Optional\[[A-Za-z]+\],". This was the only one on a public method. Would be cool if the linter could check for us.
# Tests
Could conceptually add a SDK test asserting on this behaviour but it's kinda meh?
