### PR TITLE
feat: PLA-883 Add issues SDK support for consensus review tasks

### DIFF
--- a/encord/workflow/stages/consensus_review.py
+++ b/encord/workflow/stages/consensus_review.py
@@ -17,6 +17,7 @@ from uuid import UUID
 
 from encord.common.utils import ensure_list, ensure_uuid_list
 from encord.http.bundle import Bundle
+from encord.issues.issue_client import TaskIssues
 from encord.orm.base_dto import BaseDTO
 from encord.orm.workflow import WorkflowStageType
 from encord.workflow.common import TasksQueryParams, WorkflowAction, WorkflowStageBase, WorkflowTask
@@ -85,6 +86,11 @@ class ConsensusReviewStage(WorkflowStageBase):
         for task in self._workflow_client.get_tasks(self.uuid, params, type_=ConsensusReviewTask):
             task._stage_uuid = self.uuid
             task._workflow_client = self._workflow_client
+            task._task_issues = TaskIssues(
+                api_client=self._workflow_client.api_client,
+                project_uuid=self._workflow_client.project_hash,
+                data_uuid=task.data_hash,
+            )
             yield task
 
 
@@ -221,3 +227,9 @@ class ConsensusReviewTask(WorkflowTask):
         """
         workflow_client, stage_uuid = self._get_client_data()
         workflow_client.action(stage_uuid, _ActionRelease(task_uuid=self.uuid), bundle=bundle)
+
+    @property
+    def issues(self) -> TaskIssues:
+        """Returns the issue client for the task."""
+        assert self._task_issues
+        return self._task_issues


### PR DESCRIPTION
# Introduction and Explanation
Same stuff as standard annotate / review tasks.


# Documentation
_There should be enough internal documentation for a product owner to write customer-facing documentation or a separate PR linked if writing the customer documentation directly. Link all that are relevant below_.
- Internal: NA
- Customer docs PR: NA
- OpenAPI/SDK
    - Generated docs: NA
    - Command to generate: NA

# Tests
Manually tested!!

# Known issues
None