### PR TITLE
Fix spelling in error messages (after the enforced spellcheck in the tests

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -667,7 +667,7 @@ class EncordClientDataset(EncordClient):
         if res.status == LongPollingStatus.DONE:
             return AddPrivateDataResponse(dataset_data_list=res.data_hashes_with_titles)
         elif res.status == LongPollingStatus.ERROR:
-            raise encord.exceptions.EncordException(f"add_private_data_to_dataset errors occured {res.errors}")
+            raise encord.exceptions.EncordException(f"add_private_data_to_dataset errors occurred {res.errors}")
         else:
             raise ValueError(f"res.status={res.status}, this should never happen")
 

--- a/encord/storage.py
+++ b/encord/storage.py
@@ -644,7 +644,7 @@ class StorageFolder:
         )
 
         if upload_result.status == LongPollingStatus.ERROR:
-            raise EncordException(f"Could not register audio, errors occured {upload_result.errors}")
+            raise EncordException(f"Could not register audio, errors occurred {upload_result.errors}")
         else:
             return upload_result.items_with_names[0].item_uuid
 


### PR DESCRIPTION
# Introduction and Explanation

We have a spellchecker in our BE repo so we can't have any error messages with typos (or at least we can't have tests that match against those, and for these messages we do).

# Tests

see above ;)

# Known issues

I sincerely do hope that none of the customers is matching against the misspelled error messages in their scripts ;)))