### PR TITLE
fix: missing bundle queue cleanup

### DIFF
--- a/encord/http/bundle.py
+++ b/encord/http/bundle.py
@@ -165,6 +165,7 @@ class Bundle:
                         result_handler = operation.result_handlers.get(operation.result_mapper(br))
                         if result_handler is not None:
                             result_handler(br)
+        self._operations = {}
 
     def __enter__(self):
         return self


### PR DESCRIPTION
# Introduction and Explanation
Users that mistakenly call `Bundle.execute()` when `Bundle` is used as a Context Manager are encountering errors / unknowingly repeating SDK calls because the `execute()` method doesn't clean the operations queue and then all operations are called twice (on explicit call and when exiting the Context Manager). A common error is the operation related to create label rows where the first call creates the label row and the second throws a `encord.exceptions.ResourceExistsError: Trying to create a resource that already exists`.

Code sample where the error was found:
```python
with project.create_bundle() as bundle:
    for label_row in label_rows:
        label_row.initialise_labels(overwrite=True, bundle=bundle)
    bundle.execute()
```

# Documentation
No need.