### PR TITLE
Fixing uv/python version mismatch in integration tests pipeline

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -43,7 +43,7 @@ runs:
     - name: Install uv
       uses: astral-sh/setup-uv@v5
       with:
-        version: "0.6.16"
+        version: "0.7.11"
         enable-cache: 'true'
 
     - name: Setup FFMPEG

--- a/.github/workflows/sdk-pr.yml
+++ b/.github/workflows/sdk-pr.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Run integration tests for Python 3.11
         uses: ./.github/actions/run-integration-tests
         with:
-          python-version: 3.11.2
+          python-version: 3.11.13
           integration-tests-location: ./encord-backend/projects/sdk-integration-tests
           test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_11 }}
           private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}


### PR DESCRIPTION
# Introduction and Explanation

Bumping python 3.11 to .13 patch version explicitly, and use fresh `uv`. Currently something forces the python version (though I don't see what exactly?) but the version of `uv` that we have pinned doesn't support that version, so the whole invocation fails.

# Tests

Well...

# Known issues

This has been broken for two weeks, and we've released 4 version of the SDK *without running any tests*. This is *bad*.