### PR TITLE
Allow client to inject custom trace id provider

### DIFF
--- a/encord/configs.py
+++ b/encord/configs.py
@@ -405,7 +405,7 @@ class SshConfig(Config):
         super().__init__(domain=domain, requests_settings=requests_settings)
 
     @staticmethod
-    def _get_signature(data: str, private_key: Ed25519PrivateKey) -> bytes:
+    def _get_v1_signature(data: str, private_key: Ed25519PrivateKey) -> bytes:
         hash_builder = hashlib.sha256()
         hash_builder.update(data.encode())
         contents_hash = hash_builder.digest()
@@ -413,7 +413,7 @@ class SshConfig(Config):
         return private_key.sign(contents_hash)
 
     @staticmethod
-    def _get_ssh_authorization_header(public_key_hex: str, signature: bytes) -> str:
+    def _get_v1_ssh_authorization_header(public_key_hex: str, signature: bytes) -> str:
         return f"{public_key_hex}:{signature.hex()}"
 
     def define_headers(self, resource_id: Optional[str], resource_type: Optional[str], data: str) -> Dict[str, Any]:
@@ -428,14 +428,14 @@ class SshConfig(Config):
         Returns:
             Dict[str, Any]: A dictionary of headers.
         """
-        signature = self._get_signature(data, self.private_key)
+        signature = self._get_v1_signature(data, self.private_key)
         return {
             "Accept": "application/json",
             "Content-Type": "application/json",
             "Accept-Encoding": "gzip",
             "ResourceType": resource_type or "",
             "ResourceID": resource_id or "",
-            "Authorization": self._get_ssh_authorization_header(self.public_key_hex, signature),
+            "Authorization": self._get_v1_ssh_authorization_header(self.public_key_hex, signature),
             HEADER_USER_AGENT: self._user_agent(),
             HEADER_CLOUD_TRACE_CONTEXT: self._tracing_id(),
         }

--- a/encord/configs.py
+++ b/encord/configs.py
@@ -215,8 +215,9 @@ class Config(BaseConfig):
     def _user_agent() -> str:
         return f"encord-sdk-python/{encord_version} python/{platform.python_version()}"
 
-    @staticmethod
-    def _tracing_id() -> str:
+    def _tracing_id(self) -> str:
+        if self.requests_settings.trace_id_provider:
+            return self.requests_settings.trace_id_provider()
         return f"{uuid4().hex}/1;o=1"
 
 

--- a/encord/http/__init__.py
+++ b/encord/http/__init__.py
@@ -1,0 +1,1 @@
+from encord.http.constants import RequestsSettings

--- a/encord/http/constants.py
+++ b/encord/http/constants.py
@@ -11,6 +11,7 @@ category: "64e481b57b6027003f20aaa0"
 """
 
 from dataclasses import dataclass
+from typing import Callable, Optional
 
 DEFAULT_CONNECTION_RETRIES = 3
 DEFAULT_MAX_RETRIES = 3
@@ -44,6 +45,9 @@ class RequestsSettings:
 
     write_timeout: int = DEFAULT_WRITE_TIMEOUT
     """Maximum number of seconds to send request payload"""
+
+    trace_id_provider: Optional[Callable[[], str]] = None
+    """Function that supplies trace id for every request issued by the library. Random if not provided."""
 
 
 DEFAULT_REQUESTS_SETTINGS = RequestsSettings()

--- a/encord/http/querier.py
+++ b/encord/http/querier.py
@@ -14,8 +14,6 @@
 # under the License.
 import dataclasses
 import logging
-import platform
-import uuid
 from contextlib import contextmanager
 from typing import Any, Dict, Generator, List, Optional, Sequence, Tuple, Type, TypeVar, Union
 
@@ -25,12 +23,10 @@ import requests.exceptions
 from requests import Session
 from requests.adapters import HTTPAdapter, Retry
 
-from encord._version import __version__ as encord_version
 from encord.configs import ApiKeyConfig, BaseConfig
 from encord.exceptions import RequestException, ResourceNotFoundError
 from encord.http.common import (
     HEADER_CLOUD_TRACE_CONTEXT,
-    HEADER_USER_AGENT,
     RequestContext,
 )
 from encord.http.error_utils import check_error_response
@@ -161,14 +157,6 @@ class Querier:
             raise RequestException(f"Setting {db_object_type} with uid {uid} failed.", context=context)
 
     @staticmethod
-    def _user_agent():
-        return f"encord-sdk-python/{encord_version} python/{platform.python_version()}"
-
-    @staticmethod
-    def _tracing_id() -> str:
-        return f"{uuid.uuid4().hex}/1;o=1"
-
-    @staticmethod
     def _exception_context(request: requests.PreparedRequest) -> RequestContext:
         try:
             x_cloud_trace_context = request.headers.get(HEADER_CLOUD_TRACE_CONTEXT)
@@ -191,8 +179,6 @@ class Querier:
         request.headers = self._config.define_headers(
             resource_id=self.resource_id, resource_type=self.resource_type, data=request.data
         )
-        request.headers[HEADER_USER_AGENT] = self._user_agent()
-        request.headers[HEADER_CLOUD_TRACE_CONTEXT] = self._tracing_id()
         return request
 
     def _execute(self, request: Request, retryable=False, enable_logging: bool = True) -> Tuple[Any, RequestContext]:

--- a/encord/http/v2/api_client.py
+++ b/encord/http/v2/api_client.py
@@ -31,19 +31,6 @@ class ApiClient:
         self._bound_callbacks: Dict[Callable, Callable] = {}
 
     @staticmethod
-    def _exception_context_from_response(response: Response) -> RequestContext:
-        try:
-            x_cloud_trace_context = response.headers.get(HEADER_CLOUD_TRACE_CONTEXT)
-            if x_cloud_trace_context is None:
-                return RequestContext()
-
-            x_cloud_trace_context = x_cloud_trace_context.split(";")[0]
-            trace_id, span_id = (x_cloud_trace_context.split("/") + [None, None])[:2]
-            return RequestContext(trace_id=trace_id, span_id=span_id)
-        except Exception:
-            return RequestContext()
-
-    @staticmethod
     def _exception_context(request: requests.PreparedRequest) -> RequestContext:
         try:
             x_cloud_trace_context = request.headers.get(HEADER_CLOUD_TRACE_CONTEXT)

--- a/tests/test_user_client_auth.py
+++ b/tests/test_user_client_auth.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.serialization import (
 from requests import PreparedRequest, Session
 
 from encord.client import EncordClient
-from encord.configs import _get_signature, _get_ssh_authorization_header
+from encord.configs import SshConfig
 from encord.http.v2.payloads import Page
 from encord.orm.analytics import CollaboratorTimer
 from encord.orm.ontology import Ontology as OrmOntology
@@ -127,8 +127,10 @@ def make_side_effects(project_response: Optional[MagicMock] = None, ontology_res
 def get_encord_auth_header(request: PreparedRequest) -> str:
     private_key = load_ssh_private_key(DUMMY_PRIVATE_KEY.encode(), None)
     public_key = private_key.public_key()
-    signature = _get_signature(request.body, private_key)
-    return _get_ssh_authorization_header(public_key.public_bytes(Encoding.Raw, PublicFormat.Raw).hex(), signature)
+    signature = SshConfig._get_v1_signature(request.body, private_key)
+    return SshConfig._get_v1_ssh_authorization_header(
+        public_key.public_bytes(Encoding.Raw, PublicFormat.Raw).hex(), signature
+    )
 
 
 @patch.object(Session, "send")


### PR DESCRIPTION
Allows to override trace id generator. This is useful when sdk is used as part of the bigger app that wants to supply more determined id.

```
user_client = EncordUserClient.create_with_ssh_private_key(
    requests_settings=RequestsSettings(
        trace_id_provider=lambda: <TRACE STRING>,
    )
)
```
