### PR TITLE
chore: Ubuntu 20.04 is being browned out. Go to latest

### DIFF
--- a/.github/workflows/publish_sdk.yml
+++ b/.github/workflows/publish_sdk.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   publish-sdk:
     name: Publish SDK
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
 
   send-slack-notification:
     name: Send notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [ publish-sdk ]
     if: always()
     env:

--- a/.github/workflows/publish_sdk.yml
+++ b/.github/workflows/publish_sdk.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   publish-sdk:
     name: Publish SDK
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
 
   send-slack-notification:
     name: Send notification
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [ publish-sdk ]
     if: always()
     env:

--- a/.github/workflows/sdk-pr.yml
+++ b/.github/workflows/sdk-pr.yml
@@ -39,7 +39,7 @@ jobs:
 
   unit-tests-python-3-8:
     name: Run unit tests (Python 3.8, Pydantic 1.x)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
 
   unit-tests-python-3-8-pydantic-2:
     name: Run unit tests (Python 3.8, Pydantic 2.x)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
 
   integration-tests-python-3-11:
     name: Run integration tests for Python 3.11
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/sdk-pr.yml
+++ b/.github/workflows/sdk-pr.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   formatting:
     name: Linting and type checking
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup root poetry environment
@@ -39,7 +39,7 @@ jobs:
 
   unit-tests-python-3-8:
     name: Run unit tests (Python 3.8, Pydantic 1.x)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
 
   unit-tests-python-3-8-pydantic-2:
     name: Run unit tests (Python 3.8, Pydantic 2.x)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
 
   integration-tests-python-3-11:
     name: Run integration tests for Python 3.11
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   unit-tests-python-3-8:
     name: Run unit tests for Python 3.8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
 
   unit-tests-python-3-9:
     name: Run unit tests for Python 3.9
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
 
   unit-tests-python-3-10:
     name: Run unit tests for Python 3.10
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -73,7 +73,7 @@ jobs:
 
   unit-tests-python-3-11:
     name: Run unit tests for Python 3.11
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -86,7 +86,7 @@ jobs:
 
   unit-tests-python-3-12:
     name: Run unit tests for Python 3.12
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -99,7 +99,7 @@ jobs:
 
   unit-tests-python-3-8-pydantic-2:
     name: Run unit tests for Python 3.8 with Pydantic 2.x
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
 
   unit-tests-python-3-9-pydantic-2:
     name: Run unit tests for Python 3.9 with Pydantic 2.x
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -127,7 +127,7 @@ jobs:
 
   unit-tests-python-3-10-pydantic-2:
     name: Run unit tests for Python 3.10 with Pydantic 2.x
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
 
   unit-tests-python-3-11-pydantic-2:
     name: Run unit tests for Python 3.11 with Pydantic 2.x
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -155,7 +155,7 @@ jobs:
 
   unit-tests-python-3-12-pydantic-2:
     name: Run unit tests for Python 3.12 with Pydantic 2.x
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
 
   integration-tests-python-3-11:
     name: Run integration tests for Python 3.11
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -196,7 +196,7 @@ jobs:
 
   publish-test-reports:
       name: Publish test reports
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-latest
       needs: [
         unit-tests-python-3-8,
         unit-tests-python-3-9,
@@ -269,7 +269,7 @@ jobs:
 
   send-slack-notification:
     name: Send notification
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [ publish-test-reports ]
     if: always()
     env:

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   unit-tests-python-3-8:
     name: Run unit tests for Python 3.8
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
 
   unit-tests-python-3-9:
     name: Run unit tests for Python 3.9
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
 
   unit-tests-python-3-10:
     name: Run unit tests for Python 3.10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -73,7 +73,7 @@ jobs:
 
   unit-tests-python-3-11:
     name: Run unit tests for Python 3.11
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -86,7 +86,7 @@ jobs:
 
   unit-tests-python-3-12:
     name: Run unit tests for Python 3.12
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -99,7 +99,7 @@ jobs:
 
   unit-tests-python-3-8-pydantic-2:
     name: Run unit tests for Python 3.8 with Pydantic 2.x
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
 
   unit-tests-python-3-9-pydantic-2:
     name: Run unit tests for Python 3.9 with Pydantic 2.x
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -127,7 +127,7 @@ jobs:
 
   unit-tests-python-3-10-pydantic-2:
     name: Run unit tests for Python 3.10 with Pydantic 2.x
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
 
   unit-tests-python-3-11-pydantic-2:
     name: Run unit tests for Python 3.11 with Pydantic 2.x
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -155,7 +155,7 @@ jobs:
 
   unit-tests-python-3-12-pydantic-2:
     name: Run unit tests for Python 3.12 with Pydantic 2.x
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -169,7 +169,7 @@ jobs:
 
   integration-tests-python-3-11:
     name: Run integration tests for Python 3.11
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -196,7 +196,7 @@ jobs:
 
   publish-test-reports:
       name: Publish test reports
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-24.04
       needs: [
         unit-tests-python-3-8,
         unit-tests-python-3-9,
@@ -269,7 +269,7 @@ jobs:
 
   send-slack-notification:
     name: Send notification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [ publish-test-reports ]
     if: always()
     env:


### PR DESCRIPTION
# Introduction and Explanation
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/
Made these fail: https://github.com/encord-team/encord-client-python/actions/runs/13655442262

Let's see if this passes