### PR TITLE
feat: PLA-893 - Create project default to workflow project from sdk instead of manual qa

### DIFF
--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -497,7 +497,7 @@ class EncordUserClient:
             project_description: the optional description of the project
             ontology_hash: the uid of an Ontology to be used. If omitted, a new empty Ontology will be created
             workflow_settings: selects and configures the type of the quality control Workflow to use, See :class:`encord.orm.project.ProjectWorkflowSettings` for details. If omitted, :class:`~encord.orm.project.ManualReviewWorkflowSettings` is used.
-            workflow_template_hash: Project is created using a Workflow based on the template provided. This parameter must be included to create a Workflow Project.
+            workflow_template_hash: Project is created using a Workflow based on the template provided. If omitted, the project will be created using the default standard workflow.
 
         Returns:
             the uid of the Project.


### PR DESCRIPTION
# Introduction and Explanation

Changes are made directly in backend but need to update the doc here !

Current : when creating a project from sdk with no workflow_template_hash it defaults to manual qa
New : when creating a project from sdk with no workflow_template_hash it defaults to the standard workflow

