### PR TITLE
Be even more relaxed about UUID-vs-str typing

### DIFF
--- a/encord/collection.py
+++ b/encord/collection.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from datetime import datetime
-from typing import Iterator, List, Optional, Union
+from typing import Iterator, List, Optional, Sequence, Union
 from uuid import UUID
 
 import encord.orm.storage as orm_storage
@@ -200,14 +200,12 @@ class Collection:
             else:
                 yield StorageItemInaccessible(orm_item=item)
 
-    def add_items(
-        self, storage_item_uuids: Union[List[Union[UUID, str]], List[UUID], List[str]]
-    ) -> CollectionBulkItemResponse:
+    def add_items(self, storage_item_uuids: Sequence[Union[UUID, str]]) -> CollectionBulkItemResponse:
         """
         Add storage items to the collection.
 
         Args:
-            storage_item_uuids (Union[List[Union[UUID, str]], List[UUID], List[str]]): The list of storage item UUIDs to be added.
+            storage_item_uuids (Sequence[Union[UUID, str]]): The list of storage item UUIDs to be added.
             Either UUIDs or string representations of UUIDs are accepted.
         Returns:
             CollectionBulkItemResponse: The response after adding items to the collection.
@@ -221,14 +219,12 @@ class Collection:
         )
         return res
 
-    def remove_items(
-        self, storage_item_uuids: Union[List[Union[UUID, str]], List[UUID], List[str]]
-    ) -> CollectionBulkItemResponse:
+    def remove_items(self, storage_item_uuids: Sequence[Union[UUID, str]]) -> CollectionBulkItemResponse:
         """
         Remove storage items from the collection.
 
         Args:
-            storage_item_uuids (Union[List[Union[UUID, str]], List[UUID], List[str]]): The list of storage item UUIDs to be removed.
+            storage_item_uuids (Sequence[Union[UUID, str]]): The list of storage item UUIDs to be removed.
             Either UUIDs or string representations of UUIDs are accepted.
         Returns:
             CollectionBulkItemResponse: The response after removing items from the collection.

--- a/encord/collection.py
+++ b/encord/collection.py
@@ -200,12 +200,15 @@ class Collection:
             else:
                 yield StorageItemInaccessible(orm_item=item)
 
-    def add_items(self, storage_item_uuids: List[Union[UUID, str]]) -> CollectionBulkItemResponse:
+    def add_items(
+        self, storage_item_uuids: Union[List[Union[UUID, str]], List[UUID], List[str]]
+    ) -> CollectionBulkItemResponse:
         """
         Add storage items to the collection.
 
         Args:
-            storage_item_uuids (List[Union[UUID, str]]): The list of storage item UUIDs or strings to be added.
+            storage_item_uuids (Union[List[Union[UUID, str]], List[UUID], List[str]]): The list of storage item UUIDs to be added.
+            Either UUIDs or string representations of UUIDs are accepted.
         Returns:
             CollectionBulkItemResponse: The response after adding items to the collection.
         """
@@ -218,12 +221,15 @@ class Collection:
         )
         return res
 
-    def remove_items(self, storage_item_uuids: List[Union[UUID, str]]) -> CollectionBulkItemResponse:
+    def remove_items(
+        self, storage_item_uuids: Union[List[Union[UUID, str]], List[UUID], List[str]]
+    ) -> CollectionBulkItemResponse:
         """
         Remove storage items from the collection.
 
         Args:
-            storage_item_uuids (List[Union[UUID, str]]): The list of storage item UUIDs or strings to be removed.
+            storage_item_uuids (Union[List[Union[UUID, str]], List[UUID], List[str]]): The list of storage item UUIDs to be removed.
+            Either UUIDs or string representations of UUIDs are accepted.
         Returns:
             CollectionBulkItemResponse: The response after removing items from the collection.
         """

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -17,7 +17,7 @@ import logging
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple, Union
 from uuid import UUID
 
 from encord.client import EncordClient, EncordClientDataset, EncordClientProject
@@ -849,7 +849,7 @@ class EncordUserClient:
 
     def get_storage_items(
         self,
-        item_uuids: Union[List[Union[UUID, str]], List[UUID], List[str]],
+        item_uuids: Sequence[Union[UUID, str]],
         sign_url: bool = False,
     ) -> List[StorageItem]:
         """

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -847,13 +847,17 @@ class EncordUserClient:
             item_uuid = UUID(item_uuid)
         return StorageItem._get_item(self._api_client, item_uuid, sign_url)
 
-    def get_storage_items(self, item_uuids: List[Union[UUID, str]], sign_url: bool = False) -> List[StorageItem]:
+    def get_storage_items(
+        self,
+        item_uuids: Union[List[Union[UUID, str]], List[UUID], List[str]],
+        sign_url: bool = False,
+    ) -> List[StorageItem]:
         """
         Get storage items by their UUIDs, in bulk. Useful for retrieving multiple items at once, e.g. when getting
         items pointed to by :attr:`encord.orm.dataset.DataRow.backing_item_uuid` for all data rows of a dataset.
 
         Args:
-            item_uuids: list of UUIDs of items to retrieve.
+            item_uuids: list of UUIDs of items to retrieve. Can be a list of strings or a list of UUID objects.
             sign_url: If `True`, pre-fetch a signed URLs for the items (otherwise the URLs will be signed on demand).
 
         Returns:


### PR DESCRIPTION
# Introduction and Explanation

A follow-up to #743: the way it's written now the functions "don't accept" pure `list[str]` or `list[UUID]` as arguments, typing-wise . This is not good for the customers, and also causes a typing issue in the BE repo checks (as it's used this way in the tests).

Be even more relaxed there and change it to `Sequence`. This has extra nice property of accepting things like `items_infos.keys()` where `items_infos` is a dict.

Also make the docs hopefully more clear.

# Documentation

Some docstrings changes.

# Tests

N/A
