### PR TITLE
fix: Pass service account private key to integration tests

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -15,6 +15,9 @@ inputs:
   private-key-non-org:
     description: 'Private key of the second (non-org) user for integration tests'
     required: true
+  private-key-service-account:
+    description: 'Private key for service account user for integration tests'
+    required: true
   poetry-version:
     description: 'Poetry version to use'
     default: 1.5.0


### PR DESCRIPTION
https://github.com/encord-team/encord-client-python/actions/runs/11976058761/job/33390853140
was watching this. Please see the warning in the first few lines:
Not sure if necessary.
How do we type check YAML files 🤔 
```

Download action repository 'actions/upload-artifact@v4' (SHA:b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882)
Warning: Unexpected input(s) 'private-key-service-account', valid inputs are ['python-version', 'test-report-file', 'private-key', 'private-key-non-org', 'poetry-version', 'integration-tests-location', 'test-dir', 'environment', 'sdk-repository-url']
Run ./.github/actions/run-integration-tests
Prepare all required actions

```