### PR TITLE
prevent raising LabelRowError for edge cases, just set for them

### DIFF
--- a/encord/objects/coordinates.py
+++ b/encord/objects/coordinates.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Any, Dict, List, Optional, Type, Union
 import logging
+
 from encord.exceptions import LabelRowError
 from encord.objects.bitmask import BitmaskCoordinates
 from encord.objects.common import Shape

--- a/encord/objects/coordinates.py
+++ b/encord/objects/coordinates.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Any, Dict, List, Optional, Type, Union
-
+import logging
 from encord.exceptions import LabelRowError
 from encord.objects.bitmask import BitmaskCoordinates
 from encord.objects.common import Shape
@@ -23,6 +23,7 @@ from encord.objects.html_node import HtmlRange
 from encord.orm.analytics import CamelStrEnum
 from encord.orm.base_dto import BaseDTO
 
+logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class BoundingBoxCoordinates:
@@ -177,7 +178,6 @@ class PolygonCoordinates:
             values (List[PointCoordinate]): A list of PointCoordinate objects defining the polygon.
             polygons (List[List[List[PointCoordinate]]]): A list of polygons, where each polygon is a list of contours, where each contour is a list of points.
         """
-
         if not values and not polygons:
             raise LabelRowError("Either `values` or `polygons` must be provided")
         elif values and not polygons:
@@ -191,7 +191,7 @@ class PolygonCoordinates:
                 # lets just default to polygons values
                 self._polygons = polygons
                 self._values = [point for point in self._polygons[0][0]]
-                logger.info("`values` and `polygons` are not consistent, defaulting to polygons value")
+                logger.warning("`values` and `polygons` are not consistent, defaulting to polygons value")
             else:
                 self._values = values
                 self._polygons = polygons

--- a/encord/objects/coordinates.py
+++ b/encord/objects/coordinates.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Any, Dict, List, Optional, Type, Union
 
-from docs.source.code_examples.labels_v2 import object_instance
 from encord.exceptions import LabelRowError
 from encord.objects.bitmask import BitmaskCoordinates
 from encord.objects.common import Shape

--- a/encord/objects/coordinates.py
+++ b/encord/objects/coordinates.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Any, Dict, List, Optional, Type, Union
 
+from docs.source.code_examples.labels_v2 import object_instance
 from encord.exceptions import LabelRowError
 from encord.objects.bitmask import BitmaskCoordinates
 from encord.objects.common import Shape
@@ -188,9 +189,13 @@ class PolygonCoordinates:
             self._values = [point for point in self._polygons[0][0]]
         elif polygons and values:
             if polygons[0][0] != values:
-                raise LabelRowError("`values` and `polygons` are not consistent")
-            self._values = values
-            self._polygons = polygons
+                # lets just default to polygons values
+                self._polygons = polygons
+                self._values = [point for point in self._polygons[0][0]]
+                logger.info("`values` and `polygons` are not consistent, defaulting to polygons value")
+            else:
+                self._values = values
+                self._polygons = polygons
 
     @property
     def values(self) -> list[PointCoordinate]:

--- a/encord/objects/coordinates.py
+++ b/encord/objects/coordinates.py
@@ -189,9 +189,9 @@ class PolygonCoordinates:
             self._values = [point for point in self._polygons[0][0]]
         elif polygons and values:
             if polygons[0][0] != values:
-                # lets just default to polygons values
+                # TODO: When removing Polygon from the DB & all backfilling has been completed, remove this code
                 self._polygons = polygons
-                self._values = [point for point in self._polygons[0][0]]
+                self._values = [point for point in self._polygons[0][0]] # We default to polygons values
                 logger.warning("`values` and `polygons` are not consistent, defaulting to polygons value")
             else:
                 self._values = values

--- a/encord/objects/coordinates.py
+++ b/encord/objects/coordinates.py
@@ -11,10 +11,10 @@ category: "64e481b57b6027003f20aaa0"
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Any, Dict, List, Optional, Type, Union
-import logging
 
 from encord.exceptions import LabelRowError
 from encord.objects.bitmask import BitmaskCoordinates
@@ -25,6 +25,7 @@ from encord.orm.analytics import CamelStrEnum
 from encord.orm.base_dto import BaseDTO
 
 logger = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True)
 class BoundingBoxCoordinates:
@@ -191,7 +192,7 @@ class PolygonCoordinates:
             if polygons[0][0] != values:
                 # TODO: When removing Polygon from the DB & all backfilling has been completed, remove this code
                 self._polygons = polygons
-                self._values = [point for point in self._polygons[0][0]] # We default to polygons values
+                self._values = [point for point in self._polygons[0][0]]  # We default to polygons values
                 logger.warning("`values` and `polygons` are not consistent, defaulting to polygons value")
             else:
                 self._values = values

--- a/encord/objects/coordinates.py
+++ b/encord/objects/coordinates.py
@@ -190,7 +190,6 @@ class PolygonCoordinates:
             self._values = [point for point in self._polygons[0][0]]
         elif polygons and values:
             if polygons[0][0] != values:
-                # TODO: When removing Polygon from the DB & all backfilling has been completed, remove this code
                 self._polygons = polygons
                 self._values = [point for point in self._polygons[0][0]]  # We default to polygons values
                 logger.warning("`values` and `polygons` are not consistent, defaulting to polygons value")

--- a/tests/objects/test_coordinates.py
+++ b/tests/objects/test_coordinates.py
@@ -1,3 +1,4 @@
+import logging
 from copy import copy
 
 import pytest
@@ -5,7 +6,7 @@ import pytest
 from encord.exceptions import LabelRowError
 from encord.objects import Shape
 from encord.objects.coordinates import ACCEPTABLE_COORDINATES_FOR_ONTOLOGY_ITEMS, PointCoordinate, PolygonCoordinates
-import logging
+
 
 def test_acceptable_coordinates_for_ontology_items() -> None:
     all_mappings = copy(ACCEPTABLE_COORDINATES_FOR_ONTOLOGY_ITEMS)
@@ -34,11 +35,8 @@ def test_polygon_coordinates(caplog):
     ]  # only contains the first polygon, second is ignored
 
     # inconsistent values being provided should log a warning & set to polygons value
-    caplog.set_level(logging.WARNING) # Set the log level to capture warnings
-    c3 = PolygonCoordinates(
-        values=[PointCoordinate(x=0, y=0)],
-        polygons=[[[PointCoordinate(x=1, y=1)]]]
-    )
+    caplog.set_level(logging.WARNING)  # Set the log level to capture warnings
+    c3 = PolygonCoordinates(values=[PointCoordinate(x=0, y=0)], polygons=[[[PointCoordinate(x=1, y=1)]]])
     assert "`values` and `polygons` are not consistent, defaulting to polygons value" in caplog.text
     # Assert that the values are now equal based on polygons value
     assert c3.values == [PointCoordinate(x=1, y=1)]


### PR DESCRIPTION
# Introduction and Explanation
We previously had corrupt labels due to inconsistencies between new complex polygons array & previous polygons array. The underlying issue causing this has been fixed (issue when copying & pasting labels as bulk). 
This change will just auto set the two to be aligned instead of raising exceptions. 

# JIRA

_Link ticket(s)_


# Documentation
_There should be enough internal documentation for a product owner to write customer-facing documentation or a separate PR linked if writing the customer documentation directly. Link all that are relevant below_.
- Internal: _notion link_
- Customer docs PR: _link_
- OpenAPI/SDK
    - Generated docs: _link to example if possible_
    - Command to generate: _here_

# Tests

_Make a quick statement and post any relevant links of CI / test results. If the testing infrastructure isn’t yet in-place, note that instead._

- _What are the critical unit tests?_
- _Explain the Integration Tests such that it’s clear Correctness is satisfied. Link to test results if possible._

# Known issues

_If there are any known issues with the solution, make a statement about what they are and why they are Ok to leave unsolved for now. Make tickets for the known issues linked to the original ticket linked above_
