### PR TITLE
Add 'include_org_access' to 'get_datasets'

### DIFF
--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -1092,6 +1092,7 @@ class DatasetsWithUserRolesListParams(BaseDTO):
     created_after: Optional[datetime]
     edited_before: Optional[datetime]
     edited_after: Optional[datetime]
+    include_org_access: Optional[bool] = False
 
 
 class DatasetWithUserRole(BaseDTO):
@@ -1100,7 +1101,7 @@ class DatasetWithUserRole(BaseDTO):
     description: str
     created_at: datetime
     last_edited_at: datetime
-    user_role: DatasetUserRoleV2
+    user_role: Optional[DatasetUserRoleV2]
 
     storage_location: Optional[StorageLocation] = None  # legacy field: you can have data from mixed locations now
     backing_folder_uuid: Optional[UUID] = None  # if set, this indicates a legacy 'mirror' dataset

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -286,6 +286,7 @@ class EncordUserClient:
         created_after: Optional[Union[str, datetime]] = None,
         edited_before: Optional[Union[str, datetime]] = None,
         edited_after: Optional[Union[str, datetime]] = None,
+        include_org_access: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         List either all (if called with no arguments) or matching datasets the user has access to.
@@ -299,9 +300,13 @@ class EncordUserClient:
             created_after: optional creation date filter, 'greater'
             edited_before: optional last modification date filter, 'less'
             edited_after: optional last modification date filter, 'greater'
+            include_org_access: if set to true and the calling user is the organization admin, the
+              method will return all datasets in the organization.
 
         Returns:
-            list of (role, dataset) pairs for datasets  matching filter conditions.
+            list of datasets matching filter conditions, with the roles that the current user has on them. Each item
+            is a dictionary with `"dataset"` and `"user_role"` keys. If include_org_access is set to
+            True, some of the datasets may have a `None` value for the `"user_role"` key.
         """
 
         res = self._api_client.get(
@@ -315,6 +320,7 @@ class EncordUserClient:
                 created_after=parse_datetime_optional(created_after),
                 edited_before=parse_datetime_optional(edited_before),
                 edited_after=parse_datetime_optional(edited_after),
+                include_org_access=include_org_access,
             ),
             result_type=DatasetsWithUserRolesListResponse,
         )
@@ -331,7 +337,7 @@ class EncordUserClient:
                     last_edited_at=x.last_edited_at,
                     backing_folder_uuid=x.backing_folder_uuid,
                 ),
-                "user_role": dataset_user_role_str_enum_to_int_enum(x.user_role),
+                "user_role": dataset_user_role_str_enum_to_int_enum(x.user_role) if x.user_role is not None else None,
             }
             for x in res.result
         ]


### PR DESCRIPTION
# Introduction and Explanation

Same deal as for Ontologies

# Documentation

Docstrings in place; I guess we add the 'human' documentation once at least the main entities are covered (need 'projects').

# Tests

Coming in a separate PR.