### PR TITLE
Add `folder.create_subfolder() API

### DIFF
--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -804,19 +804,8 @@ class EncordUserClient:
         Returns:
             The created storage folder. See :class:`encord.storage.StorageFolder` for details.
         """
-        if isinstance(parent_folder, StorageFolder):
-            parent_folder = parent_folder.uuid
 
-        payload = CreateStorageFolderPayload(
-            name=name,
-            description=description,
-            parent=parent_folder,
-            client_metadata=json.dumps(client_metadata) if client_metadata is not None else None,
-        )
-        folder_orm = self._api_client.post(
-            "storage/folders", params=None, payload=payload, result_type=OrmStorageFolder
-        )
-        return StorageFolder(self._api_client, folder_orm)
+        return StorageFolder._create_folder(self._api_client, name, description, client_metadata, parent_folder)
 
     def get_storage_folder(self, folder_uuid: UUID) -> StorageFolder:
         """


### PR DESCRIPTION
# Introduction and Explanation

Just some obvious shorthand (plus move a bit of code around to avoid circular deps)

# JIRA

Fixes https://linear.app/encord/issue/EC-4433/creating-nested-folders-in-sdk-is-un-ergonomic

# Documentation

The docstrings are in place

# Tests

TBD

