### PR TITLE
feat: add branch name option to import coco labels

### DIFF
--- a/encord/project.py
+++ b/encord/project.py
@@ -1131,6 +1131,7 @@ class Project:
         labels_dict: Dict[str, Any],
         category_id_to_feature_hash: Dict[CategoryID, str],
         image_id_to_frame_index: Dict[ImageID, FrameIndex],
+        branch_name: Optional[str] = None,
     ) -> None:
         """Import labels from a COCO format into your Encord project
 
@@ -1138,9 +1139,16 @@ class Project:
             labels_dict (Dict[str, Any]): Raw label dictionary conforming to Encord format
             category_id_to_feature_hash (Dict[CategoryID, str]): Dictionary mapping category_id as used in the COCO data to the feature hash for the corresponding element in this Ontology
             image_id_to_frame_index (Dict[ImageID, FrameIndex]): Dictionary mapping int to FrameIndex(data_hash, frame_offset) which is used to identify the corresponding frame in the Encord setting
+            branch_name (Optional[str]): Optionally specify a branch name. Defaults to the `main` branch.
         """
         from encord.utilities.coco.datastructure import CocoRootModel
         from encord.utilities.coco.importer import import_coco_labels
 
         coco = CocoRootModel.from_dict(labels_dict)
-        import_coco_labels(self, coco, category_id_to_feature_hash, image_id_to_frame_index)
+        import_coco_labels(
+            self,
+            coco,
+            category_id_to_feature_hash,
+            image_id_to_frame_index,
+            branch_name=branch_name,
+        )

--- a/encord/utilities/coco/importer.py
+++ b/encord/utilities/coco/importer.py
@@ -40,10 +40,12 @@ def build_category_id_to_encord_ontology_object_map(
 
 
 def initialise_label_rows(
-    project: Project, image_id_to_frame_index: Dict[ImageID, FrameIndex]
+    project: Project,
+    image_id_to_frame_index: Dict[ImageID, FrameIndex],
+    branch_name: Optional[str] = None,
 ) -> Dict[str, LabelRowV2]:
     data_hashes = list({frame_index.data_hash for frame_index in image_id_to_frame_index.values()})
-    label_rows = project.list_label_rows_v2(data_hashes=data_hashes)
+    label_rows = project.list_label_rows_v2(data_hashes=data_hashes, branch_name=branch_name)
     with project.create_bundle() as bundle:
         for lr in label_rows:
             lr.initialise_labels(bundle=bundle)
@@ -55,8 +57,9 @@ def import_coco_labels(
     coco: CocoRootModel,
     category_id_to_feature_hash: Dict[CategoryID, str],
     image_id_to_frame_index: Dict[ImageID, FrameIndex],
+    branch_name: Optional[str] = None,
 ) -> None:
-    label_rows = initialise_label_rows(project, image_id_to_frame_index)
+    label_rows = initialise_label_rows(project, image_id_to_frame_index, branch_name=branch_name)
     category_id_to_objects = build_category_id_to_encord_ontology_object_map(project, category_id_to_feature_hash)
     coco_image_lookup = {i.id: i for i in coco.images}
 


### PR DESCRIPTION
# Introduction and Explanation
The `project.import_coco_labels()` method only uploads COCO labels to the main branch and is unaware of the existence of any other branches. We need to make it branch aware, so predictions in the COCO format can be uploaded at their respective branch.

# Documentation
Already updated the relevant docs.

# Tests
Non-existent in this code section. Tested it myself on my side.