### PR TITLE
Org-wide and filtered access to cloud integrations

### DIFF
--- a/encord/orm/cloud_integration.py
+++ b/encord/orm/cloud_integration.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from uuid import UUID
 
 from encord.orm.base_dto import BaseDTO
@@ -16,3 +16,9 @@ class CloudIntegrationV2(BaseDTO):
 
 class GetCloudIntegrationsResponse(BaseDTO):
     result: List[CloudIntegrationV2]
+
+
+class GetCloudIntegrationsParams(BaseDTO):
+    filter_integration_uuids: Optional[List[UUID]] = None
+    filter_integration_titles: Optional[List[str]] = None
+    include_org_access: bool = False


### PR DESCRIPTION
# Introduction and Explanation

Allowing org admins to fetch all the cloud integrations in the org; also adding filtering by title and by 'id' (aka 'integration_hash').

BE implementation in BE PR: https://github.com/encord-team/cord-backend/pull/4540

# Documentation

Added some docstrings.

# Tests

In BE PR: https://github.com/encord-team/cord-backend/pull/4540
