### PR TITLE
Don't do request retries on unsafe calls

### DIFF
--- a/encord/api/ml_endpoints.py
+++ b/encord/api/ml_endpoints.py
@@ -83,7 +83,7 @@ def _api_ml_delete_model(
     *,
     client: ApiClient,
 ) -> None:
-    return client._request(
+    client._request(
         Request(
             method="delete",
             url=f"{client._domain}/v2/public/ml-models/{model_uuid}",
@@ -183,7 +183,7 @@ def _api_ml_delete_training_iteration(
     *,
     client: ApiClient,
 ) -> None:
-    return client._request(
+    client._request(
         Request(
             method="delete",
             url=f"{client._domain}/v2/public/ml-models/{model_uuid}/iterations/{training_uuid}",
@@ -245,7 +245,7 @@ def _api_project_delete_model_attachment(
     *,
     client: ApiClient,
 ) -> None:
-    return client._request(
+    client._request(
         Request(
             method="delete",
             url=f"{client._domain}/v2/public/projects/{project_uuid}/models-attachments/{project_model_uuid}",

--- a/encord/collection.py
+++ b/encord/collection.py
@@ -457,6 +457,7 @@ class ProjectCollection:
             params=params,
             payload=payload,
             result_type=UUID,
+            allow_retries=False,
         )
 
     def update_collection(self, name: Optional[str] = None, description: Optional[str] = None) -> None:

--- a/encord/filter_preset.py
+++ b/encord/filter_preset.py
@@ -141,6 +141,7 @@ class FilterPreset:
             payload=payload,
             params=CreatePresetParams(),
             result_type=UUID,
+            allow_retries=False,
         )
 
     def get_filter_preset_json(self) -> IndexFilterPresetDefinition:
@@ -311,5 +312,11 @@ class ProjectFilterPreset:
         if not filter_preset.local_filters and not filter_preset.global_filters:
             raise EncordException("We require there to be a non-zero number of filters in a preset for creation")
         payload = ActiveCreatePresetPayload(name=name, filter_preset_json=filter_preset.to_dict())
-        orm_resp = client.post(f"active/{project_uuid}/presets", params=None, payload=payload, result_type=UUID)
+        orm_resp = client.post(
+            f"active/{project_uuid}/presets",
+            params=None,
+            payload=payload,
+            result_type=UUID,
+            allow_retries=False,
+        )
         return orm_resp

--- a/encord/storage.py
+++ b/encord/storage.py
@@ -333,6 +333,7 @@ class StorageFolder:
                 force_full_reencoding=force_full_reencoding,
             ),
             result_type=UUID,
+            allow_retries=False,
         )
 
     def get_re_encoding_status(self, process_hash: UUID) -> ReencodeVideoItemsResponse:
@@ -1305,6 +1306,7 @@ class StorageFolder:
             params=None,
             payload=payload,
             result_type=UUID,
+            allow_retries=False,
         )
 
         logger.info(f"add_data_to_folder job started with upload_job_id={upload_job_id}.")
@@ -1451,7 +1453,11 @@ class StorageFolder:
             client_metadata=json.dumps(client_metadata) if client_metadata is not None else None,
         )
         folder_orm = api_client.post(
-            "storage/folders", params=None, payload=payload, result_type=orm_storage.StorageFolder
+            "storage/folders",
+            params=None,
+            payload=payload,
+            result_type=orm_storage.StorageFolder,
+            allow_retries=False,
         )
         return StorageFolder(api_client, folder_orm)
 

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -228,6 +228,7 @@ class EncordUserClient:
                 legacy_call=legacy_call,
             ),
             result_type=CreateDatasetResponseV2,
+            allow_retries=False,
         )
 
         return CreateDatasetResponse(
@@ -628,6 +629,7 @@ class EncordUserClient:
             ),
             params=None,
             result_type=UUID,
+            allow_retries=False,
         )
 
         return cvat_import_uuid
@@ -944,7 +946,13 @@ class EncordUserClient:
             editor=structure_dict,
         )
 
-        ontology = self._api_client.post("ontologies", payload=payload, params=None, result_type=OntologyWithUserRole)
+        ontology = self._api_client.post(
+            "ontologies",
+            payload=payload,
+            params=None,
+            result_type=OntologyWithUserRole,
+            allow_retries=False,
+        )
 
         return Ontology._from_api_payload(ontology, self._api_client)
 
@@ -1039,6 +1047,7 @@ class EncordUserClient:
             ),
             params=None,
             result_type=UUID,
+            allow_retries=False,
         )
 
         return dicom_deid_uuid

--- a/encord/utilities/storage/cloud_data_migration.py
+++ b/encord/utilities/storage/cloud_data_migration.py
@@ -174,4 +174,5 @@ def _migrate_items_bundle(
                 skip_missing=single_call_items_list[0].skip_missing,
             ),
             result_type=None,
+            allow_retries=False,
         )


### PR DESCRIPTION
# Introduction and Explanation

Some requests (e.g. entity creation) are inherently non-idempotent so we should *not* be retrying those. Make this explicit on a per-call-type basis.

# JIRA

Fixes https://linear.app/encord/issue/EC-5991/serious-bug-with-cloud-storage-file-upload-via-sdk-causing-duplicates

# Documentation

We should maybe raise this point in the docs: if a request raises an exception, then it makes sense for the caller to double-check if it may have succeeded but just failed to return the result.

# Tests

Nothing specific, but this is all common stuff that's generally covered.

# Known issues

We should make more effort to avoid huuuuuuge requests that are slow. The 'start upload job' should be async internally (slurp the input and store it as a blob and return the job id, then turn around and create the actual job units and stuff); and we should maybe even do it via the bucket storage?