### PR TITLE
feat: Allow user agent suffixes

### DIFF
--- a/encord/common/utils.py
+++ b/encord/common/utils.py
@@ -34,3 +34,32 @@ def ensure_uuid_list(value: Union[List[UUID], List[str], UUID, str, None]) -> Op
             raise AssertionError(f"Can't convert {type(v)} to UUID")
 
     return results
+
+
+def validate_user_agent_suffix(user_agent_suffix: str) -> str:
+    """
+    Validate a User-Agent string according to RFC 9110, excluding comments.
+    Returns it whitespace trimmed
+    Args:
+        user_agent_suffix: The User-Agent string to validate
+
+    Returns:
+        The validated User-Agent string
+
+    Raises:
+        ValueError: If the User-Agent string is invalid
+    """
+    user_agent = user_agent_suffix.strip()
+    # Define regex components
+    tchar = r"[-!#$%&'*+.^_`|~0-9A-Za-z]"
+    token = f"{tchar}+"
+    product = f"{token}(?:/{token})?"
+    RWS = r"[ \t]+"
+
+    # Complete User-Agent pattern (just products separated by whitespace)
+    pattern = re.compile(f"^{product}(?:{RWS}{product})*$")
+
+    if not pattern.match(user_agent):
+        raise ValueError(f"Invalid User-Agent string: '{user_agent_suffix}'. ")
+
+    return user_agent

--- a/encord/configs.py
+++ b/encord/configs.py
@@ -252,12 +252,13 @@ class SshConfig(Config):
         private_key: Ed25519PrivateKey,
         domain: str = ENCORD_DOMAIN,
         requests_settings: RequestsSettings = DEFAULT_REQUESTS_SETTINGS,
+        user_agent_suffix: Optional[str] = None,
     ):
         self.private_key: Ed25519PrivateKey = private_key
         self.public_key: Ed25519PublicKey = private_key.public_key()
         self.public_key_hex: str = self.public_key.public_bytes(Encoding.Raw, PublicFormat.Raw).hex()
 
-        super().__init__(domain=domain, requests_settings=requests_settings)
+        super().__init__(domain=domain, requests_settings=requests_settings, user_agent_suffix=user_agent_suffix)
 
     @staticmethod
     def _get_v1_signature(data: str, private_key: Ed25519PrivateKey) -> bytes:

--- a/encord/configs.py
+++ b/encord/configs.py
@@ -29,6 +29,7 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat,
 from requests import PreparedRequest
 
 from encord._version import __version__ as encord_version
+from encord.common.utils import validate_user_agent_suffix
 from encord.exceptions import ResourceNotFoundError
 from encord.http.common import (
     HEADER_CLOUD_TRACE_CONTEXT,
@@ -172,17 +173,21 @@ class Config(BaseConfig):
         web_file_path: str = ENCORD_PUBLIC_PATH,
         domain: Optional[str] = None,
         requests_settings: RequestsSettings = DEFAULT_REQUESTS_SETTINGS,
+        user_agent_suffix: Optional[str] = None,
     ):
         if domain is None:
             raise RuntimeError("`domain` must be specified")
 
         self.domain = domain
+        self.user_agent_suffix = validate_user_agent_suffix(user_agent_suffix) if user_agent_suffix else None
         endpoint = domain + web_file_path
         super().__init__(endpoint, requests_settings=requests_settings)
 
-    @staticmethod
-    def _user_agent() -> str:
-        return f"encord-sdk-python/{encord_version} python/{platform.python_version()} pydantic/{pydantic_version_str}"
+    def _user_agent(self) -> str:
+        base_agent_header = (
+            f"encord-sdk-python/{encord_version} python/{platform.python_version()} pydantic/{pydantic_version_str}"
+        )
+        return base_agent_header + " " + self.user_agent_suffix if self.user_agent_suffix else base_agent_header
 
     def _tracing_id(self) -> str:
         if self.requests_settings.trace_id_provider:

--- a/tests/test_user_client.py
+++ b/tests/test_user_client.py
@@ -48,6 +48,14 @@ def test_initialise_with_correct_ssh_file_content():
     assert isinstance(user_client, EncordUserClient)
 
 
+def test_initialise_with_custom_user_agent():
+    custom_agent_suffix = "CustomAgentSuffix/1.1.2"
+    user_client = EncordUserClient.create_with_ssh_private_key(PRIVATE_KEY_PEM, user_agent_suffix=custom_agent_suffix)
+    assert isinstance(user_client, EncordUserClient)
+    user_agent_header = user_client._config.config._user_agent()
+    assert custom_agent_suffix in user_agent_header
+
+
 def test_initialise_with_correct_ssh_file_content_from_env():
     assert _ENCORD_SSH_KEY_FILE not in os.environ
     os.environ[_ENCORD_SSH_KEY] = PRIVATE_KEY_PEM

--- a/tests/utilities/test_user_agent_suffix.py
+++ b/tests/utilities/test_user_agent_suffix.py
@@ -1,0 +1,32 @@
+import contextlib
+
+import pytest
+
+from encord.common.utils import validate_user_agent_suffix
+
+valid_examples = [
+    "CERN-LineMode/2.15 libwww/2.17b3",
+    "Mozilla/5.0",
+    "Simple-Bot",
+    "Product/1.0 AnotherProduct/2.0",
+    "Chrome/91.0.4472.124 Safari/537.36",
+]
+
+invalid_examples = [
+    "",  # Empty string
+    "/",  # Just a slash
+    "Invalid/Version/",  # Trailing slash
+    "Product/1.0/",  # Trailing slash
+    "Product//1.0",  # Double slash
+    "/1.0",  # Missing product name
+]
+
+
+@pytest.mark.parametrize(
+    ["user_agent_suffix", "should_raise"],
+    [(example, False) for example in valid_examples] + [(example, True) for example in invalid_examples],
+)
+def test_user_agent_validate_happy(user_agent_suffix: str, should_raise: bool) -> None:
+    context = pytest.raises(ValueError) if should_raise else contextlib.nullcontext()
+    with context:
+        validate_user_agent_suffix(user_agent_suffix)


### PR DESCRIPTION
For understanding the usage of the Encord lib in downstream packages, (including the Encord agents library) allow users to specify a suffix to the User Agent Header. To improve telemetry and observability

# Documentation
We should consider not documenting this for now as there's not necessarily any need for an end user to consume this argument.
# Tests
Some unit tests against the regex. Restricted the suffix to exclude comments type as per the RFC. Could consider disallowing any whitespace characters at all
