### PR TITLE
SDK changes to make use of 'V2' ontologies APIs, plus 'include_org_access' feature

### DIFF
--- a/encord/http/v2/api_client.py
+++ b/encord/http/v2/api_client.py
@@ -115,6 +115,14 @@ class ApiClient:
     ) -> T:
         return self._request_with_payload("POST", path, params, payload, result_type)
 
+    def put(
+        self,
+        path: str,
+        params: Optional[BaseDTO],
+        payload: Union[BaseDTO, Sequence[BaseDTO], None],
+    ) -> None:
+        self._request_with_payload("PUT", path, params, payload, None, allow_none=True)
+
     def patch(
         self, path: str, params: Optional[BaseDTO], payload: Optional[BaseDTO], result_type: Optional[Type[T]]
     ) -> T:
@@ -143,6 +151,7 @@ class ApiClient:
         params: Optional[BaseDTO],
         payload: Union[BaseDTO, Sequence[BaseDTO], None],
         result_type: Optional[Type[T]],
+        allow_none: bool = False,
     ) -> T:
         params_dict = params.to_dict() if params is not None else None
         payload_serialised = self._serialise_payload(payload)
@@ -154,7 +163,7 @@ class ApiClient:
             json=payload_serialised,
         ).prepare()
 
-        return self._request(req, result_type=result_type)  # type: ignore
+        return self._request(req, result_type=result_type, allow_none=allow_none)  # type: ignore
 
     def _request_without_payload(
         self,

--- a/encord/orm/ontology.py
+++ b/encord/orm/ontology.py
@@ -6,12 +6,9 @@ from typing import Dict, Optional
 
 # pylint: disable=unused-import
 from encord.objects.ontology_structure import OntologyStructure
+from encord.orm.base_dto import BaseDTO, dto_validator
 from encord.orm.formatter import Formatter
-
-
-class OntologyUserRole(IntEnum):
-    ADMIN = 0
-    USER = 1
+from encord.utilities.ontology_user import OntologyUserRole
 
 
 class Ontology(dict, Formatter):
@@ -23,6 +20,7 @@ class Ontology(dict, Formatter):
         created_at: datetime,
         last_edited_at: datetime,
         description: Optional[str] = None,
+        user_role: Optional[OntologyUserRole] = None,
     ):
         """
         DEPRECATED - prefer using the :class:`encord.ontology.Ontology` class instead.
@@ -43,6 +41,7 @@ class Ontology(dict, Formatter):
                 "structure": structure,
                 "created_at": created_at,
                 "last_edited_at": last_edited_at,
+                "user_role": user_role,
             }
         )
 
@@ -82,6 +81,10 @@ class Ontology(dict, Formatter):
     def last_edited_at(self) -> datetime:
         return self["last_edited_at"]
 
+    @property
+    def user_role(self) -> OntologyUserRole:
+        return self["user_role"]
+
     @classmethod
     def from_dict(cls, json_dict: Dict) -> Ontology:
         return Ontology(
@@ -91,4 +94,11 @@ class Ontology(dict, Formatter):
             structure=OntologyStructure.from_dict(json_dict["editor"]),
             created_at=json_dict["created_at"],
             last_edited_at=json_dict["last_edited_at"],
+            user_role=json_dict.get("user_role"),  #  has to be like this to support the legacy endpoints for tests
         )
+
+
+class CreateOrUpdateOntologyPayload(BaseDTO):
+    title: str
+    description: str
+    editor: dict

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -13,6 +13,7 @@ category: "64e481b57b6027003f20aaa0"
 from __future__ import annotations
 
 import base64
+import dataclasses
 import logging
 import time
 import uuid
@@ -75,6 +76,7 @@ from encord.orm.deidentification import (
     DicomDeIdStartPayload,
 )
 from encord.orm.group import Group as OrmGroup
+from encord.orm.ontology import CreateOrUpdateOntologyPayload
 from encord.orm.ontology import Ontology as OrmOntology
 from encord.orm.project import (
     BenchmarkQaWorkflowSettings,
@@ -102,7 +104,7 @@ from encord.utilities.client_utilities import (
     Issues,
     LocalImport,
 )
-from encord.utilities.ontology_user import OntologyUserRole, OntologyWithUserRole
+from encord.utilities.ontology_user import OntologiesFilterParams, OntologyUserRole, OntologyWithUserRole
 from encord.utilities.project_user import ProjectUserRole
 
 CVAT_LONG_POLLING_RESPONSE_RETRY_N = 3
@@ -187,15 +189,15 @@ class EncordUserClient:
         client = EncordClientProject(querier=querier, config=self._config.config, api_client=self._api_client)
         project_orm = client.get_project_v2()
 
-        orm_ontology = querier.basic_getter(OrmOntology, project_orm.ontology_hash)
-        project_ontology = Ontology(querier, orm_ontology, self._api_client)
+        project_ontology = self.get_ontology(project_orm.ontology_hash)
 
         return Project(client, project_orm, project_ontology, self._api_client)
 
     def get_ontology(self, ontology_hash: str) -> Ontology:
-        querier = Querier(self._config.config, resource_type=TYPE_ONTOLOGY, resource_id=ontology_hash)
-        orm_ontology = querier.basic_getter(OrmOntology, ontology_hash)
-        return Ontology(querier, orm_ontology, self._api_client)
+        ontology_with_user_role = self._api_client.get(
+            f"ontologies/{ontology_hash}", params=None, result_type=OntologyWithUserRole
+        )
+        return Ontology._from_api_payload(ontology_with_user_role, self._api_client)
 
     @deprecated("0.1.104", alternative=".create_dataset")
     def create_private_dataset(
@@ -785,6 +787,7 @@ class EncordUserClient:
         created_after: Optional[Union[str, datetime]] = None,
         edited_before: Optional[Union[str, datetime]] = None,
         edited_after: Optional[Union[str, datetime]] = None,
+        include_org_access: bool = False,
     ) -> List[Dict]:
         """
         List either all (if called with no arguments) or matching ontologies the user has access to.
@@ -798,21 +801,24 @@ class EncordUserClient:
             created_after: optional creation date filter, 'greater'
             edited_before: optional last modification date filter, 'less'
             edited_after: optional last modification date filter, 'greater'
+            include_org_access: if set to true and the calling user is the organization admin, the
+              method will return all ontologies in the organization.
 
         Returns:
-            list of (role, projects) pairs for ontologies matching filter conditions.
+            list of ontologies matching filter conditions, with the roles that the current user has on them. Each item
+            is a dictionary with `"ontology"` and `"user_role"` keys. If include_org_access is set to
+            True, some of the ontologies may have a `None` value for the `"user_role"` key.
         """
-        properties_filter = self.__validate_filter(locals())
+        properties_filter = OntologiesFilterParams.from_dict(self.__validate_filter(locals()))
+        page = self._api_client.get("ontologies", params=properties_filter, result_type=Page[OntologyWithUserRole])
+
         # a hack to be able to share validation code without too much c&p
-        data = self._querier.get_multiple(OntologyWithUserRole, payload={"filter": properties_filter})
         retval: List[Dict] = []
-        for row in data:
-            ontology = OrmOntology.from_dict(row.ontology)
-            querier = Querier(self._config, resource_type=TYPE_ONTOLOGY, resource_id=ontology.ontology_hash)
+        for row in page.results:
             retval.append(
                 {
-                    "ontology": Ontology(querier, ontology, api_client=self._api_client),
-                    "user_role": OntologyUserRole(row.user_role),
+                    "ontology": Ontology._from_api_payload(row, self._api_client),
+                    "user_role": row.user_role,
                 }
             )
         return retval
@@ -828,17 +834,15 @@ class EncordUserClient:
         except ValueError as e:
             raise ValueError("Can't create an Ontology containing a Classification without any attributes. " + str(e))
 
-        ontology = {
-            "title": title,
-            "description": description,
-            "editor": structure_dict,
-        }
+        payload = CreateOrUpdateOntologyPayload(
+            title=title,
+            description=description,
+            editor=structure_dict,
+        )
 
-        retval = self._querier.basic_setter(OrmOntology, uid=None, payload=ontology)
-        ontology = OrmOntology.from_dict(retval)
-        querier = Querier(self._config, resource_type=TYPE_ONTOLOGY, resource_id=ontology.ontology_hash)
+        ontology = self._api_client.post("ontologies", payload=payload, params=None, result_type=OntologyWithUserRole)
 
-        return Ontology(querier, ontology, self._api_client)
+        return Ontology._from_api_payload(ontology, self._api_client)
 
     def __validate_filter(self, properties_filter: Dict) -> Dict:
         if not isinstance(properties_filter, dict):

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -810,6 +810,7 @@ class EncordUserClient:
             True, some of the ontologies may have a `None` value for the `"user_role"` key.
         """
         properties_filter = OntologiesFilterParams.from_dict(self.__validate_filter(locals()))
+        properties_filter.include_org_access = include_org_access
         page = self._api_client.get("ontologies", params=properties_filter, result_type=Page[OntologyWithUserRole])
 
         # a hack to be able to share validation code without too much c&p

--- a/encord/utilities/ontology_user.py
+++ b/encord/utilities/ontology_user.py
@@ -11,7 +11,12 @@ category: "64e481b57b6027003f20aaa0"
 """
 
 from dataclasses import dataclass
+from datetime import datetime
 from enum import IntEnum
+from typing import Optional, Union
+from uuid import UUID
+
+from encord.orm.base_dto import BaseDTO
 
 
 class OntologyUserRole(IntEnum):
@@ -19,12 +24,31 @@ class OntologyUserRole(IntEnum):
     USER = 1
 
 
-@dataclass(frozen=True)
-class OntologyWithUserRole:
+class OntologyWithUserRole(BaseDTO):
     """
-    This is a helper class denoting the relationship between the current user an an ontology
+    An on-the-wire representation from /v2/public/ontologies endpoints
     """
 
-    user_role: int
-    user_email: str
-    ontology: dict
+    ontology_uuid: UUID
+    title: str
+    description: str
+    editor: dict
+    created_at: datetime
+    last_edited_at: datetime
+    user_role: Optional[OntologyUserRole]
+
+
+class OntologiesFilterParams(BaseDTO):
+    """
+    Filter parameters for the /v2/public/ontologies endpoint
+    """
+
+    title_eq: Optional[str] = None
+    title_like: Optional[str] = None
+    desc_eq: Optional[str] = None
+    desc_like: Optional[str] = None
+    created_before: Optional[Union[str, datetime]] = None
+    created_after: Optional[Union[str, datetime]] = None
+    edited_before: Optional[Union[str, datetime]] = None
+    edited_after: Optional[Union[str, datetime]] = None
+    include_org_access: bool = False

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from cryptography.hazmat.primitives import serialization
@@ -8,7 +8,6 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from encord import EncordUserClient, Project
 from encord.client import EncordClientProject
-from encord.http.querier import Querier
 from encord.ontology import Ontology
 from encord.orm.ontology import Ontology as OrmOntology
 from encord.orm.project import ProjectDTO, ProjectType
@@ -25,7 +24,7 @@ PRIVATE_KEY_PEM = PRIVATE_KEY.private_bytes(
 
 @pytest.fixture
 def ontology() -> Ontology:
-    return Ontology(None, OrmOntology.from_dict(ONTOLOGY_BLURB), None)
+    return Ontology(OrmOntology.from_dict(ONTOLOGY_BLURB), MagicMock())
 
 
 @pytest.fixture
@@ -35,9 +34,14 @@ def user_client() -> EncordUserClient:
 
 @pytest.fixture
 @patch.object(EncordClientProject, "get_project_v2")
-@patch.object(Querier, "basic_getter")
-def project(querier_mock: Querier, client_project_mock, user_client: EncordUserClient, ontology: Ontology) -> Project:
-    querier_mock.return_value = OrmOntology.from_dict(ONTOLOGY_BLURB)
+@patch.object(EncordUserClient, "get_ontology")
+def project(
+    client_ontology_mock: MagicMock,
+    client_project_mock: MagicMock,
+    user_client: EncordUserClient,
+    ontology: Ontology,
+) -> Project:
+    client_ontology_mock.return_value = ontology
 
     client_project_mock.return_value = ProjectDTO(
         project_hash=uuid.uuid4(),

--- a/tests/http/test_timeout_overrides_setting.py
+++ b/tests/http/test_timeout_overrides_setting.py
@@ -40,7 +40,18 @@ def stub_responses(*args, **kwargs) -> MagicMock:
         }
         mock_response.status_code = 200
         mock_response.json.return_value = response
-
+    elif args[0].path_url.startswith("/v2/public/ontologies"):
+        response = {
+            "ontologyUuid": ONTOLOGY_HASH,
+            "title": "Test ontology",
+            "description": "",
+            "created_at": "2024-01-01 11:11:11",
+            "last_edited_at": "2024-01-01 11:11:11",
+            "editor": {"objects": [], "classifications": []},
+            "user_role": 1,
+        }
+        mock_response.status_code = 200
+        mock_response.json.return_value = response
     else:
         # Legacy api
         body_json = json.loads(args[0].body)

--- a/tests/test_user_client_auth.py
+++ b/tests/test_user_client_auth.py
@@ -15,37 +15,39 @@ from requests import PreparedRequest, Session
 from encord.configs import SshConfig
 from encord.http.v2.payloads import Page
 from encord.orm.analytics import CollaboratorTimer
-from encord.orm.ontology import Ontology as OrmOntology
-from encord.orm.ontology import OntologyStructure
 from encord.orm.project import Project as OrmProject
 from encord.orm.project import ProjectDTO, ProjectType
 from encord.user_client import EncordUserClient
+from encord.utilities.ontology_user import OntologyUserRole, OntologyWithUserRole
 from tests.fixtures import PRIVATE_KEY_PEM
 
 PROJECT_HASH = str(uuid.uuid4())
-ONTOLOGY_HASH = str(uuid.uuid4())
+DATASET_HASH = str(uuid.uuid4())
+ONTOLOGY_UUID = uuid.uuid4()
 
 
-ontology_orm = OrmOntology(
-    ontology_hash=ONTOLOGY_HASH,
-    title="Test ontology",
-    structure=OntologyStructure(),
-    created_at=datetime.now(),
-    last_edited_at=datetime.now(),
-)
-
-ontology_dic = {
-    "ontology_hash": ONTOLOGY_HASH,
-    "title": "Test ontology",
+dataset_dic = {
+    "dataset_hash": DATASET_HASH,
+    "dataset_type": 0,
+    "title": "Test dataset",
     "created_at": datetime.now(),
     "last_edited_at": datetime.now(),
-    "editor": OntologyStructure().to_dict(),
     "description": "",
 }
 
+ontology_orm = OntologyWithUserRole(
+    ontology_uuid=ONTOLOGY_UUID,
+    title="Dummy ontology",
+    description="",
+    editor={"objects": [], "classifications": []},
+    created_at=datetime.now(),
+    last_edited_at=datetime.now(),
+    user_role=OntologyUserRole.USER,
+)
+
 api_key_meta_dic = {"title": "dummy key", "resource_type": "project"}
 
-project_orm = OrmProject({"project_hash": PROJECT_HASH, "ontology_hash": ONTOLOGY_HASH})
+project_orm = OrmProject({"project_hash": PROJECT_HASH, "ontology_hash": DATASET_HASH})
 project_dto = ProjectDTO(
     project_hash=uuid.uuid4(),
     project_type=ProjectType.MANUAL_QA,
@@ -53,7 +55,7 @@ project_dto = ProjectDTO(
     description="",
     created_at=datetime.now(),
     last_edited_at=datetime.now(),
-    ontology_hash="dummy-ontology-hash",
+    ontology_hash=str(ONTOLOGY_UUID),
     workflow=None,
 )
 
@@ -63,7 +65,7 @@ def bearer_token() -> str:
     return "a-fake-token"
 
 
-def make_side_effects(project_response: Optional[MagicMock] = None, ontology_response: Optional[MagicMock] = None):
+def make_side_effects(project_response: Optional[MagicMock] = None):
     # Mocking a few service endpoints to make it possible to test authentication
 
     def side_effects(*args, **kwargs):
@@ -87,13 +89,11 @@ def make_side_effects(project_response: Optional[MagicMock] = None, ontology_res
                 mock_response.json.return_value = {"status": 200, "response": project_orm}
                 mock_response.content = json.dumps({"status": 200, "response": project_orm}, default=str)
                 return mock_response
-            if request_type == "ontology":
-                if ontology_response:
-                    return ontology_response
+            if request_type == "dataset":
                 mock_response = MagicMock()
                 mock_response.status_code = 200
-                mock_response.json.return_value = {"status": 200, "response": ontology_dic}
-                mock_response.content = json.dumps({"status": 200, "response": ontology_dic}, default=str)
+                mock_response.json.return_value = {"status": 200, "response": dataset_dic}
+                mock_response.content = json.dumps({"status": 200, "response": dataset_dic}, default=str)
                 return mock_response
             else:
                 print(f"Unknown type {request_type}")
@@ -110,6 +110,13 @@ def make_side_effects(project_response: Optional[MagicMock] = None, ontology_res
             mock_response.status_code = 200
             mock_response.json.return_value = Page[CollaboratorTimer](results=[]).to_dict()
             mock_response.json.content = json.dumps(Page[CollaboratorTimer](results=[]).to_dict())
+            return mock_response
+        elif args[0].method == "GET" and args[0].path_url.startswith("/v2/public/ontologies/"):
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+
+            mock_response.json.return_value = ontology_orm.to_dict()
+            mock_response.content = json.dumps(ontology_orm.to_dict())
             return mock_response
         else:
             raise RuntimeError(f"Not mocked URL: {args[0].path_url}")
@@ -131,7 +138,7 @@ def test_v1_public_resource_when_initialised_with_ssh_key(mock_send, bearer_toke
     mock_send.side_effect = make_side_effects()
 
     user_client = EncordUserClient.create_with_ssh_private_key(ssh_private_key=PRIVATE_KEY_PEM)
-    user_client.get_ontology(ONTOLOGY_HASH)
+    user_client.get_dataset(DATASET_HASH)
 
     assert mock_send.call_count == 1
     for mock_call in mock_send.call_args_list:
@@ -139,8 +146,8 @@ def test_v1_public_resource_when_initialised_with_ssh_key(mock_send, bearer_toke
         request = mock_call.args[0]
 
         assert request.path_url == "/public"
-        assert request.headers["ResourceType"] == "ontology"
-        assert request.headers["ResourceID"] == ONTOLOGY_HASH
+        assert request.headers["ResourceType"] == "dataset"
+        assert request.headers["ResourceID"] == DATASET_HASH
         assert request.headers["Authorization"] == get_encord_auth_header(request)
 
 
@@ -149,14 +156,14 @@ def test_v1_public_resource_when_initialised_with_bearer_auth(mock_send, bearer_
     mock_send.side_effect = make_side_effects()
 
     user_client = EncordUserClient.create_with_bearer_token(bearer_token)
-    user_client.get_ontology(ONTOLOGY_HASH)
+    user_client.get_dataset(DATASET_HASH)
 
     assert mock_send.call_count == 1
     for mock_call in mock_send.call_args_list:
         # Expect call to have correct resource type and id, and correct bearer auth
         assert mock_call.args[0].path_url == "/public"
-        assert mock_call.args[0].headers["ResourceType"] == "ontology"
-        assert mock_call.args[0].headers["ResourceID"] == ONTOLOGY_HASH
+        assert mock_call.args[0].headers["ResourceType"] == "dataset"
+        assert mock_call.args[0].headers["ResourceID"] == DATASET_HASH
         assert mock_call.args[0].headers["Authorization"] == f"Bearer {bearer_token}"
 
 


### PR DESCRIPTION
# Introduction and Explanation

Adding 'list all the ontologies in the org' feature, and converting the whole feature to use the '/v2' SDK. Based/depends on https://github.com/encord-team/cord-backend/pull/4349

# Documentation

The functional change is just a single parameter that's documented in the source. Will need user-facing 'story' type documentation, but probably only once the whole suite of 'org-wide access' features will land (projects/datasets/folders, at least).

# Tests

Mostly covered by the existing SDK testsuite; plus the specific test is coming with the BE change.

# Known issues

Relying on very old crufty objects to pass data around -- but these are semi-public so don't want to break the clients.
