### PR TITLE
feat: Handle empty bitmasks appropriately

### DIFF
--- a/encord/common/bitmask_operations/bitmask_operations.py
+++ b/encord/common/bitmask_operations/bitmask_operations.py
@@ -58,6 +58,8 @@ def _rle_to_string(rle: Sequence[int]) -> str:
 
 def _mask_to_rle(mask: bytes) -> List[int]:
     """COCO-compatible raw bitmask to COCO-compatible RLE"""
+    if len(mask) == 0:
+        return []
     raw_rle = [len(list(group)) for _, group in groupby(mask)]
     # note that the odd counts are always the numbers of zeros
     if mask[0] == 1:

--- a/encord/common/bitmask_operations/bitmask_operations_numpy.py
+++ b/encord/common/bitmask_operations/bitmask_operations_numpy.py
@@ -8,6 +8,8 @@ from .bitmask_operations import _rle_to_mask, _rle_to_string, _string_to_rle
 
 def _mask_to_rle(mask: bytes) -> List[int]:
     """COCO-compatible raw bitmask to COCO-compatible RLE"""
+    if len(mask) == 0:
+        return []
     mask_buffer = np.frombuffer(mask, dtype=np.bool_)
     changes = np.diff(mask_buffer, prepend=mask_buffer[0], append=mask_buffer[-1])
     change_indices = np.flatnonzero(changes != 0)

--- a/tests/objects/test_bitmask.py
+++ b/tests/objects/test_bitmask.py
@@ -104,3 +104,16 @@ def test_serialise_bitmask_starting_with_true():
     mask_decoded = BitmaskCoordinates(mask_encoded).to_numpy_array()
 
     assert np.array_equal(mask, mask_decoded)
+
+
+def test_serialise_bitmask_empty():
+    mask = np.array([[]], dtype=bool)
+    shape = mask.shape
+
+    rle_string = serialise_bitmask(mask.tobytes())
+    mask_encoded = BitmaskCoordinates.EncodedBitmask(
+        top=0, left=0, height=shape[0], width=shape[1], rle_string=rle_string
+    )
+    mask_decoded = BitmaskCoordinates(mask_encoded).to_numpy_array()
+
+    assert np.array_equal(mask, mask_decoded)  # Mask is inverted and the test fails.

--- a/tests/objects/test_bitmask_numpy.py
+++ b/tests/objects/test_bitmask_numpy.py
@@ -104,3 +104,16 @@ def test_serialise_bitmask_starting_with_true():
     mask_decoded = BitmaskCoordinates(mask_encoded).to_numpy_array()
 
     assert np.array_equal(mask, mask_decoded)
+
+
+def test_serialise_bitmask_empty():
+    mask = np.array([[]], dtype=bool)
+    shape = mask.shape
+
+    rle_string = serialise_bitmask(mask.tobytes())
+    mask_encoded = BitmaskCoordinates.EncodedBitmask(
+        top=0, left=0, height=shape[0], width=shape[1], rle_string=rle_string
+    )
+    mask_decoded = BitmaskCoordinates(mask_encoded).to_numpy_array()
+
+    assert np.array_equal(mask, mask_decoded)  # Mask is inverted and the test fails.


### PR DESCRIPTION
# Introduction and Explanation
Not a hugely impactful bug as Encord doesn't really have empty bitmasks. But better this than a failed to index error.
https://github.com/encord-team/encord-client-python/issues/874
# Tests
Yes
