### PR TITLE
feat: allow custom confidence field in COCO importer

### DIFF
--- a/encord/orm/base_dto/__init__.py
+++ b/encord/orm/base_dto/__init__.py
@@ -8,6 +8,7 @@ pydantic_version = int(pydantic_version_str.split(".")[0])
 if pydantic_version < 2:
     from encord.orm.base_dto.base_dto_pydantic_v1 import (
         BaseDTO,
+        BaseDTOWithExtra,
         Field,
         GenericBaseDTO,
         PrivateAttr,
@@ -17,6 +18,7 @@ if pydantic_version < 2:
 else:
     from encord.orm.base_dto.base_dto_pydantic_v2 import (  # type: ignore[assignment]
         BaseDTO,
+        BaseDTOWithExtra,
         Field,
         GenericBaseDTO,
         PrivateAttr,

--- a/encord/orm/base_dto/base_dto_pydantic_v1.py
+++ b/encord/orm/base_dto/base_dto_pydantic_v1.py
@@ -45,6 +45,16 @@ class BaseDTO(BaseDTOInterface, BaseModel):
         return json.loads(self.json(by_alias=by_alias, exclude_none=exclude_none))  # type: ignore[attr-defined]
 
 
+class BaseDTOWithExtra(BaseDTO):
+    class Config:
+        extra = "allow"
+        alias_generator = snake_to_camel
+        allow_population_by_field_name = True
+
+    def get_extra(self, field_name: str):
+        return self.__dict__.get(field_name)
+
+
 DataT = TypeVar("DataT")
 
 

--- a/encord/orm/base_dto/base_dto_pydantic_v2.py
+++ b/encord/orm/base_dto/base_dto_pydantic_v2.py
@@ -50,6 +50,18 @@ class BaseDTO(BaseDTOInterface, BaseModel):
         return self.model_dump(by_alias=by_alias, exclude_none=exclude_none, mode="json")  # type: ignore[attr-defined]
 
 
+class BaseDTOWithExtra(BaseDTO):
+    model_config = ConfigDict(
+        extra="allow",
+        populate_by_name=True,
+        alias_generator=snake_to_camel,
+        protected_namespaces=(),  # otherwise clash with model_ prefixes
+    )  # type: ignore[typeddict-unknown-key,typeddict-item]
+
+    def get_extra(self, field_name: str):
+        return self.model_extra.get(field_name) if self.model_extra else None
+
+
 DataT = TypeVar("DataT")
 
 

--- a/encord/project.py
+++ b/encord/project.py
@@ -927,14 +927,16 @@ class Project:
         category_id_to_feature_hash: Dict[CategoryID, str],
         image_id_to_frame_index: Dict[ImageID, FrameIndex],
         branch_name: Optional[str] = None,
+        confidence_field_name: Optional[str] = None,
     ) -> None:
-        """Import labels from a COCO format into your Encord project
+        """Import labels in COCO format to an Encord Project.
 
         Args:
-            labels_dict (Dict[str, Any]): Raw label dictionary conforming to Encord format
-            category_id_to_feature_hash (Dict[CategoryID, str]): Dictionary mapping category_id as used in the COCO data to the feature hash for the corresponding element in this Ontology
-            image_id_to_frame_index (Dict[ImageID, FrameIndex]): Dictionary mapping int to FrameIndex(data_hash, frame_offset) which is used to identify the corresponding frame in the Encord setting
+            labels_dict (Dict[str, Any]): A dictionary in COCO annotation format.
+            category_id_to_feature_hash (Dict[CategoryID, str]): A mapping of category IDs from the COCO data to their corresponding feature hashes in the Project's Ontology.
+            image_id_to_frame_index (Dict[ImageID, FrameIndex]): A mapping of image IDs to FrameIndex(data_hash, frame_offset), used to locate the corresponding frames in the Encord Project.
             branch_name (Optional[str]): Optionally specify a branch name. Defaults to the `main` branch.
+            confidence_field_name (Optional[str]): Optionally specify the name of the confidence field in the COCO annotations. Defaults to assigning `1.0` as confidence value to all annotations.
         """
         from encord.utilities.coco.datastructure import CocoRootModel
         from encord.utilities.coco.importer import import_coco_labels
@@ -946,6 +948,7 @@ class Project:
             category_id_to_feature_hash,
             image_id_to_frame_index,
             branch_name=branch_name,
+            confidence_field_name=confidence_field_name,
         )
 
     def export_coco_labels(

--- a/encord/utilities/coco/datastructure.py
+++ b/encord/utilities/coco/datastructure.py
@@ -9,7 +9,7 @@ from encord.common.bitmask_operations import (
     transpose_bytearray,
 )
 from encord.objects.coordinates import BitmaskCoordinates, BoundingBoxCoordinates, PointCoordinate, PolygonCoordinates
-from encord.orm.base_dto import BaseDTO, dto_validator
+from encord.orm.base_dto import BaseDTO, BaseDTOWithExtra, dto_validator
 
 ImageID = int
 CategoryID = int
@@ -108,7 +108,7 @@ class CocoRLE(BaseDTO):
         return BitmaskCoordinates(encoded_bitmask)
 
 
-class CocoAnnotationModel(BaseDTO):
+class CocoAnnotationModel(BaseDTOWithExtra):
     @dto_validator(mode="before")
     def polygon_validator(cls, _value):
         segm = _value.get("segmentation")

--- a/encord/utilities/coco/importer.py
+++ b/encord/utilities/coco/importer.py
@@ -56,6 +56,7 @@ def import_coco_labels(
     category_id_to_feature_hash: Dict[CategoryID, str],
     image_id_to_frame_index: Dict[ImageID, FrameIndex],
     branch_name: Optional[str] = None,
+    confidence_field_name: Optional[str] = None,
 ) -> None:
     label_rows = initialise_label_rows(project, image_id_to_frame_index, branch_name=branch_name)
     category_id_to_objects = build_category_id_to_encord_ontology_object_map(project, category_id_to_feature_hash)
@@ -92,6 +93,7 @@ def import_coco_labels(
                 f"The provided coco annotation dictionary have annotations with `image_id`s that do not match any image ids in the provided `images` list. Couldn't find image id {annotation.image_id}."
             )
 
+        confidence = annotation.get_extra(confidence_field_name) if confidence_field_name is not None else None
         coordinates = coco_annotation_to_encord_coordinates(
             coco_annotation=annotation,
             shape=ont_obj.shape,
@@ -99,7 +101,7 @@ def import_coco_labels(
             height=coco_image.height,
         )
         obj_instance = ont_obj.create_instance()
-        obj_instance.set_for_frames(coordinates=coordinates, frames=frame_idx.frame)
+        obj_instance.set_for_frames(coordinates=coordinates, frames=frame_idx.frame, confidence=confidence)
         label_row.add_object_instance(obj_instance)
 
     with project.create_bundle() as bundle:

--- a/tests/orm/test_base_dto.py
+++ b/tests/orm/test_base_dto.py
@@ -6,7 +6,7 @@ import pytest
 
 from encord.common.constants import DATETIME_LONG_STRING_FORMAT
 from encord.exceptions import EncordException
-from encord.orm.base_dto import BaseDTO, dto_validator
+from encord.orm.base_dto import BaseDTO, BaseDTOWithExtra, dto_validator
 from encord.orm.dataset import DatasetDataLongPolling, LongPollingStatus
 
 
@@ -20,6 +20,26 @@ class TestModelWithLists(BaseDTO):
     text_values: List[str]
     number_values: List[int]
     datetime_values: List[datetime]
+
+
+class TestModelWithExtra(BaseDTOWithExtra):
+    text_value: str
+
+
+def test_deserialize_model_with_extra():
+    time_value = datetime.now()
+    data_dict = {
+        "text_value": "abc",
+        "int_value": 22,
+        "float_value": 22.22,
+        "datetime_value": time_value.strftime(DATETIME_LONG_STRING_FORMAT),
+    }
+
+    model = TestModelWithExtra.from_dict(data_dict)
+
+    assert model.text_value == "abc"
+    assert model.get_extra("int_value") == 22
+    assert model.get_extra("float_value") == 22.22
 
 
 def test_basic_model_with_deserialization():

--- a/tests/utilities/coco/test_datastructure.py
+++ b/tests/utilities/coco/test_datastructure.py
@@ -1,6 +1,8 @@
 import copy
+from typing import Any
 
 import numpy as np
+import pytest
 
 from encord.utilities.coco.datastructure import (
     CocoAnnotationModel,
@@ -45,6 +47,28 @@ def test_coco_annotation_model_with_missing_segmentation_field() -> None:
         assert np.allclose(containing_bbox, ann_model.bbox)
         # Assert the area of the generated polygon is the same as the area of the input bounding box
         assert np.isclose(polygon_area(ann_model.segmentation), ann_model.bbox.w * ann_model.bbox.h)
+
+
+@pytest.mark.parametrize(
+    ["field_name", "field_value"],
+    [
+        ("text_value", "abc"),
+        ("int_value", 42),
+        ("confidence", 0.5),
+        ("score", 0.9),
+        ("confidence_score", 0.01),
+    ],
+)
+def test_coco_annotation_model_with_extra_fields(field_name: str, field_value: Any) -> None:
+    for i, ann in enumerate(copy.deepcopy(DATA_TEST_DATASTRUCTURE_COCO)["annotations"]):
+        # Test 1: Missing extra field
+        ann_model = CocoAnnotationModel.from_dict(ann)
+        assert ann_model.get_extra(field_name) is None, f"Expected None for missing extra field in annotation {i}"
+
+        # Test 2: Existing extra field
+        ann[field_name] = field_value
+        ann_model = CocoAnnotationModel.from_dict(ann)
+        assert ann_model.get_extra(field_name) == field_value, f"Extra field value mismatch in annotation {i}"
 
 
 def test_coco_model_label_validation() -> None:


### PR DESCRIPTION
# Introduction and Explanation

Current COCO label importer doesn't provide a way to set confidence values other than the default `1.0` which is not ideal when uploading COCO labels as predictions. This PR aims to tackle this misalignment.

# Documentation

We should update the documentation around [importing COCO labels as predictions](https://docs.encord.com/sdk-documentation/api-active/active-api-import-model-predictions-cloud#import-coco-labels-as-predictions) to reflect this update.

# Tests

In place.

# Known issues

We should definitively deprecate Pydantic V1, makes everything X times harder (with X > 2).