### PR TITLE
fix: make workflow stages comparable

### DIFF
--- a/encord/workflow/common.py
+++ b/encord/workflow/common.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Iterable, List, Optional, Sequence, Tuple, Type, TypeVar
+from typing import Iterable, Optional, Sequence, Tuple, Type, TypeVar
 from uuid import UUID
 
 from encord.http.bundle import Bundle, bundled_operation
@@ -16,7 +16,7 @@ class TasksQueryParams(BaseDTO):
 
 @dataclass(frozen=True)
 class WorkflowStageBase:
-    _workflow_client: WorkflowClient
+    _workflow_client: WorkflowClient = field(compare=False, hash=False)
     uuid: UUID
     title: str
 


### PR DESCRIPTION
# Introduction and Explanation

previously, this would cause an error:

```python
stages: set[WorkflowStage] = {s for s in project.workflow.stages}
```

Because the WorkflowStage has a "hidden" client.
This fixes it by ignoring it in the automatically generated `__hash__` function.
