### PR TITLE
fix: get_no_payload allow_none=True

### DIFF
--- a/.github/actions/run-unit-tests/action.yml
+++ b/.github/actions/run-unit-tests/action.yml
@@ -46,7 +46,7 @@ runs:
 
       - name: Override pydantic version
         if: ${{ inputs.pydantic-version }}
-        run: python3 -m pip install pydantic==${{ inputs.pydantic-version }}
+        run: poetry run python -m pip install pydantic==${{ inputs.pydantic-version }}
         shell: bash
 
       - name: Run tests

--- a/.github/workflows/sdk-pr.yml
+++ b/.github/workflows/sdk-pr.yml
@@ -50,7 +50,7 @@ jobs:
           pydantic-version: 1.10.14
           test-report-file: ${{ env.UNIT_TEST_REPORT_PYTHON_3_8_P1 }}
 
-      - name: Publish unit test report Python 3.8 (Pydantic 2.x)
+      - name: Publish unit test report Python 3.8 (Pydantic 1.x)
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           files: ${{ env.UNIT_TEST_REPORT_PYTHON_3_8_P1 }}

--- a/encord/http/v2/api_client.py
+++ b/encord/http/v2/api_client.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 import uuid
 from typing import Callable, Dict, Iterator, List, Optional, Sequence, Type, TypeVar, Union
 from urllib.parse import urljoin
@@ -128,7 +129,7 @@ class ApiClient:
             if hasattr(payload, "model_dump"):
                 return payload.model_dump(mode="json")
             else:
-                return payload.dict()
+                return json.loads(payload.json())
         elif payload is None:
             return None
         else:
@@ -143,7 +144,9 @@ class ApiClient:
         result_type: Optional[Type[T]],
     ) -> T:
         params_dict = params.to_dict() if params is not None else None
+        print(f"{params_dict}")
         payload_serialised = self._serialise_payload(payload)
+        print(f"{payload_serialised}")
 
         req = requests.Request(
             method=method,

--- a/encord/http/v2/api_client.py
+++ b/encord/http/v2/api_client.py
@@ -69,7 +69,7 @@ class ApiClient:
             raise RuntimeError(f"Operation {operation} does not have an 'api_client' parameter")
 
     def get(self, path: str, params: Optional[BaseDTO], result_type: Type[T], allow_none: bool = False) -> T:
-        return self._request_without_payload("GET", path, params, result_type)
+        return self._request_without_payload("GET", path, params, result_type, allow_none=allow_none)
 
     def get_paged_iterator(
         self,
@@ -99,8 +99,8 @@ class ApiClient:
             else:
                 break
 
-    def delete(self, path: str, params: Optional[BaseDTO], result_type: Optional[Type[T]] = None) -> T:
-        return self._request_without_payload("DELETE", path, params, result_type)
+    def delete(self, path: str, params: Optional[BaseDTO], result_type: Optional[Type[T]] = None, allow_none: bool = False) -> T:
+        return self._request_without_payload("DELETE", path, params, result_type, allow_none=allow_none)
 
     def post(
         self,
@@ -153,13 +153,13 @@ class ApiClient:
         return self._request(req, result_type=result_type)  # type: ignore
 
     def _request_without_payload(
-        self, method: str, path: str, params: Optional[BaseDTO], result_type: Optional[Type[T]]
+        self, method: str, path: str, params: Optional[BaseDTO], result_type: Optional[Type[T]], allow_none: bool = False,
     ) -> T:
         params_dict = params.to_dict() if params is not None else None
 
         req = requests.Request(method=method, url=self._build_url(path), params=params_dict).prepare()
 
-        return self._request(req, result_type=result_type)  # type: ignore
+        return self._request(req, result_type=result_type, allow_none=allow_none)  # type: ignore
 
     def _request(self, req: PreparedRequest, result_type: Optional[Type[T]], allow_none: bool = False):
         req = self._config.define_headers_v2(req)

--- a/encord/http/v2/api_client.py
+++ b/encord/http/v2/api_client.py
@@ -99,7 +99,9 @@ class ApiClient:
             else:
                 break
 
-    def delete(self, path: str, params: Optional[BaseDTO], result_type: Optional[Type[T]] = None, allow_none: bool = False) -> T:
+    def delete(
+        self, path: str, params: Optional[BaseDTO], result_type: Optional[Type[T]] = None, allow_none: bool = False
+    ) -> T:
         return self._request_without_payload("DELETE", path, params, result_type, allow_none=allow_none)
 
     def post(
@@ -153,7 +155,12 @@ class ApiClient:
         return self._request(req, result_type=result_type)  # type: ignore
 
     def _request_without_payload(
-        self, method: str, path: str, params: Optional[BaseDTO], result_type: Optional[Type[T]], allow_none: bool = False,
+        self,
+        method: str,
+        path: str,
+        params: Optional[BaseDTO],
+        result_type: Optional[Type[T]],
+        allow_none: bool = False,
     ) -> T:
         params_dict = params.to_dict() if params is not None else None
 

--- a/encord/http/v2/api_client.py
+++ b/encord/http/v2/api_client.py
@@ -144,9 +144,7 @@ class ApiClient:
         result_type: Optional[Type[T]],
     ) -> T:
         params_dict = params.to_dict() if params is not None else None
-        print(f"{params_dict}")
         payload_serialised = self._serialise_payload(payload)
-        print(f"{payload_serialised}")
 
         req = requests.Request(
             method=method,

--- a/tests/http/test_api_v2_client.py
+++ b/tests/http/test_api_v2_client.py
@@ -41,18 +41,30 @@ def api_client():
 
 
 @pytest.mark.parametrize("payload_type", [TestPayload, TestPayloadV2])
+@pytest.mark.parameterize("allow_none", [False, True])
 @patch.object(Session, "send")
-def test_constructed_url_is_correct(send: MagicMock, api_client: ApiClient, payload_type: Type[TestPayload]) -> None:
+def test_constructed_url_is_correct(
+    send: MagicMock, api_client: ApiClient, payload_type: Type[TestPayload], allow_none: bool
+) -> None:
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.json.return_value = {"payload": "hello world"}
     mock_response.content = json.dumps({"payload": "hello world"})
-    send.return_value = mock_response
+    send.return_value = None if allow_none else mock_response
 
-    api_client.get("/", params=None, result_type=payload_type)
-    api_client.get("/test", params=None, result_type=payload_type)
-    api_client.get("/test/", params=None, result_type=payload_type)
-    api_client.get("test/", params=None, result_type=payload_type)
+    res = [
+        api_client.get("/", params=None, result_type=payload_type, allow_none=allow_none),
+        api_client.get("/test", params=None, result_type=payload_type, allow_none=allow_none),
+        api_client.get("/test/", params=None, result_type=payload_type, allow_none=allow_none),
+        api_client.get("test/", params=None, result_type=payload_type, allow_none=allow_none),
+    ]
+    if allow_none:
+        for r in res:
+            assert r is None
+    else:
+        for r in res:
+            assert r is not None
+            assert r.payload == "hello world"
 
     assert send.call_args_list[0].args[0].url == "https://api.encord.com/v2/public"
     assert send.call_args_list[1].args[0].url == "https://api.encord.com/v2/public/test"
@@ -61,18 +73,26 @@ def test_constructed_url_is_correct(send: MagicMock, api_client: ApiClient, payl
 
 
 @pytest.mark.parametrize("payload_type", [TestPayload, TestPayloadV2])
+@pytest.mark.parameterize("allow_none", [False, True])
 @patch.object(Session, "send")
-def test_payload_url_serialisation(send: MagicMock, api_client: ApiClient, payload_type: Type[TestPayload]) -> None:
+def test_payload_url_serialisation(
+    send: MagicMock, api_client: ApiClient, payload_type: Type[TestPayload], allow_none: bool
+) -> None:
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.json.return_value = {"payload": "hello world"}
     mock_response.content = json.dumps({"payload": "hello world"})
-    send.return_value = mock_response
+    send.return_value = None if allow_none else mock_response
 
     expected_time = datetime.fromisoformat("2024-02-01T01:02:03+01:00")
     payload = TestComplexPayload(text="test", number=0.01, time=expected_time)
 
-    api_client.get("/", params=payload, result_type=payload_type)
+    res = api_client.get("/", params=payload, result_type=payload_type, allow_none=allow_none)
+    if allow_none:
+        assert res is None
+    else:
+        assert res is not None
+        assert res.payload == "hello world"
 
     assert (
         send.call_args_list[0].args[0].url
@@ -80,22 +100,31 @@ def test_payload_url_serialisation(send: MagicMock, api_client: ApiClient, paylo
     )
 
 
-@pytest.mark.parametrize("payload_type", [TestPayload, TestPayloadV2])
+@pytest.mark.parametrize("payload_type", [TestPayload, TestPayloadV2, None])
 @pytest.mark.parametrize("param_type", [TestComplexPayload, TestComplexPayloadV2])
 @patch.object(Session, "send")
 def test_payload_body_serialisation(
-    send: MagicMock, api_client: ApiClient, payload_type: Type[TestPayload], param_type: Type[TestComplexPayload]
+    send: MagicMock,
+    api_client: ApiClient,
+    payload_type: Type[TestPayload],
+    param_type: Type[TestComplexPayload],
+    allow_none: bool,
 ) -> None:
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.json.return_value = {"payload": "hello world"}
     mock_response.content = json.dumps({"payload": "hello world"})
-    send.return_value = mock_response
+    send.return_value = None if payload_type is None else mock_response
 
     expected_time = datetime.fromisoformat("2024-02-01T01:02:03+01:00")
     payload = param_type(text="test", number=0.01, time=expected_time)
 
-    api_client.post("/", params=None, payload=payload, result_type=payload_type)
+    r = api_client.post("/", params=None, payload=payload, result_type=payload_type)
+    if payload_type is None:
+        assert r is None
+    else:
+        assert r is not None
+        assert r.payload == "hello world"
 
     assert send.call_args_list[0].args[0].url == "https://api.encord.com/v2/public"
     assert (

--- a/tests/http/test_api_v2_client.py
+++ b/tests/http/test_api_v2_client.py
@@ -41,16 +41,16 @@ def api_client():
 
 
 @pytest.mark.parametrize("payload_type", [TestPayload, TestPayloadV2])
-@pytest.mark.parameterize("allow_none", [False, True])
+@pytest.mark.parametrize("allow_none", [False, True])
 @patch.object(Session, "send")
 def test_constructed_url_is_correct(
     send: MagicMock, api_client: ApiClient, payload_type: Type[TestPayload], allow_none: bool
 ) -> None:
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"payload": "hello world"}
-    mock_response.content = json.dumps({"payload": "hello world"})
-    send.return_value = None if allow_none else mock_response
+    mock_response.json.return_value = None if allow_none else {"payload": "hello world"}
+    mock_response.content = "null" if allow_none else json.dumps({"payload": "hello world"})
+    send.return_value = mock_response
 
     res = [
         api_client.get("/", params=None, result_type=payload_type, allow_none=allow_none),
@@ -73,16 +73,16 @@ def test_constructed_url_is_correct(
 
 
 @pytest.mark.parametrize("payload_type", [TestPayload, TestPayloadV2])
-@pytest.mark.parameterize("allow_none", [False, True])
+@pytest.mark.parametrize("allow_none", [False, True])
 @patch.object(Session, "send")
 def test_payload_url_serialisation(
     send: MagicMock, api_client: ApiClient, payload_type: Type[TestPayload], allow_none: bool
 ) -> None:
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"payload": "hello world"}
-    mock_response.content = json.dumps({"payload": "hello world"})
-    send.return_value = None if allow_none else mock_response
+    mock_response.json.return_value = None if allow_none else {"payload": "hello world"}
+    mock_response.content = "null" if allow_none else json.dumps({"payload": "hello world"})
+    send.return_value = mock_response
 
     expected_time = datetime.fromisoformat("2024-02-01T01:02:03+01:00")
     payload = TestComplexPayload(text="test", number=0.01, time=expected_time)
@@ -108,13 +108,12 @@ def test_payload_body_serialisation(
     api_client: ApiClient,
     payload_type: Type[TestPayload],
     param_type: Type[TestComplexPayload],
-    allow_none: bool,
 ) -> None:
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"payload": "hello world"}
-    mock_response.content = json.dumps({"payload": "hello world"})
-    send.return_value = None if payload_type is None else mock_response
+    mock_response.json.return_value = None if payload_type is None else {"payload": "hello world"}
+    mock_response.content = "null" if payload_type is None else json.dumps({"payload": "hello world"})
+    send.return_value = mock_response
 
     expected_time = datetime.fromisoformat("2024-02-01T01:02:03+01:00")
     payload = param_type(text="test", number=0.01, time=expected_time)


### PR DESCRIPTION
# Introduction and Explanation
allow_none is a parameter that currently does nothing, it should in fact do something.
this causes issues in creating a fresh metadata schema.

Tested against empty schema on DEV

also some more api server tests to catch issues like this