### PR TITLE
chore: add MetadataSchemaScalarType input in metadata schema data_type

### DIFF
--- a/encord/metadata_schema.py
+++ b/encord/metadata_schema.py
@@ -272,7 +272,7 @@ class MetadataSchema:
         k: str,
         *,
         data_type: Union[
-            Literal["boolean", "datetime", "number", "uuid", "text", "varchar", "string", "long_string"],
+            Literal["boolean", "datetime", "number", "uuid", "varchar", "text", "string", "long_string"],
             MetadataSchemaScalarType,
         ],
     ) -> None:
@@ -282,7 +282,7 @@ class MetadataSchema:
         **Parameters:**
 
         - k : str: The key for which the metadata type is being set.
-        - data_type : Literal["boolean", "datetime", "number", "uuid", "text", "varchar", "string", "long_string"]
+        - data_type : Literal["boolean", "datetime", "number", "uuid", "varchar", "text", "string", "long_string"]
                    The type of metadata to be associated with the key. Must be a valid identifier.
                    "string" is an alias of "varchar"
                    "long_string" is an alias of "text"

--- a/encord/metadata_schema.py
+++ b/encord/metadata_schema.py
@@ -7,7 +7,7 @@ from typing_extensions import Annotated
 
 from encord.http.v2.api_client import ApiClient
 
-__all__ = ["MetadataSchema", "MetadataSchemaError"]
+__all__ = ["MetadataSchema", "MetadataSchemaError", "MetadataSchemaScalarType"]
 
 from encord.orm.base_dto import RootModelDTO
 
@@ -86,6 +86,9 @@ class _ClientMetadataSchemaTypeVariantHint(Enum):
             return cls.VARCHAR
 
         raise ValueError(f"Unknown simple schema type: {value}")
+
+
+MetadataSchemaScalarType = _ClientMetadataSchemaTypeVariantHint
 
 
 class _ClientMetadataSchemaTypeVariant(BaseModel):
@@ -269,7 +272,8 @@ class MetadataSchema:
         k: str,
         *,
         data_type: Union[
-            Literal["boolean", "datetime", "number", "uuid", "text", "varchar", "string", "long_string"], str
+            Literal["boolean", "datetime", "number", "uuid", "text", "varchar", "string", "long_string"],
+            MetadataSchemaScalarType,
         ],
     ) -> None:
         """
@@ -286,8 +290,11 @@ class MetadataSchema:
         **Raises:**
 
         MetadataSchemaError: If the key `k` is already defined in the schema with a conflicting type.
-        ValueError: If the type of metadata `data_type` is an invalid identifier.
+        ValueError: If `data_type` is not a valid type of metadata identifier.
         """
+        if isinstance(data_type, MetadataSchemaScalarType):
+            data_type = data_type.to_simple_str()
+
         if k in self._schema:
             v = self._schema[k]
             if not isinstance(v.root, _ClientMetadataSchemaTypeVariant):

--- a/encord/metadata_schema.py
+++ b/encord/metadata_schema.py
@@ -76,7 +76,7 @@ class _ClientMetadataSchemaTypeVariantHint(Enum):
         elif self.value == "uuid":
             return "uuid"
         else:
-            raise ValueError(f"Unknown simple type: {self}")
+            raise ValueError(f"Unknown simple schema type: {self}")
 
     @classmethod
     def _missing_(cls, value):
@@ -85,7 +85,7 @@ class _ClientMetadataSchemaTypeVariantHint(Enum):
         elif value in ("varchar", "string"):
             return cls.VARCHAR
 
-        raise ValueError("Unknown simple schema type")
+        raise ValueError(f"Unknown simple schema type: {value}")
 
 
 class _ClientMetadataSchemaTypeVariant(BaseModel):
@@ -268,7 +268,9 @@ class MetadataSchema:
         self,
         k: str,
         *,
-        data_type: Literal["boolean", "datetime", "number", "uuid", "text", "varchar", "string", "long_string"],
+        data_type: Union[
+            Literal["boolean", "datetime", "number", "uuid", "text", "varchar", "string", "long_string"], str
+        ],
     ) -> None:
         """
         Sets a simple metadata type for a given key in the schema.
@@ -276,7 +278,7 @@ class MetadataSchema:
         **Parameters:**
 
         - k : str: The key for which the metadata type is being set.
-        - schema : Literal["boolean", "datetime", "number", "uuid", "text", "varchar", "string", "long_string"]
+        - data_type : Literal["boolean", "datetime", "number", "uuid", "text", "varchar", "string", "long_string"]
                    The type of metadata to be associated with the key. Must be a valid identifier.
                    "string" is an alias of "varchar"
                    "long_string" is an alias of "text"
@@ -284,6 +286,7 @@ class MetadataSchema:
         **Raises:**
 
         MetadataSchemaError: If the key `k` is already defined in the schema with a conflicting type.
+        ValueError: If the type of metadata `data_type` is an invalid identifier.
         """
         if k in self._schema:
             v = self._schema[k]

--- a/tests/test_metadata_schema.py
+++ b/tests/test_metadata_schema.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from encord.metadata_schema import MetadataSchema, MetadataSchemaError
+from encord.metadata_schema import MetadataSchema, MetadataSchemaError, MetadataSchemaScalarType
 
 
 def test_root_model() -> None:
@@ -65,11 +65,27 @@ def test_metadata_schema() -> None:
 
     meta.add_scalar("a.b", data_type="boolean")
 
+    meta.add_scalar("A", data_type=MetadataSchemaScalarType.NUMBER)
+    meta.add_scalar("B", data_type=MetadataSchemaScalarType.BOOLEAN)
+    meta.add_scalar("C", data_type=MetadataSchemaScalarType.DATETIME)
+    meta.add_scalar("D", data_type=MetadataSchemaScalarType.TEXT)
+    meta.add_scalar("E", data_type=MetadataSchemaScalarType.VARCHAR)
+    meta.add_scalar("F", data_type=MetadataSchemaScalarType.UUID)
+
+    for k in ["A", "B", "C", "D", "E", "F"]:
+        assert meta.has_key(k)
+
     assert (
         f"{meta}".strip()
         == """
 Metadata Schema:
 ----------------
+ - 'A':        scalar(hint=number)
+ - 'B':        scalar(hint=boolean)
+ - 'C':        scalar(hint=datetime)
+ - 'D':        scalar(hint=text)
+ - 'E':        scalar(hint=varchar)
+ - 'F':        scalar(hint=uuid)
  - 'a':        scalar(hint=text)
  - 'a.b':      scalar(hint=boolean)
  - 'b':        scalar(hint=boolean)


### PR DESCRIPTION
# Introduction and Explanation
Resolve mypy error encountered when using the `MetadataSchema.add_scalar()` method.
Edit: Via adding the `MetadataSchemaScalarType` enum.

```
error: Argument "data_type" to "add_scalar" of "MetadataSchema" has incompatible type "str";
expected "Literal['boolean', 'datetime', 'number', 'uuid', 'text', 'varchar', 'string', 'long_string']"  [arg-type]
```

# Documentation
Added the missing `ValueError` exception to the relevant docstring.

# Tests
No need. `MetadataSchema.add_scalar()` already throws a `ValueError` when an incorrect `data_type` is used.
Edit: Added tests for `MetadataSchemaScalarType` usage in `add_scalar()`.
