### PR TITLE
chore: remove unused fields from the COCO annotation model

### DIFF
--- a/encord/utilities/coco/datastructure.py
+++ b/encord/utilities/coco/datastructure.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Any, List, NamedTuple, Optional, Union
 
 from encord.common.bitmask_operations import (
@@ -22,30 +21,12 @@ class FrameIndex:
     frame: int = 0
 
 
-class CocoInfoModel(BaseDTO):
-    year: Optional[int] = None
-    version: Optional[str] = None
-    description: Optional[str] = None
-    contributor: Optional[str] = None
-    url: Optional[str] = None
-    date_created: Optional[str] = None
-
-
-class CocoLicenseModel(BaseDTO):
-    id: int
-    name: str
-    url: str
-
-
 class CocoImageModel(BaseDTO):
     id: ImageID
     width: int
     height: int
     file_name: Optional[str] = None
-    license: Optional[int] = None
-    flickr_url: Optional[str] = None
     coco_url: Optional[str] = None
-    date_captured: Optional[datetime] = None
 
 
 class CocoCategoryModel(BaseDTO):
@@ -164,8 +145,6 @@ class CocoAnnotationModel(BaseDTO):
 
 
 class CocoRootModel(BaseDTO):
-    info: CocoInfoModel
     categories: List[CocoCategoryModel]
     images: List[CocoImageModel]
     annotations: List[CocoAnnotationModel]
-    licenses: Optional[List[CocoLicenseModel]] = None


### PR DESCRIPTION
# Introduction and Explanation

Remove unused fields from the COCO annotation model to prevent parsing errors during label migration. This streamlining will focus only on essential fields required (or potentially used in the future) for the label migration process.

# Documentation

It would be beneficial to create a comprehensive guide in our documentation similar to [AWS's COCO dataset format guide](https://docs.aws.amazon.com/rekognition/latest/customlabels-dg/md-coco-overview.html). This would provide clear format specifications and implementation examples for users.

# Tests

In place as existing sample data already contained the soon-to-be-ignored fields.

# Known issues

The COCO annotation model is only used when importing COCO annotations, so there is some redundancy between the COCO labels import and export code, but unrelated to this PR.