### PR TITLE
Stop reversing classifications

### DIFF
--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -1695,7 +1695,7 @@ class LabelRowV2:
             all_static_answers = classification.get_all_static_answers()
             classifications = [answer.to_encord_dict() for answer in all_static_answers if answer.is_answered()]
             ret[classification.classification_hash] = {
-                "classifications": list(reversed(classifications)),
+                "classifications": list(classifications),
                 "classificationHash": classification.classification_hash,
                 "featureHash": classification.feature_hash,
             }


### PR DESCRIPTION
# Introduction and Explanation
For some reason, we reverse the order of our classifications in `to_encord_dict`.

Can't think of any good reason why we do this. It just results in classifications being in the wrong order in the UI.
- E.g. if I have nested classifications, the child answer is shown first, then the parent answer.

# JIRA

_Link ticket(s)_


# Documentation
_There should be enough internal documentation for a product owner to write customer-facing documentation or a separate PR linked if writing the customer documentation directly. Link all that are relevant below_.
- Internal: _notion link_
- Customer docs PR: _link_
- OpenAPI/SDK
    - Generated docs: _link to example if possible_
    - Command to generate: _here_

# Tests

_Make a quick statement and post any relevant links of CI / test results. If the testing infrastructure isn’t yet in-place, note that instead._

- _What are the critical unit tests?_
- _Explain the Integration Tests such that it’s clear Correctness is satisfied. Link to test results if possible._

# Known issues

_If there are any known issues with the solution, make a statement about what they are and why they are Ok to leave unsolved for now. Make tickets for the known issues linked to the original ticket linked above_
