### PR TITLE
chore: Allow uv to bump the version of the package for us.

### DIFF
--- a/.github/workflows/publish_sdk.yml
+++ b/.github/workflows/publish_sdk.yml
@@ -26,6 +26,9 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           with-dev-dependencies: false
 
+      - name: uv Version Bump
+        run: uv version ${{ github.ref_name }}
+
       - name: Build SDK
         run: uv build --sdist --wheel
 


### PR DESCRIPTION
# Introduction and Explanation
As discussed here, we can use this:
https://github.com/astral-sh/uv/issues/6298

There's the very reasonable concern that currently publishing the SDK requires someone else to approve the version bump and that this would remove that barrier.
# Tests
Annoyingly not easy at all to test.