### PR TITLE
add empty set check for _frames_to_answers

### DIFF
--- a/encord/objects/ontology_object_instance.py
+++ b/encord/objects/ontology_object_instance.py
@@ -823,6 +823,8 @@ class DynamicAnswerManager:
 
             if to_remove_answer is not None:
                 self._frames_to_answers[frame].remove(to_remove_answer)
+                if self._frames_to_answers[frame] == set():
+                    del self._frames_to_answers[frame]
                 self._answers_to_frames[to_remove_answer].remove(frame)
                 if self._answers_to_frames[to_remove_answer] == set():
                     del self._answers_to_frames[to_remove_answer]


### PR DESCRIPTION
The delete_answer function was only clearing empty sets for the _answers_to_frames dict. 

Need to do the same for _frames_to_answers 