### PR TITLE
fix: Appropriately handle Bitmasks that have the top left coordinate filled in

### DIFF
--- a/encord/common/bitmask_operations/bitmask_operations.py
+++ b/encord/common/bitmask_operations/bitmask_operations.py
@@ -58,7 +58,11 @@ def _rle_to_string(rle: Sequence[int]) -> str:
 
 def _mask_to_rle(mask: bytes) -> List[int]:
     """COCO-compatible raw bitmask to COCO-compatible RLE"""
-    return [len(list(group)) for _, group in groupby(mask)]
+    raw_rle = [len(list(group)) for _, group in groupby(mask)]
+    # note that the odd counts are always the numbers of zeros
+    if mask[0] == 1:
+        raw_rle.insert(0, 0)
+    return raw_rle
 
 
 def _rle_to_mask(rle: List[int], size: int) -> bytes:

--- a/encord/common/bitmask_operations/bitmask_operations_numpy.py
+++ b/encord/common/bitmask_operations/bitmask_operations_numpy.py
@@ -12,6 +12,11 @@ def _mask_to_rle(mask: bytes) -> List[int]:
     changes = np.diff(mask_buffer, prepend=mask_buffer[0], append=mask_buffer[-1])
     change_indices = np.flatnonzero(changes != 0)
     run_lengths = np.diff(np.concatenate(([0], change_indices, [len(mask_buffer)])))
+
+    # note that the odd counts are always the numbers of zeros
+    if mask_buffer[0] == True:
+        run_lengths = np.concatenate(([0], run_lengths))
+
     return run_lengths.tolist()
 
 

--- a/tests/objects/test_bitmask.py
+++ b/tests/objects/test_bitmask.py
@@ -1,10 +1,11 @@
 import numpy as np
 
-from encord.common.bitmask_operations import (
+from encord.common.bitmask_operations.bitmask_operations import (
     _mask_to_rle,
     _rle_to_mask,
     _rle_to_string,
     _string_to_rle,
+    serialise_bitmask,
     transpose_bytearray,
 )
 from encord.objects.bitmask import (
@@ -86,3 +87,20 @@ def test_transpose_bytearray():
     expected = b"\x00\x00\x00\x00\x01\x00\x00\x01\x00\x00\x00\x00"
     ans = transpose_bytearray(mask, shape)
     assert ans == expected
+
+
+def test_serialise_bitmask_starting_with_true():
+    mask = np.array(
+        [
+            [True, True, True],
+            [False, False, False],
+        ]
+    )
+    shape = mask.shape
+    rle_string = serialise_bitmask(mask.tobytes())
+    mask_encoded = BitmaskCoordinates.EncodedBitmask(
+        top=0, left=0, height=shape[0], width=shape[1], rle_string=rle_string
+    )
+    mask_decoded = BitmaskCoordinates(mask_encoded).to_numpy_array()
+
+    assert np.array_equal(mask, mask_decoded)

--- a/tests/objects/test_bitmask_numpy.py
+++ b/tests/objects/test_bitmask_numpy.py
@@ -5,6 +5,7 @@ from encord.common.bitmask_operations.bitmask_operations_numpy import (
     _rle_to_mask,
     _rle_to_string,
     _string_to_rle,
+    serialise_bitmask,
     transpose_bytearray,
 )
 from encord.objects.bitmask import (
@@ -86,3 +87,20 @@ def test_transpose_bytearray():
     expected = b"\x00\x00\x00\x00\x01\x00\x00\x01\x00\x00\x00\x00"
     ans = transpose_bytearray(mask, shape)
     assert ans == expected
+
+
+def test_serialise_bitmask_starting_with_true():
+    mask = np.array(
+        [
+            [True, True, True],
+            [False, False, False],
+        ]
+    )
+    shape = mask.shape
+    rle_string = serialise_bitmask(mask.tobytes())
+    mask_encoded = BitmaskCoordinates.EncodedBitmask(
+        top=0, left=0, height=shape[0], width=shape[1], rle_string=rle_string
+    )
+    mask_decoded = BitmaskCoordinates(mask_encoded).to_numpy_array()
+
+    assert np.array_equal(mask, mask_decoded)


### PR DESCRIPTION
# Introduction and Explanation
Raised in this issue: https://github.com/encord-team/encord-client-python/issues/865
# Tests
Including the test in the PR and trying to cover both the Numpy and non-Numpy method

# Known issues
Could maybe go through all 2^4 masks of size 2x2 and check that they round-trip appropriately for some additional coverage?