### PR TITLE
feat: PLA-819 Set project status from SDK

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -102,7 +102,9 @@ from encord.orm.project import (
     ProjectCopy,
     ProjectCopyOptions,
     ProjectDataset,
+    ProjectStatus,
     ProjectUsers,
+    SetProjectStatusPayload,
     TaskPriorityParams,
 )
 from encord.orm.project import Project as OrmProject
@@ -1207,6 +1209,13 @@ class EncordClientProject(EncordClient):
             result_type=None,
         )
         logger.info("Sync initiated in Active, please check the app to see progress")
+
+    def set_status(self, status: ProjectStatus) -> None:
+        self._api_client.put(
+            f"projects/{self.project_hash}/status",
+            params=None,
+            payload=SetProjectStatusPayload(status=status),
+        )
 
 
 CordClientProject = EncordClientProject

--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -174,6 +174,7 @@ class ProjectStatus(str, Enum):
     PAUSED = "paused"
     COMPLETED = "completed"
     CANCELLED = "cancelled"
+    ARCHIVED = "archived"
 
 
 class ProjectCopyOptions(str, Enum):
@@ -390,3 +391,7 @@ class ProjectFilterParams(BaseDTO):
     edited_before: Optional[Union[str, datetime.datetime]] = None
     edited_after: Optional[Union[str, datetime.datetime]] = None
     include_org_access: bool = False
+
+
+class SetProjectStatusPayload(BaseDTO):
+    status: ProjectStatus

--- a/encord/project.py
+++ b/encord/project.py
@@ -1060,3 +1060,11 @@ class Project:
             project_uuid=self._project_instance.project_hash,
             filter_preset_uuid=uuid,
         )
+
+    def set_status(self, status: ProjectStatus):
+        """Set the status of the project.
+
+        Args:
+            status: The new status of the project.
+        """
+        self._client.set_status(status)


### PR DESCRIPTION
# Introduction and Explanation
See title!

# Documentation
_There should be enough internal documentation for a product owner to write customer-facing documentation or a separate PR linked if writing the customer documentation directly. Link all that are relevant below_.
- Internal: NA
- Customer docs PR: NA
- OpenAPI/SDK
    - Generated docs: NA
    - Command to generate: NA

# Tests
Existing BE tests should cover it

# Known issues
None