### PR TITLE
Allow for manupulation of Storage access via Groups

### DIFF
--- a/encord/orm/group.py
+++ b/encord/orm/group.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from encord.orm.base_dto import BaseDTO
 from encord.orm.dataset import DatasetUserRole
+from encord.orm.storage import StorageUserRole
 from encord.utilities.ontology_user import OntologyUserRole
 from encord.utilities.project_user import ProjectUserRole
 
@@ -15,19 +16,24 @@ class Group(BaseDTO):
     created_at: datetime
 
 
-class ProjectGroup(Group):
+class EntityGroup(Group):
+    is_same_organisation: bool
+
+
+class ProjectGroup(EntityGroup):
     user_role: ProjectUserRole
-    is_same_organisation: bool
 
 
-class OntologyGroup(Group):
+class OntologyGroup(EntityGroup):
     user_role: OntologyUserRole
-    is_same_organisation: bool
 
 
-class DatasetGroup(Group):
+class DatasetGroup(EntityGroup):
     user_role: DatasetUserRole
-    is_same_organisation: bool
+
+
+class StorageFolderGroup(EntityGroup):
+    user_role: StorageUserRole
 
 
 class AddGroupsPayload(BaseDTO):
@@ -44,6 +50,10 @@ class AddDatasetGroupsPayload(AddGroupsPayload):
 
 class AddOntologyGroupsPayload(AddGroupsPayload):
     user_role: OntologyUserRole
+
+
+class AddStorageFolderGroupsPayload(AddGroupsPayload):
+    user_role: StorageUserRole
 
 
 class RemoveGroupsParams(BaseDTO):

--- a/encord/storage.py
+++ b/encord/storage.py
@@ -33,6 +33,7 @@ from encord.http.utils import CloudUploadSettings, _upload_single_file
 from encord.http.v2.api_client import ApiClient
 from encord.http.v2.payloads import Page
 from encord.orm.dataset import LongPollingStatus
+from encord.orm.group import AddStorageFolderGroupsPayload, RemoveGroupsParams, StorageFolderGroup
 from encord.orm.storage import (
     CustomerProvidedAudioMetadata,
     CustomerProvidedVideoMetadata,
@@ -50,6 +51,7 @@ from encord.orm.storage import (
     StorageItemSummary,
     StorageItemType,
     StorageLocationName,
+    StorageUserRole,
     UploadLongPollingState,
     UploadSignedUrlsPayload,
 )
@@ -951,6 +953,52 @@ class StorageFolder:
             payload=orm_storage.DeleteItemsPayload(child_uuids=item_uuids, remove_unused_frames=remove_unused_frames),
             result_type=None,  # we don't need a result here, even though the server provides it
         )
+
+    def list_groups(self) -> Iterable[StorageFolderGroup]:
+        """
+        List all groups that have access to this folder.
+        """
+        page = self._api_client.get(
+            f"/storage/folders/{self.uuid}/groups", params=None, result_type=Page[StorageFolderGroup]
+        )
+
+        yield from page.results
+
+    def add_group(self, group_hash: Union[List[UUID], UUID], user_role: StorageUserRole):
+        """
+        Allow access to this folder for members of a group.
+
+        Args:
+            group_hash: Group hash, or a list of group hashes to be added.
+            user_role: User role that the group will be given.
+
+        Returns:
+            None
+        """
+        if isinstance(group_hash, UUID):
+            group_hash = [group_hash]
+        payload = AddStorageFolderGroupsPayload(group_hash_list=group_hash, user_role=user_role)
+        self._api_client.post(
+            f"/storage/folders/{self.uuid}/groups",
+            params=None,
+            payload=payload,
+            result_type=None,
+        )
+
+    def remove_group(self, group_hash: Union[List[UUID], UUID]):
+        """
+        Revoke access to the folder from the members of a group.
+
+        Args:
+            group_hash: Group hash, or a list of group hashes to be removed.
+
+        Returns:
+            None
+        """
+        if isinstance(group_hash, UUID):
+            group_hash = [group_hash]
+        params = RemoveGroupsParams(group_hash_list=group_hash)
+        self._api_client.delete(f"/storage/folders/{self.uuid}/groups", params=params, result_type=None)
 
     def refetch_data(self) -> None:
         """


### PR DESCRIPTION
# Introduction and Explanation

$title

# JIRA

Fixes https://linear.app/encord/issue/EC-4273/folders-sdk-for-managing-user-permissions-via-groups

# Documentation

Docstrings exist; will need proper 'story' page, too.

# Tests

In https://github.com/encord-team/cord-backend/pull/3566


