### PR TITLE
Clinton/rename duration in customer provided audio metadata

### DIFF
--- a/encord/orm/storage.py
+++ b/encord/orm/storage.py
@@ -177,7 +177,7 @@ class CustomerProvidedAudioMetadata(BaseDTO):
     Media metadata for an audio file; if provided, Encord service will use the values here instead of scanning the files
     """
 
-    duration_seconds: float
+    duration: float
     """Audio duration in (float) seconds."""
     file_size: int
     """Size of the audio file in bytes."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "encord"
-version = "0.1.121"
+version = "0.1.122"
 description = "Encord Python SDK Client"
 authors = ["Cord Technologies Limited <hello@encord.com>"]
 license = "Apache Software License"


### PR DESCRIPTION
# Introduction and Explanation

 made a silly error. Named a property in CustomerProvidedAudioMetadata "duration_seconds", when for every other file type, it is "duration".

Fix: Change this back to "duration"
This needs to be released with the corresponding BE fix.

# JIRA



# Documentation

# Tests


# Known issues

