### PR TITLE
Update get_items docstring to reflect updated response

### DIFF
--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -1242,7 +1242,7 @@ class EncordUserClient:
             sign_url: If `True`, pre-fetch a signed URLs for the items (otherwise the URLs will be signed on demand).
 
         Returns:
-            A list of storage items. See :class:`encord.storage.StorageItem` for details.
+            A list of storage items. See :class:`encord.storage.StorageItem` for details. Items will be in the same order as `item_uuids` in the request
 
         Raises:
             ValueError: If any of the item uuids is a badly formed UUID.


### PR DESCRIPTION
# Introduction and Explanation
Reflecting invariant introduced on the BE
# Tests
Theoretically should check via integration test that we aren't reordering the params somehow. But so overkill