### PR TITLE
feat: Add backing_item_uuid to the LRv2 as an optional attribute

### DIFF
--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -2039,7 +2039,7 @@ class LabelRowV2:
             images_data=label_row_dict.get("images_data", self._label_row_read_only_data.images_data),
             file_type=label_row_dict.get("file_type", None),
             is_valid=bool(label_row_dict.get("is_valid", True)),
-            backing_item_uuid=label_row_dict.get("backing_item_uuid"),
+            backing_item_uuid=label_row_dict.get("backing_item_uuid", self.backing_item_uuid),
         )
 
     def _parse_labels_from_dict(self, label_row_dict: dict):

--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -410,9 +410,9 @@ class LabelRowV2:
     @property
     def backing_item_uuid(self) -> Optional[str]:
         """
-        Returns the unique id for the backing storage item for the row
-
-        Will always be present in response from server but marked optional for backwards compatibility.
+        Returns the unique identifier (UUID) for the backing storage item associated with this label row.
+        The backing item UUID represents the storage reference for the data linked to the row.
+        While it is always included in server responses, it is marked as optional for backward compatibility with earlier versions.
 
         Returns:
             Optional[str]: The backing storage item id or None if not found.

--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -408,6 +408,10 @@ class LabelRowV2:
         return self._label_row_read_only_data.audio_num_channels
 
     @property
+    def backing_item_uuid(self) -> Optional[str]:
+        return self._label_row_read_only_data.backing_item_uuid
+
+    @property
     def priority(self) -> Optional[float]:
         """
         Returns the workflow priority for the task associated with the data unit.
@@ -1576,6 +1580,7 @@ class LabelRowV2:
         last_edited_at: Optional[datetime]
         data_hash: str
         data_type: DataType
+        backing_item_uuid: Optional[str]
         label_status: LabelStatus
         annotation_task_status: Optional[AnnotationTaskStatus]
         workflow_graph_node: Optional[WorkflowGraphNode]
@@ -1595,7 +1600,7 @@ class LabelRowV2:
         data_link: Optional[str]
         priority: Optional[float]
         file_type: Optional[str]
-        client_metadata: Optional[dict]
+        client_metadata: Optional[Dict[str, Any]]
         images_data: Optional[List[LabelRowV2.LabelRowReadOnlyDataImagesDataEntry]]
         branch_name: str
         frame_level_data: Dict[int, LabelRowV2.FrameLevelImageGroupData] = field(default_factory=dict)
@@ -1947,6 +1952,7 @@ class LabelRowV2:
             client_metadata=label_row_metadata.client_metadata,
             file_type=label_row_metadata.file_type,
             is_valid=label_row_metadata.is_valid,
+            backing_item_uuid=label_row_metadata.backing_item_uuid,
         )
 
     def _parse_label_row_dict(self, label_row_dict: dict) -> LabelRowReadOnlyData:
@@ -2033,6 +2039,7 @@ class LabelRowV2:
             images_data=label_row_dict.get("images_data", self._label_row_read_only_data.images_data),
             file_type=label_row_dict.get("file_type", None),
             is_valid=bool(label_row_dict.get("is_valid", True)),
+            backing_item_uuid=label_row_dict.get("backing_item_uuid"),
         )
 
     def _parse_labels_from_dict(self, label_row_dict: dict):

--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -409,6 +409,15 @@ class LabelRowV2:
 
     @property
     def backing_item_uuid(self) -> Optional[str]:
+        """
+        Returns the unique id for the backing storage item for the row
+
+        Will always be present in response from server but marked optional for backwards compatibility.
+
+        Returns:
+            Optional[str]: The backing storage item id or None if not found.
+        """
+        # TODO: Mark required in 0.2 release
         return self._label_row_read_only_data.backing_item_uuid
 
     @property

--- a/encord/orm/label_row.py
+++ b/encord/orm/label_row.py
@@ -396,7 +396,7 @@ class LabelRowMetadataDTO(BaseDTO):
     data_title: str
     data_type: str
     data_link: Optional[str] = None
-    backing_item_uuid: str
+
     """Can be `None` for label rows of image groups or DICOM series."""
     label_status: LabelStatus
     """Can be `None` for TMS2 projects"""
@@ -427,6 +427,8 @@ class LabelRowMetadataDTO(BaseDTO):
     file_type: Optional[str] = None
     """Only available for certain read requests"""
     is_valid: bool = True
+
+    backing_item_uuid: Optional[str] = None
 
 
 def label_row_metadata_dto_to_label_row_metadata(label_row_metadata_dto: LabelRowMetadataDTO) -> LabelRowMetadata:

--- a/encord/orm/label_row.py
+++ b/encord/orm/label_row.py
@@ -260,7 +260,6 @@ class LabelRowMetadata(Formatter):
     data_title: str
     data_type: str
     data_link: Optional[str]
-    backing_item_uuid: str
     """Can be `None` for label rows of image groups or DICOM series."""
     label_status: LabelStatus
     """Can be `None` for TMS2 projects"""
@@ -291,6 +290,8 @@ class LabelRowMetadata(Formatter):
     file_type: Optional[str] = None
     """Only available for certain read requests"""
     is_valid: bool = True
+
+    backing_item_uuid: Optional[str] = None
 
     @classmethod
     def from_dict(cls, json_dict: Dict) -> LabelRowMetadata:

--- a/encord/orm/label_row.py
+++ b/encord/orm/label_row.py
@@ -260,6 +260,7 @@ class LabelRowMetadata(Formatter):
     data_title: str
     data_type: str
     data_link: Optional[str]
+    backing_item_uuid: str
     """Can be `None` for label rows of image groups or DICOM series."""
     label_status: LabelStatus
     """Can be `None` for TMS2 projects"""
@@ -335,6 +336,7 @@ class LabelRowMetadata(Formatter):
             file_type=json_dict.get("file_type"),
             is_valid=bool(json_dict.get("is_valid", True)),
             branch_name=json_dict["branch_name"],
+            backing_item_uuid=json_dict.get("backing_item_uuid", None),
         )
 
     @classmethod
@@ -393,6 +395,7 @@ class LabelRowMetadataDTO(BaseDTO):
     data_title: str
     data_type: str
     data_link: Optional[str] = None
+    backing_item_uuid: str
     """Can be `None` for label rows of image groups or DICOM series."""
     label_status: LabelStatus
     """Can be `None` for TMS2 projects"""
@@ -418,8 +421,8 @@ class LabelRowMetadataDTO(BaseDTO):
 
     priority: Optional[float] = None
     """Only available for not complete tasks"""
-    client_metadata: Optional[dict] = None
-    images_data: Optional[list] = None
+    client_metadata: Optional[Dict[str, Any]] = None
+    images_data: Optional[List[Any]] = None
     file_type: Optional[str] = None
     """Only available for certain read requests"""
     is_valid: bool = True
@@ -455,4 +458,5 @@ def label_row_metadata_dto_to_label_row_metadata(label_row_metadata_dto: LabelRo
         file_type=label_row_metadata_dto.file_type,
         is_valid=label_row_metadata_dto.is_valid,
         branch_name=label_row_metadata_dto.branch_name,
+        backing_item_uuid=label_row_metadata_dto.backing_item_uuid,
     )


### PR DESCRIPTION
# Introduction and Explanation
Requested internally. Makes a lot of flows easier if we can treat the label row object as like our mega table without having to do other joins to resolve queries like what are the backing_uids for the items in this collection.

# Documentation
May actually need some yh
# Tests
Integration test written in BE.