### PR TITLE
hotfix: allow dot in the name

### DIFF
--- a/encord/metadata_schema.py
+++ b/encord/metadata_schema.py
@@ -143,7 +143,7 @@ class MetadataSchemaError(RuntimeError):
 def _is_valid_metadata_key(value: str) -> bool:
     if value.startswith("$") or value == "":
         return False
-    for extra_char in ["-", "_", " "]:
+    for extra_char in ["-", "_", " ", "."]:
         value = value.replace(extra_char, "")
     if value == "":
         return False

--- a/tests/test_metadata_schema.py
+++ b/tests/test_metadata_schema.py
@@ -63,12 +63,15 @@ def test_metadata_schema() -> None:
     with pytest.raises(MetadataSchemaError):
         meta.add_scalar("en", data_type="boolean")
 
+    meta.add_scalar("a.b", data_type="boolean")
+
     assert (
         f"{meta}".strip()
         == """
 Metadata Schema:
 ----------------
  - 'a':        scalar(hint=text)
+ - 'a.b':      scalar(hint=boolean)
  - 'b':        scalar(hint=boolean)
  - 'c':        scalar(hint=varchar)
  - 'd':        scalar(hint=text)


### PR DESCRIPTION
# Introduction and Explanation
part 3 of hotfix - allow dots in metadata schema names
