### PR TITLE
[EC-5527] Allow review as someone else

### DIFF
--- a/encord/workflow/stages/annotation.py
+++ b/encord/workflow/stages/annotation.py
@@ -138,6 +138,7 @@ class AnnotationTask(WorkflowTask):
         Submits the task for review.
 
         **Parameters**
+
         - `assignee` (Optional[str]): User email to be assigned to the task whilst submitting the task.
         - `retain_assignee` (bool): Retains the current assignee of the task. This is ignored if `assignee` is provided. An Error will occur if the task does not already have an assignee and `retain_assignee` is True.
         - `bundle` (Optional[Bundle]): Optional bundle to be included with the submission.

--- a/encord/workflow/stages/consensus_review.py
+++ b/encord/workflow/stages/consensus_review.py
@@ -92,10 +92,14 @@ class ConsensusReviewStage(WorkflowStageBase):
 
 class _ActionApprove(WorkflowAction):
     action: Literal["APPROVE"] = "APPROVE"
+    assignee: Optional[str] = None
+    retain_assignee: bool = False
 
 
 class _ActionReject(WorkflowAction):
     action: Literal["REJECT"] = "REJECT"
+    assignee: Optional[str] = None
+    retain_assignee: bool = False
 
 
 class _ActionAssign(WorkflowAction):
@@ -139,12 +143,20 @@ class ConsensusReviewTask(WorkflowTask):
     - `release`: Releases a task from the current user.
     """
 
-    def approve(self, *, bundle: Optional[Bundle] = None) -> None:
+    def approve(
+        self,
+        *,
+        assignee: Optional[str] = None,
+        retain_assignee: bool = False,
+        bundle: Optional[Bundle] = None,
+    ) -> None:
         """
         Approve the current task.
 
         **Parameters**
 
+        - `assignee` (Optional[str]): User email to be assigned to the review task whilst approving the task.
+        - `retain_assignee` (bool): Retains the current assignee whilst approving the task. This is ignored if `assignee` is provided. An Error will occur if the task does not already have an assignee and `retain_assignee` is True.
         - `bundle` (Optional[Bundle]): Optional bundle of actions to execute with the approval.
 
         **Returns**
@@ -152,14 +164,26 @@ class ConsensusReviewTask(WorkflowTask):
         None
         """
         workflow_client, stage_uuid = self._get_client_data()
-        workflow_client.action(stage_uuid, _ActionApprove(task_uuid=self.uuid), bundle=bundle)
+        workflow_client.action(
+            stage_uuid,
+            _ActionApprove(task_uuid=self.uuid, assignee=assignee, retain_assignee=retain_assignee),
+            bundle=bundle,
+        )
 
-    def reject(self, *, bundle: Optional[Bundle] = None) -> None:
+    def reject(
+        self,
+        *,
+        assignee: Optional[str] = None,
+        retain_assignee: bool = False,
+        bundle: Optional[Bundle] = None,
+    ) -> None:
         """
         Reject the current task.
 
         **Parameters**
 
+        - `assignee` (Optional[str]): User email to be assigned to the review task whilst rejecting the task.
+        - `retain_assignee` (bool): Retains the current assignee whilst rejecting the task. This is ignored if `assignee` is provided. An Error will occur if the task does not already have an assignee and `retain_assignee` is True.
         - `bundle` (Optional[Bundle]): Optional bundle of actions to execute with the rejection.
 
         **Returns**
@@ -167,7 +191,11 @@ class ConsensusReviewTask(WorkflowTask):
         None
         """
         workflow_client, stage_uuid = self._get_client_data()
-        workflow_client.action(stage_uuid, _ActionReject(task_uuid=self.uuid), bundle=bundle)
+        workflow_client.action(
+            stage_uuid,
+            _ActionReject(task_uuid=self.uuid, assignee=assignee, retain_assignee=retain_assignee),
+            bundle=bundle,
+        )
 
     def assign(self, assignee: str, *, bundle: Optional[Bundle] = None) -> None:
         """

--- a/encord/workflow/stages/consensus_review.py
+++ b/encord/workflow/stages/consensus_review.py
@@ -156,7 +156,7 @@ class ConsensusReviewTask(WorkflowTask):
         **Parameters**
 
         - `assignee` (Optional[str]): User email to be assigned to the review task whilst approving the task.
-        - `retain_assignee` (bool): Retains the current assignee whilst approving the task. This is ignored if `assignee` is provided. An Error will occur if the task does not already have an assignee and `retain_assignee` is True.
+        - `retain_assignee` (bool): Retains the current assignee whilst approving the task. This is ignored if `assignee` is provided. An error will occur if the task does not already have an assignee and `retain_assignee` is True.
         - `bundle` (Optional[Bundle]): Optional bundle of actions to execute with the approval.
 
         **Returns**
@@ -183,7 +183,7 @@ class ConsensusReviewTask(WorkflowTask):
         **Parameters**
 
         - `assignee` (Optional[str]): User email to be assigned to the review task whilst rejecting the task.
-        - `retain_assignee` (bool): Retains the current assignee whilst rejecting the task. This is ignored if `assignee` is provided. An Error will occur if the task does not already have an assignee and `retain_assignee` is True.
+        - `retain_assignee` (bool): Retains the current assignee whilst rejecting the task. This is ignored if `assignee` is provided. An error will occur if the task does not already have an assignee and `retain_assignee` is True.
         - `bundle` (Optional[Bundle]): Optional bundle of actions to execute with the rejection.
 
         **Returns**

--- a/encord/workflow/stages/review.py
+++ b/encord/workflow/stages/review.py
@@ -235,7 +235,7 @@ class ReviewTask(WorkflowTask):
         **Parameters**
 
         - `assignee` (Optional[str]): User email to be assigned to the task whilst approving the task.
-        - `retain_assignee` (bool): Retains the current assignee whilst approving the task. This is ignored if `assignee` is provided. An Error will occur if the task does not already have an assignee and `retain_assignee` is True.
+        - `retain_assignee` (bool): Retains the current assignee whilst approving the task. This is ignored if `assignee` is provided. An error will occur if the task does not already have an assignee and `retain_assignee` is True.
         - `bundle` (Optional[Bundle]): Optional bundle parameter.
         """
         workflow_client, stage_uuid = self._get_client_data()
@@ -258,7 +258,7 @@ class ReviewTask(WorkflowTask):
         **Parameters**
 
         - `assignee` (Optional[str]): User email to be assigned to the task whilst rejecting the task.
-        - `retain_assignee` (bool): Retains the current assignee whilst rejecting the task. This is ignored if `assignee` is provided. An Error will occur if the task does not already have an assignee and `retain_assignee` is True.
+        - `retain_assignee` (bool): Retains the current assignee whilst rejecting the task. This is ignored if `assignee` is provided. An error will occur if the task does not already have an assignee and `retain_assignee` is True.
         - `bundle` (Optional[Bundle]): Optional bundle parameter.
         """
         workflow_client, stage_uuid = self._get_client_data()

--- a/encord/workflow/stages/review.py
+++ b/encord/workflow/stages/review.py
@@ -235,7 +235,7 @@ class ReviewTask(WorkflowTask):
         **Parameters**
 
         - `assignee` (Optional[str]): User email to be assigned to the task whilst approving the task.
-        - `retain_assignee` (bool): Retains the current assignee of the task. This is ignored if `assignee` is provided. An Error will occur if the task does not already have an assignee and `retain_assignee` is True.
+        - `retain_assignee` (bool): Retains the current assignee whilst approving the task. This is ignored if `assignee` is provided. An Error will occur if the task does not already have an assignee and `retain_assignee` is True.
         - `bundle` (Optional[Bundle]): Optional bundle parameter.
         """
         workflow_client, stage_uuid = self._get_client_data()
@@ -258,7 +258,7 @@ class ReviewTask(WorkflowTask):
         **Parameters**
 
         - `assignee` (Optional[str]): User email to be assigned to the task whilst rejecting the task.
-        - `retain_assignee` (bool): Retains the current assignee of the task. This is ignored if `assignee` is provided. An Error will occur if the task does not already have an assignee and `retain_assignee` is True.
+        - `retain_assignee` (bool): Retains the current assignee whilst rejecting the task. This is ignored if `assignee` is provided. An Error will occur if the task does not already have an assignee and `retain_assignee` is True.
         - `bundle` (Optional[Bundle]): Optional bundle parameter.
         """
         workflow_client, stage_uuid = self._get_client_data()

--- a/encord/workflow/stages/review.py
+++ b/encord/workflow/stages/review.py
@@ -178,11 +178,15 @@ class ReviewStage(WorkflowStageBase):
 class _ActionApprove(WorkflowAction):
     action: Literal["APPROVE"] = "APPROVE"
     approve_label_reviews: bool = True
+    assignee: Optional[str] = None
+    retain_assignee: bool = False
 
 
 class _ActionReject(WorkflowAction):
     action: Literal["REJECT"] = "REJECT"
     reject_label_reviews: bool = True
+    assignee: Optional[str] = None
+    retain_assignee: bool = False
 
 
 class _ActionAssign(WorkflowAction):
@@ -218,27 +222,51 @@ class ReviewTask(WorkflowTask):
     - `release`: Releases a task from the current user.
     """
 
-    def approve(self, *, bundle: Optional[Bundle] = None) -> None:
+    def approve(
+        self,
+        *,
+        assignee: Optional[str] = None,
+        retain_assignee: bool = False,
+        bundle: Optional[Bundle] = None,
+    ) -> None:
         """
         Approves the task.
 
         **Parameters**
 
+        - `assignee` (Optional[str]): User email to be assigned to the task whilst approving the task.
+        - `retain_assignee` (bool): Retains the current assignee of the task. This is ignored if `assignee` is provided. An Error will occur if the task does not already have an assignee and `retain_assignee` is True.
         - `bundle` (Optional[Bundle]): Optional bundle parameter.
         """
         workflow_client, stage_uuid = self._get_client_data()
-        workflow_client.action(stage_uuid, _ActionApprove(task_uuid=self.uuid), bundle=bundle)
+        workflow_client.action(
+            stage_uuid,
+            _ActionApprove(task_uuid=self.uuid, assignee=assignee, retain_assignee=retain_assignee),
+            bundle=bundle,
+        )
 
-    def reject(self, *, bundle: Optional[Bundle] = None) -> None:
+    def reject(
+        self,
+        *,
+        assignee: Optional[str] = None,
+        retain_assignee: bool = False,
+        bundle: Optional[Bundle] = None,
+    ) -> None:
         """
         Rejects the task.
 
         **Parameters**
 
+        - `assignee` (Optional[str]): User email to be assigned to the task whilst rejecting the task.
+        - `retain_assignee` (bool): Retains the current assignee of the task. This is ignored if `assignee` is provided. An Error will occur if the task does not already have an assignee and `retain_assignee` is True.
         - `bundle` (Optional[Bundle]): Optional bundle parameter.
         """
         workflow_client, stage_uuid = self._get_client_data()
-        workflow_client.action(stage_uuid, _ActionReject(task_uuid=self.uuid), bundle=bundle)
+        workflow_client.action(
+            stage_uuid,
+            _ActionReject(task_uuid=self.uuid, assignee=assignee, retain_assignee=retain_assignee),
+            bundle=bundle,
+        )
 
     def assign(self, assignee: str, *, bundle: Optional[Bundle] = None) -> None:
         """


### PR DESCRIPTION
# Introduction and Explanation
Add assignee and retain_assignee params to approve & reject for composite review and consensus review. This allows admins to "review as someone else".

BE PR: https://github.com/encord-team/cord-backend/pull/4205

# Documentation
_There should be enough internal documentation for a product owner to write customer-facing documentation or a separate PR linked if writing the customer documentation directly. Link all that are relevant below_.
- Internal: NA
- Customer docs PR: NA
- OpenAPI/SDK
    - Generated docs: NA
    - Command to generate: NA

# Tests
None (No logic in SDK really, all logic / tests in BE)

# Known issues
None