### PR TITLE
fix: Create LabelRow task_uuid as UUID instead of str to be consistent with type annotations

### DIFF
--- a/encord/orm/label_row.py
+++ b/encord/orm/label_row.py
@@ -330,7 +330,7 @@ class LabelRowMetadata(Formatter):
             audio_sample_rate=json_dict.get("audio_sample_rate", None),
             height=json_dict.get("height"),
             width=json_dict.get("width"),
-            task_uuid=json_dict.get("task_uuid"),
+            task_uuid=UUID(json_dict["task_uuid"]) if "task_uuid" in json_dict else None,
             priority=json_dict.get("priority"),
             client_metadata=json_dict.get("client_metadata", None),
             images_data=json_dict.get("images_data", None),


### PR DESCRIPTION
# Introduction and Explanation
- `LabelRow.task_uuid` is typed as `UUID`. However, on runtime a `str` is provided.

# JIRA
None

# Documentation
None

# Tests
None

# Known issues
None