### PR TITLE
Remove old CVAT route models

### DIFF
--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -290,11 +290,6 @@ class CvatExportType(str, Enum):
     TASK = "task"
 
 
-class ProjectImporter(BaseDTO):
-    project_hash: Optional[str]
-    errors: List[str]
-
-
 class TaskPriorityParams(BaseDTO):
     priorities: List[Tuple[str, float]]
 

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -76,7 +76,6 @@ from encord.orm.project import (
     CvatImportStartPayload,
     CvatReviewMode,
     ManualReviewWorkflowSettings,
-    ProjectImporter,
     ProjectWorkflowSettings,
     ProjectWorkflowType,
     ReviewMode,


### PR DESCRIPTION
# Introduction and Explanation
Remove old CVAT route models