### PR TITLE
Pass (and get back) the 'json upload file' name

### DIFF
--- a/encord/orm/storage.py
+++ b/encord/orm/storage.py
@@ -151,6 +151,9 @@ class UploadLongPollingState(BaseDTO):
     unit_errors: List[DataUnitError]
     """Structured list of per-item upload errors. See :class:`DataUnitError` for more details."""
 
+    file_name: Optional[str] = None
+    """Name of the JSON or CSV file that contained the list of URLs to ingest form the cloud bucket. Optional."""
+
 
 class CustomerProvidedVideoMetadata(BaseDTO):
     """
@@ -282,6 +285,7 @@ class PostUploadJobParams(BaseDTO):
     external_files: Optional[dict] = None
     integration_hash: Optional[UUID] = None
     ignore_errors: bool = False
+    file_name: Optional[str] = None
 
 
 class GetUploadJobParams(BaseDTO):

--- a/encord/storage.py
+++ b/encord/storage.py
@@ -1120,11 +1120,13 @@ class StorageFolder:
         private_files: Union[str, Dict, Path, TextIO, DataUploadItems],
         ignore_errors: bool = False,
     ) -> UUID:
+        file_name: Optional[str] = None
         if isinstance(private_files, dict):
             files: Optional[dict] = private_files
         elif isinstance(private_files, str):
             if os.path.exists(private_files):
                 text_contents = Path(private_files).read_text(encoding="utf-8")
+                file_name = Path(private_files).name
             else:
                 text_contents = private_files
 
@@ -1132,9 +1134,11 @@ class StorageFolder:
         elif isinstance(private_files, Path):
             text_contents = private_files.read_text(encoding="utf-8")
             files = json.loads(text_contents)
+            file_name = private_files.name
         elif isinstance(private_files, TextIO):
             text_contents = private_files.read()
             files = json.loads(text_contents)
+            file_name = Path(private_files.name).name
         elif isinstance(private_files, DataUploadItems):
             files = None
         else:
@@ -1145,6 +1149,7 @@ class StorageFolder:
             external_files=files,
             integration_hash=UUID(integration_id) if integration_id is not None else None,
             ignore_errors=ignore_errors,
+            file_name=file_name,
         )
 
         upload_job_id = self._api_client.post(


### PR DESCRIPTION
# Introduction and Explanation

so that people can reason about which jobs they have dealt with in the past.

# JIRA

Fixes https://linear.app/encord/issue/EC-4521/add-upload-file-name-to-upload-job-details

# Documentation

Docstring is in place, but it's not *super* useful. Will need proper docs.

# Tests

SDK tests in the BE PR: https://github.com/encord-team/cord-backend/pull/3647

# Known issues

The FE is TBD