### PR TITLE
feat: Add assigned user in label row response

### DIFF
--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -476,6 +476,13 @@ class LabelRowV2:
 
     @property
     def assigned_user_email(self) -> str | None:
+        """Email of the user assigned to annotation or review task for a workflow-based project.
+        In case of completed task, it is None.
+
+        Returns:
+            str | None: The email of the user assigned to the data.
+
+        """
         return self._label_row_read_only_data.assigned_user_email
 
     def initialise_labels(

--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -474,6 +474,10 @@ class LabelRowV2:
     def __is_tms2_project(self) -> bool:
         return self.workflow_graph_node is not None
 
+    @property
+    def assigned_user_email(self) -> str | None:
+        return self._label_row_read_only_data.assigned_user_email
+
     def initialise_labels(
         self,
         include_object_feature_hashes: Optional[Set[str]] = None,
@@ -1550,6 +1554,7 @@ class LabelRowV2:
             image_hash_to_frame: Mapping from image hash to frame number.
             frame_to_image_hash: Mapping from frame number to image hash.
             is_valid: Boolean indicating if the data is valid.
+            assigned_user_email: Optional email of the user assigned to the data.
         """
 
         label_hash: Optional[str]
@@ -1585,6 +1590,7 @@ class LabelRowV2:
         image_hash_to_frame: Dict[str, int] = field(default_factory=dict)
         frame_to_image_hash: Dict[int, str] = field(default_factory=dict)
         is_valid: bool = field(default=True)
+        assigned_user_email: Optional[str] = None
 
     def _to_object_answers(self) -> Dict[str, Any]:
         ret: Dict[str, Any] = {}
@@ -1986,6 +1992,7 @@ class LabelRowV2:
             file_type=label_row_metadata.file_type,
             is_valid=label_row_metadata.is_valid,
             backing_item_uuid=label_row_metadata.backing_item_uuid,
+            assigned_user_email=label_row_metadata.assigned_user_email,
         )
 
     def _parse_label_row_dict(self, label_row_dict: dict) -> LabelRowReadOnlyData:
@@ -2093,6 +2100,9 @@ class LabelRowV2:
             file_type=file_type,
             is_valid=bool(label_row_dict.get("is_valid", True)),
             backing_item_uuid=self.backing_item_uuid,
+            assigned_user_email=label_row_dict.get(
+                "assigned_user_email", self._label_row_read_only_data.assigned_user_email
+            ),
         )
 
     def _parse_labels_from_dict(self, label_row_dict: dict):

--- a/encord/orm/label_row.py
+++ b/encord/orm/label_row.py
@@ -287,6 +287,7 @@ class LabelRowMetadata(Formatter):
     is_valid: bool = True
 
     backing_item_uuid: Optional[UUID] = None
+    assigned_user_email: Optional[str] = None
 
     @classmethod
     def from_dict(cls, json_dict: Dict) -> LabelRowMetadata:
@@ -335,6 +336,7 @@ class LabelRowMetadata(Formatter):
             backing_item_uuid=UUID(json_dict["backing_item_uuid"])
             if json_dict.get("backing_item_uuid") is not None
             else None,
+            assigned_user_email=json_dict.get("assigned_user_email", None),
         )
 
     @classmethod
@@ -424,6 +426,7 @@ class LabelRowMetadataDTO(BaseDTO):
     is_valid: bool = True
 
     backing_item_uuid: Optional[UUID] = None
+    assigned_user_email: Optional[str] = None
 
 
 def label_row_metadata_dto_to_label_row_metadata(label_row_metadata_dto: LabelRowMetadataDTO) -> LabelRowMetadata:
@@ -458,4 +461,5 @@ def label_row_metadata_dto_to_label_row_metadata(label_row_metadata_dto: LabelRo
         is_valid=label_row_metadata_dto.is_valid,
         branch_name=label_row_metadata_dto.branch_name,
         backing_item_uuid=label_row_metadata_dto.backing_item_uuid,
+        assigned_user_email=label_row_metadata_dto.assigned_user_email,
     )


### PR DESCRIPTION
# Introduction and Explanation
Adding assigned_user for projects managed by workflow. It is needed as we want to propagate this information to Active and show on each card. This has come up as a requirement from Abyss as they want to use the new active view in annotate to assign tasks to users.

# JIRA

Fixes https://linear.app/encord/issue/MGC-161/add-assigned-to-column-in-active-and-expose-as-a-card-item


# Documentation
_There should be enough internal documentation for a product owner to write customer-facing documentation or a separate PR linked if writing the customer documentation directly. Link all that are relevant below_.
- Internal: _notion link_
- Customer docs PR: _link_
- OpenAPI/SDK
    - Generated docs: _link to example if possible_
    - Command to generate: _here_

# Tests

_Make a quick statement and post any relevant links of CI / test results. If the testing infrastructure isn’t yet in-place, note that instead._

- _What are the critical unit tests?_
- _Explain the Integration Tests such that it’s clear Correctness is satisfied. Link to test results if possible._

# Known issues

_If there are any known issues with the solution, make a statement about what they are and why they are Ok to leave unsolved for now. Make tickets for the known issues linked to the original ticket linked above_
