### PR TITLE
fix: dont import from numpy

### DIFF
--- a/encord/http/v2/api_client.py
+++ b/encord/http/v2/api_client.py
@@ -6,7 +6,6 @@ from typing import Callable, Dict, Iterator, List, Optional, Sequence, Type, Typ
 from urllib.parse import urljoin
 
 import requests
-from numpy.core.multiarray import result_type
 from pydantic import BaseModel
 from requests import PreparedRequest, Response
 


### PR DESCRIPTION
# Introduction and Explanation
We introduced a regression by importing things from `numpy`. As we don't have numpy as a dependency for the sdk, users will have issues if they happen to not have numpy installed.

This is the error that users will get.

```
Traceback (most recent call last):
  File "/path/to/my_script.py", line 5, in <module>
    from encord.objects.attributes import RadioAttribute
  File "/path/to/.venv/lib/python3.13/site-packages/encord/__init__.py", line 2, in <module>
    from encord.dataset import Dataset
  File "/path/to/.venv/lib/python3.13/site-packages/encord/dataset.py", line 17, in <module>
    from encord.client import EncordClientDataset
  File "/path/to/.venv/lib/python3.13/site-packages/encord/client.py", line 48, in <module>
    from encord.http.v2.api_client import ApiClient
  File "/path/to/.venv/lib/python3.13/site-packages/encord/http/v2/api_client.py", line 9, in <module>
    from numpy.core.multiarray import result_type
ModuleNotFoundError: No module named 'numpy'
```

# JIRA

No ticket, found and fixed straight away.

# Documentation
Nothing to document.

# Tests
This is something that we should've probably tested for. I am guessing that we didn't notice this because some of our tests depends on numpy so it happens to be installed.