### PR TITLE
fix: Allow bearer token to also pass user_agent_suffix

### DIFF
--- a/encord/configs.py
+++ b/encord/configs.py
@@ -216,7 +216,7 @@ def get_env_ssh_key() -> str:
 
     if raw_ssh_key == "":
         raise ResourceNotFoundError(
-            f"Environment variable {_ENCORD_SSH_KEY} found but is empty. " f"Failed to load private ssh key."
+            f"Environment variable {_ENCORD_SSH_KEY} found but is empty. Failed to load private ssh key."
         )
 
     return raw_ssh_key
@@ -345,9 +345,10 @@ class BearerConfig(Config):
         token: str,
         domain: str = ENCORD_DOMAIN,
         requests_settings: RequestsSettings = DEFAULT_REQUESTS_SETTINGS,
+        user_agent_suffix: Optional[str] = None,
     ):
         self.token = token
-        super().__init__(domain=domain, requests_settings=requests_settings)
+        super().__init__(domain=domain, requests_settings=requests_settings, user_agent_suffix=user_agent_suffix)
 
     def define_headers(self, resource_id: Optional[str], resource_type: Optional[str], data: str) -> Dict[str, Any]:
         """Define headers for a bearer token-based request.

--- a/tests/test_user_client_auth.py
+++ b/tests/test_user_client_auth.py
@@ -200,6 +200,22 @@ def test_v1_public_user_resource_when_initialised_with_bearer_auth(mock_send, be
 
 
 @patch.object(Session, "send")
+def test_v1_public_user_resource_when_initialised_with_bearer_auth_can_pass_auth_agent_suffix(mock_send, bearer_token):
+    mock_send.side_effect = make_side_effects()
+
+    user_client = EncordUserClient.create_with_bearer_token(bearer_token, user_agent_suffix="suffix")
+    user_client.get_projects()
+
+    assert mock_send.call_count == 1
+    for mock_call in mock_send.call_args_list:
+        # Expect call to have correct resource type and id, and correct bearer auth
+        request = mock_call.args[0]
+        assert request.path_url == "/public/user"
+        assert request.headers["Authorization"] == f"Bearer {bearer_token}"
+        assert "suffix" in request.headers["User-Agent"]
+
+
+@patch.object(Session, "send")
 def test_v2_api_when_initialised_with_ssh_key(mock_send, bearer_token):
     mock_send.side_effect = make_side_effects()
 


### PR DESCRIPTION
# Introduction and Explanation
Eventually going to want have bearer token auth used elsewhere. This will be useful for the other libs.

# Tests
Yes, co-opted other test. Would throw previously, not just fail to pass.