### PR TITLE
implement 'list_projects' with the org access feature

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -1139,6 +1139,7 @@ class EncordClientProject(EncordClient):
             .results
         )
 
+    @deprecated("0.1.102", alternative="encord.ontology.Ontology class")
     def get_project_ontology(self) -> LegacyOntology:
         project = self.get_project()
         ontology = project["editor_ontology"]

--- a/encord/orm/base_orm.py
+++ b/encord/orm/base_orm.py
@@ -83,43 +83,6 @@ class BaseORM(dict):
         else:
             super().__delattr__(name)
 
-    @staticmethod
-    def from_db_row(row, db_field):
-        """
-        Static method for conveniently converting db row to client object.
-        :param row:
-        :param db_field:
-        :return:
-        """
-        return {attribute: row[i] for i, attribute in enumerate(db_field)}
-
-    def to_dic(self, time_str: bool = True):
-        """
-        Conveniently set client object as dict.
-        Only considers the dict items, no other object attr will be counted
-
-        Args:
-            time_str: if set to True, will convert datetime field
-                      to str with format %Y-%m-%d %H:%M:%S.
-                      If False, will keep the original datetime type.
-                      Default will be True.
-
-        """
-        res = {}
-        for k, v in self.items():
-            if isinstance(v, datetime.datetime) and time_str:
-                v = v.strftime("%Y-%m-%d %H:%M:%S")
-            elif isinstance(v, dict):
-                v = json.dumps(v)
-            res[k] = v
-
-        return res
-
-    def updatable_fields(self):
-        for k, v in self.items():
-            if k not in self.NON_UPDATABLE_FIELDS and v is not None:
-                yield k, v
-
 
 class BaseListORM(list):
     """A wrapper for a list of objects of a specific ORM."""

--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -11,6 +11,7 @@ from encord.orm import base_orm
 from encord.orm.analytics import CamelStrEnum
 from encord.orm.base_dto import BaseDTO
 from encord.orm.workflow import Workflow
+from encord.utilities.project_user import ProjectUserRole
 
 
 class Project(base_orm.BaseORM):
@@ -91,7 +92,7 @@ class Project(base_orm.BaseORM):
 
                 label_rows = project.get_label_rows(created_labels_list, get_signed_url=False)
         """
-        labels = self.to_dic().get("label_rows", [])
+        labels = self.label_rows() or []
         return [label.get("label_hash") for label in labels]
 
     @property
@@ -135,8 +136,11 @@ class Project(base_orm.BaseORM):
         return self["last_edited_at"]
 
     @property
-    def workflow_manager_uuid(self) -> UUID:
-        return self["workflow_manager_uuid"]
+    def workflow_manager_uuid(self) -> Optional[UUID]:
+        if workflow_manager_uuid := self.get("workflow_manager_uuid"):
+            return UUID(workflow_manager_uuid)
+        else:
+            return None
 
 
 class ProjectCopy:
@@ -302,6 +306,10 @@ class ProjectDTO(BaseDTO):
     created_at: datetime.datetime
     last_edited_at: datetime.datetime
     ontology_hash: str
+    editor_ontology: Dict[str, Any]
+    user_role: Optional[ProjectUserRole] = None
+    source_projects: Optional[List[str]] = None
+    workflow_manager_uuid: Optional[UUID] = None
     workflow: Optional[Workflow] = None
 
 
@@ -360,3 +368,19 @@ class CvatImportGetResultResponse(BaseDTO):
     status: CvatImportGetResultLongPollingStatus
     project_uuid: Optional[UUID] = None
     issues: Optional[Dict] = None
+
+
+class ProjectFilterParams(BaseDTO):
+    """
+    Filter parameters for the /v2/public/projects endpoint
+    """
+
+    title_eq: Optional[str] = None
+    title_like: Optional[str] = None
+    desc_eq: Optional[str] = None
+    desc_like: Optional[str] = None
+    created_before: Optional[Union[str, datetime.datetime]] = None
+    created_after: Optional[Union[str, datetime.datetime]] = None
+    edited_before: Optional[Union[str, datetime.datetime]] = None
+    edited_after: Optional[Union[str, datetime.datetime]] = None
+    include_org_access: bool = False

--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -7,6 +7,7 @@ from enum import Enum, auto
 from typing import Any, Dict, List, Optional, Tuple, Union
 from uuid import UUID
 
+from encord.exceptions import WrongProjectTypeError
 from encord.orm import base_orm
 from encord.orm.analytics import CamelStrEnum
 from encord.orm.base_dto import BaseDTO
@@ -136,11 +137,16 @@ class Project(base_orm.BaseORM):
         return self["last_edited_at"]
 
     @property
-    def workflow_manager_uuid(self) -> Optional[UUID]:
-        if workflow_manager_uuid := self.get("workflow_manager_uuid"):
-            return UUID(workflow_manager_uuid)
-        else:
-            return None
+    def workflow_manager_uuid(self) -> UUID:
+        """
+        Accessing this property will raise a `WrongProjectTypeError` if the project is not a workflow project.
+        """
+        try:
+            return self["workflow_manager_uuid"]
+        except KeyError as e:
+            raise WrongProjectTypeError(
+                "This project is not a workflow project, workflow_manager_uuid is not available."
+            ) from e
 
 
 class ProjectCopy:

--- a/encord/project.py
+++ b/encord/project.py
@@ -66,7 +66,7 @@ class Project:
     ):
         self._client = client
         self._project_instance = project_instance
-        self._ontology = ontology
+        self._ontology_internal = ontology
         self._api_client = api_client
 
         if project_instance.workflow:
@@ -118,7 +118,7 @@ class Project:
         This method returns the same structure as :meth:`encord.Project.ontology_structure`, just in
         raw python dictionary format.
         """
-        return self._ontology_instance.structure.to_dict()
+        return self._ontology.structure.to_dict()
 
     @property
     def ontology_hash(self) -> str:
@@ -132,7 +132,7 @@ class Project:
         """
         Get the ontology structure of the project's ontology.
         """
-        return self._ontology_instance.structure
+        return self._ontology.structure
 
     @property
     def user_role(self) -> Optional[ProjectUserRole]:
@@ -197,7 +197,7 @@ class Project:
         """
         Update the ontology for the project to reflect changes on the backend.
         """
-        self._ontology_instance.refetch_data()
+        self._ontology.refetch_data()
 
     def get_project(self) -> OrmProject:
         """
@@ -218,12 +218,12 @@ class Project:
         return self._workflow
 
     @property
-    def _ontology_instance(self) -> Ontology:
-        if self._ontology is None:
-            self._ontology = Ontology(
+    def _ontology(self) -> Ontology:
+        if self._ontology_internal is None:
+            self._ontology_internal = Ontology(
                 Ontology._fetch_ontology(self._api_client, self.ontology_hash), self._api_client
             )  # lazy loading
-        return self._ontology
+        return self._ontology_internal
 
     def list_label_rows_v2(
         self,
@@ -285,8 +285,7 @@ class Project:
             branch_name=branch_name,
         )
         label_rows = [
-            LabelRowV2(label_row_metadata, self._client, self._ontology_instance)
-            for label_row_metadata in label_row_metadatas
+            LabelRowV2(label_row_metadata, self._client, self._ontology) for label_row_metadata in label_row_metadatas
         ]
         return label_rows
 
@@ -1186,7 +1185,7 @@ class Project:
     def get_collection(self, collection_uuid: Union[str, UUID]) -> ProjectCollection:
         return ProjectCollection._get_collection(
             project_client=self._client,
-            ontology=self._ontology_instance,
+            ontology=self._ontology,
             project_uuid=self._project_instance.project_hash,
             collection_uuid=UUID(collection_uuid) if isinstance(collection_uuid, str) else collection_uuid,
         )
@@ -1214,7 +1213,7 @@ class Project:
         )
         return ProjectCollection._list_collections(
             project_client=self._client,
-            ontology=self._ontology_instance,
+            ontology=self._ontology,
             project_uuid=self._project_instance.project_hash,
             collection_uuids=collections,
             page_size=page_size,

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -13,7 +13,6 @@ category: "64e481b57b6027003f20aaa0"
 from __future__ import annotations
 
 import base64
-import dataclasses
 import logging
 import time
 import uuid
@@ -91,6 +90,8 @@ from encord.orm.project import (
     CvatImportStartPayload,
     CvatReviewMode,
     ManualReviewWorkflowSettings,
+    ProjectDTO,
+    ProjectFilterParams,
     ProjectWorkflowSettings,
     ProjectWorkflowType,
     ReviewMode,
@@ -169,7 +170,7 @@ class EncordUserClient:
         orm_dataset = client.get_dataset()
         return Dataset(client, orm_dataset)
 
-    def get_project(self, project_hash: str | UUID) -> Project:
+    def get_project(self, project_hash: Union[str, UUID]) -> Project:
         """
         Get the Project class to access project fields and manipulate a project.
 
@@ -347,7 +348,7 @@ class EncordUserClient:
         ssh_private_key: Optional[str] = None,
         password: Optional[str] = None,
         requests_settings: RequestsSettings = DEFAULT_REQUESTS_SETTINGS,
-        ssh_private_key_path: Optional[str | Path] = None,
+        ssh_private_key_path: Optional[Union[str, Path]] = None,
         **kwargs,
     ) -> EncordUserClient:
         """
@@ -413,12 +414,59 @@ class EncordUserClient:
             edited_after: optional last modification date filter, 'greater'
 
         Returns:
-            list of (role, projects) pairs for Project matching filter conditions.
+            list of Projects matching filter conditions, with the roles that the current user has on them. Each item
+            is a dictionary with `"project"` and `"user_role"` keys.
         """
         properties_filter = self.__validate_filter(locals())
         # a hack to be able to share validation code without too much c&p
         data = self._querier.get_multiple(ProjectWithUserRole, payload={"filter": properties_filter})
         return [{"project": OrmProject(p.project), "user_role": ProjectUserRole(p.user_role)} for p in data]
+
+    def list_projects(
+        self,
+        title_eq: Optional[str] = None,
+        title_like: Optional[str] = None,
+        desc_eq: Optional[str] = None,
+        desc_like: Optional[str] = None,
+        created_before: Optional[Union[str, datetime]] = None,
+        created_after: Optional[Union[str, datetime]] = None,
+        edited_before: Optional[Union[str, datetime]] = None,
+        edited_after: Optional[Union[str, datetime]] = None,
+        include_org_access: bool = False,
+    ) -> Iterable[Project]:
+        """
+        List either all (if called with no arguments) or matching projects the user has access to.
+
+        Args:
+            title_eq: optional exact title filter
+            title_like: optional fuzzy title filter; SQL syntax
+            desc_eq: optional exact description filter
+            desc_like: optional fuzzy description filter; SQL syntax
+            created_before: optional creation date filter, 'less'
+            created_after: optional creation date filter, 'greater'
+            edited_before: optional last modification date filter, 'less'
+            edited_after: optional last modification date filter, 'greater'
+            include_org_access: if set to true and the calling user is the organization admin, the
+              method will return all ontologies in the organization.
+
+        Returns:
+            list of Projects matching filter conditions, as :class:`~encord.project.Project` instances.
+        """
+        properties_filter = ProjectFilterParams.from_dict(self.__validate_filter(locals()))
+        properties_filter.include_org_access = include_org_access
+        page = self._api_client.get("projects", params=properties_filter, result_type=Page[ProjectDTO])
+
+        retval: List[Dict] = []
+        for row in page.results:
+            querier = Querier(self._config.config, resource_type=TYPE_PROJECT, resource_id=str(row.project_hash))
+            client = EncordClientProject(querier=querier, config=self._config.config, api_client=self._api_client)
+
+            yield Project(
+                client=client,
+                project_instance=row,
+                ontology=None,  # lazy-load
+                api_client=self._api_client,
+            )
 
     def create_project(
         self,
@@ -1389,7 +1437,7 @@ class EncordUserClient:
     def list_collections(
         self,
         top_level_folder_uuid: Union[str, UUID, None] = None,
-        collection_uuids: List[str | UUID] | None = None,
+        collection_uuids: Optional[List[Union[str, UUID]]] = None,
         page_size: Optional[int] = None,
     ) -> Iterator[Collection]:
         """

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -456,7 +456,6 @@ class EncordUserClient:
         properties_filter.include_org_access = include_org_access
         page = self._api_client.get("projects", params=properties_filter, result_type=Page[ProjectDTO])
 
-        retval: List[Dict] = []
         for row in page.results:
             querier = Querier(self._config.config, resource_type=TYPE_PROJECT, resource_id=str(row.project_hash))
             client = EncordClientProject(querier=querier, config=self._config.config, api_client=self._api_client)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -51,6 +51,7 @@ def project(
         created_at=datetime.now(),
         last_edited_at=datetime.now(),
         ontology_hash="dummy-ontology-hash",
+        editor_ontology=ONTOLOGY_BLURB,
         workflow=None,
     )
 

--- a/tests/test_user_client_auth.py
+++ b/tests/test_user_client_auth.py
@@ -56,6 +56,7 @@ project_dto = ProjectDTO(
     created_at=datetime.now(),
     last_edited_at=datetime.now(),
     ontology_hash=str(ONTOLOGY_UUID),
+    editor_ontology=ontology_orm.editor,
     workflow=None,
 )
 


### PR DESCRIPTION
# Introduction and Explanation

Next step towards org-wide access: projects.

Unfortunately we're "doing too much" in project listing, and doing this within the confines of the old `get_projects` was not feasible (would have to fetch *a lot* of data potentially, with the label rows and editors and stuff).

So I'm adding the new `list_projects` instead, with a nicer API; also doing lots of unrelated-ish refactorings/cleanups because I initially attempted to do it backwards-compatibly.


# Documentation

Docstrings; the main docs to be written

# Tests

Coming in the BE PR https://github.com/encord-team/cord-backend/pull/4431

# Known issues

This is *so hairy* and took me 10x the estimated time :/