### PR TITLE
Allow explicitly pass bundle size when initialising bundle

### DIFF
--- a/encord/http/bundle.py
+++ b/encord/http/bundle.py
@@ -115,7 +115,8 @@ class Bundle:
                 # At this point all labels will be initialised
     """
 
-    def __init__(self) -> None:
+    def __init__(self, bundle_size: Optional[int] = None) -> None:
+        self._bundle_size = bundle_size
         self._operations: Dict[Callable, BundledOperation] = {}
 
     def __register_operation(
@@ -146,7 +147,7 @@ class Bundle:
         """
         result_mapping_getter = result_mapper.result_mapping_predicate if result_mapper else None
         result_handler = result_mapper.result_handler if result_mapper else None
-        self.__register_operation(type(payload), operation, result_mapping_getter, limit).append(
+        self.__register_operation(type(payload), operation, result_mapping_getter, self._bundle_size or limit).append(
             payload, result_handler
         )
 

--- a/encord/project.py
+++ b/encord/project.py
@@ -1028,16 +1028,20 @@ class Project:
         """
         return self._client.create_label_row(uid)
 
-    def create_bundle(self) -> Bundle:
+    def create_bundle(self, bundle_size: Optional[int] = None) -> Bundle:
         """
         Initializes a bundle to reduce the number of network calls performed by the Encord SDK.
 
         See the :class:`encord.http.bundle.Bundle` documentation for more details.
 
+        Args:
+            bundle_size: maximum number of items bundled. If more actions provided to the bundle, they will be
+                automatically split into separate api calls.
+
         Returns:
             Bundle: An instance of the Bundle class.
         """
-        return Bundle()
+        return Bundle(bundle_size=bundle_size)
 
     def list_collaborator_timers(
         self,

--- a/tests/test_bundled_label_operations.py
+++ b/tests/test_bundled_label_operations.py
@@ -174,6 +174,7 @@ def test_bundled_label_save(save_label_rows_mock: MagicMock, project: Project):
 @patch.object(EncordClientProject, "save_label_rows")
 def test_bundled_label_save_with_explicit_bundle_size(save_label_rows_mock: MagicMock, project: Project):
     label_rows = get_valid_label_rows(project)
+    assert len(label_rows) == 3
 
     bundle = project.create_bundle(bundle_size=2)
     for row in label_rows:

--- a/tests/test_bundled_label_operations.py
+++ b/tests/test_bundled_label_operations.py
@@ -169,3 +169,28 @@ def test_bundled_label_save(save_label_rows_mock: MagicMock, project: Project):
     assert args is not None
     assert len(args["uids"]) == 3, "Expected 3 updates bundled"
     assert len(args["payload"]) == 3, "Expected 3 updates bundled"
+
+
+@patch.object(EncordClientProject, "save_label_rows")
+def test_bundled_label_save_with_explicit_bundle_size(save_label_rows_mock: MagicMock, project: Project):
+    label_rows = get_valid_label_rows(project)
+
+    bundle = project.create_bundle(bundle_size=2)
+    for row in label_rows:
+        row.save(bundle=bundle)
+
+    save_label_rows_mock.assert_not_called()
+
+    bundle.execute()
+
+    assert save_label_rows_mock.call_count == 2
+
+    args_0 = save_label_rows_mock.call_args_list[0][1]
+    assert args_0 is not None
+    assert len(args_0["uids"]) == 2, "Expected 2 updates bundled in the first bundle"
+    assert len(args_0["payload"]) == 2, "Expected 2 updates bundled in the fist bundle"
+
+    args_1 = save_label_rows_mock.call_args_list[1][1]
+    assert args_1 is not None
+    assert len(args_1["uids"]) == 1, "Expected 1 updates bundled in the first bundle"
+    assert len(args_1["payload"]) == 1, "Expected 1 updates bundled in the fist bundle"


### PR DESCRIPTION
Allowing to explicitly set bundle size when bundling operations, e.g.:
```
with project.create_bundle(bundle_size=10) as bundle:
    for row in label_rows:
        row.save(bundle=bundle)
```

After than customer can add any amount of operations to the bundle, and they will be automatically split into the bundles of size `bundle_size`. 
