### PR TITLE
feat: PLA-554 Add project status to project DTO

### DIFF
--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -167,6 +167,13 @@ class ProjectType(str, Enum):
     WORKFLOW = "workflow"
     MANUAL_QA = "manual_qa"
 
+class ProjectStatus(str, Enum):
+    NOT_STARTED = "notStarted"
+    IN_PROGRESS = "inProgress"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
 
 class ProjectCopyOptions(str, Enum):
     COLLABORATORS = "collaborators"
@@ -302,6 +309,7 @@ class TaskPriorityParams(BaseDTO):
 class ProjectDTO(BaseDTO):
     project_hash: UUID
     project_type: ProjectType
+    status: ProjectStatus
     title: str
     description: str
     created_at: datetime.datetime


### PR DESCRIPTION
# Introduction and Explanation
Adding project status field to Project DTO.


# Documentation
_There should be enough internal documentation for a product owner to write customer-facing documentation or a separate PR linked if writing the customer documentation directly. Link all that are relevant below_.
- Internal: NA
- Customer docs PR: NA
- OpenAPI/SDK
    - Generated docs: NA
    - Command to generate: NA
