### PR TITLE
EC-5051: Add service account auth to sdk-integration-tests

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -55,6 +55,7 @@ runs:
         run: |
           cd ${{ inputs.integration-tests-location }}
           export PRIVATE_KEY="${{ inputs.private-key }}"
+          export PRIVATE_KEY_SERVICE_ACCOUNT="${{ inputs.private-key-service-account }}"
           export PRIVATE_KEY_NON_ORG='${{ inputs.private-key-non-org }}'
           export CORD_ENV="${{ inputs.environment }}"
           source $(poetry env info --path)/bin/activate

--- a/.github/workflows/sdk-pr.yml
+++ b/.github/workflows/sdk-pr.yml
@@ -15,6 +15,7 @@ env:
 
   INTEGRATION_TEST_REPORT_PYTHON_3_11: integration-test-report-python3_11.xml
   INTEGRATION_TESTS_PRIVATE_KEY: ${{ secrets.SDK_TESTS_PRIVATE_KEY }}
+  INTEGRATION_TESTS_PRIVATE_KEY_SERVICE_ACCOUNT: ${{ secrets.SDK_TESTS_PRIVATE_KEY_SERVICE_ACCOUNT }}
   INTEGRATION_TESTS_PRIVATE_KEY_NON_ORG: ${{ secrets.SDK_TESTS_PRIVATE_KEY_NON_ORG }}
 
 concurrency:
@@ -97,6 +98,7 @@ jobs:
           integration-tests-location: ./encord-backend/projects/sdk-integration-tests
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_11 }}
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
+          private-key-service-account: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY_SERVICE_ACCOUNT }}
           private-key-non-org: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY_NON_ORG }}
           sdk-repository-url: https://github.com/encord-team/encord-client-python@${{ github.sha }}
 

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -20,6 +20,7 @@ env:
 
   INTEGRATION_TEST_REPORT_PYTHON_3_11: integration-test-report-python3_11.xml
   INTEGRATION_TESTS_PRIVATE_KEY: ${{ secrets.SDK_TESTS_PRIVATE_KEY }}
+  INTEGRATION_TESTS_PRIVATE_KEY_SERVICE_ACCOUNT: ${{ secrets.SDK_TESTS_PRIVATE_KEY_SERVICE_ACCOUNT }}
   INTEGRATION_TESTS_PRIVATE_KEY_NON_ORG: ${{ secrets.SDK_TESTS_PRIVATE_KEY_NON_ORG }}
 
   BACKEND_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
@@ -187,6 +188,7 @@ jobs:
           integration-tests-location: ./encord-backend/projects/sdk-integration-tests
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_11 }}
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
+          private-key-service-account: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY_SERVICE_ACCOUNT }}
           private-key-non-org: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY_NON_ORG }}
           sdk-repository-url: https://github.com/encord-team/encord-client-python@${{ github.sha }}
 


### PR DESCRIPTION
# Introduction and Explanation

Backfill missing places for `PRIVATE_KEY_SERVICE_ACCOUNT` env vars.

# Documentation

See https://github.com/encord-team/cord-backend/pull/4012

# Tests

N/a

# Known issues

N/a