### PR TITLE
ED-682: Throw error when initialising labels for pdf

### DIFF
--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -499,7 +499,7 @@ class LabelRowV2:
                 "You are trying to re-initialise a label row that has already been initialised. This would overwrite "
                 "current labels. If this is your intend, set the `overwrite` flag to `True`."
             )
-    
+
         if self.data_type == DataType.PDF:
             raise LabelRowError(
                 "You are trying to initialise a label row for a PDF file. "

--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -499,6 +499,12 @@ class LabelRowV2:
                 "You are trying to re-initialise a label row that has already been initialised. This would overwrite "
                 "current labels. If this is your intend, set the `overwrite` flag to `True`."
             )
+    
+        if self.data_type == DataType.PDF:
+            raise LabelRowError(
+                "You are trying to initialise a label row for a PDF file. "
+                "The SDK does not yet support working with labels on PDF files."
+            )
 
         if not self.label_hash:
             # If label_hash is None, it means we need to explicitly create the label row first


### PR DESCRIPTION
# Introduction and Explanation
PDF isn't supported yet on our SDK. Throw error when someone tries to initialise labels.

# JIRA

_Link ticket(s)_


# Documentation
_There should be enough internal documentation for a product owner to write customer-facing documentation or a separate PR linked if writing the customer documentation directly. Link all that are relevant below_.
- Internal: _notion link_
- Customer docs PR: _link_
- OpenAPI/SDK
    - Generated docs: _link to example if possible_
    - Command to generate: _here_

# Tests

_Make a quick statement and post any relevant links of CI / test results. If the testing infrastructure isn’t yet in-place, note that instead._

- _What are the critical unit tests?_
- _Explain the Integration Tests such that it’s clear Correctness is satisfied. Link to test results if possible._

# Known issues

_If there are any known issues with the solution, make a statement about what they are and why they are Ok to leave unsolved for now. Make tickets for the known issues linked to the original ticket linked above_
