### PR TITLE
 FOU-300: Github Actions cleanup

### DIFF
--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -74,5 +74,5 @@ runs:
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
       with:
-        files: ./encord-backend/projects/sdk-integration-tests/${{ inputs.test-report-file }}
+        files: ${{ inputs.integration-tests-location }}/${{ inputs.test-report-file }}
         check_name: SDK integration test report

--- a/.github/actions/run-integration-tests/action.yml
+++ b/.github/actions/run-integration-tests/action.yml
@@ -4,11 +4,12 @@ description: 'Run the integration tests for a given Python version. These tests 
 inputs:
   python-version:
     description: 'Python version to use'
-    default: 3.11.13
+    default: 3.13
     required: false
   test-report-file:
     description: 'File name to save the test report in'
-    required: true
+    required: false
+    default: integration-test-report-python3_13.xml
   private-key:
     description: 'Private key for integration tests'
     required: true
@@ -20,7 +21,7 @@ inputs:
     required: true
   integration-tests-location:
     description: 'project of the backend repo.'
-    default: projects/sdk-integration-tests
+    default: ./encord-backend/projects/sdk-integration-tests
     required: false
   test-dir:
     description: 'Test directory of the integration tests project.'
@@ -68,3 +69,10 @@ runs:
       with:
         name: ${{ inputs.test-report-file }}
         path: ${{ inputs.integration-tests-location }}/${{ inputs.test-report-file }}
+
+    - name: Publish integration test report Python ${{ inputs.python-version }}
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()
+      with:
+        files: ./encord-backend/projects/sdk-integration-tests/${{ inputs.test-report-file }}
+        check_name: SDK integration test report

--- a/.github/actions/run-unit-tests/action.yml
+++ b/.github/actions/run-unit-tests/action.yml
@@ -4,12 +4,10 @@ description: 'Run the unit tests for a given Python version'
 inputs:
   python-version:
     description: 'Python version to use'
-    default: 3.8.18
-    required: false
+    required: true
   pydantic-version:
     description: 'Pydantic version to use'
-    default: ''
-    required: false
+    required: true
   test-report-file:
     description: 'File name to save the test report in'
     required: true
@@ -35,9 +33,9 @@ runs:
           uv run python -m pytest tests --verbose --junitxml=${{ inputs.test-report-file }}
         shell: bash
 
-      - name: Upload report
-        uses: actions/upload-artifact@v4
+      - name: Publish unit test report
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
-          name: ${{ inputs.test-report-file }}
-          path: ${{ inputs.test-report-file }}
+          files: ${{ inputs.test-report-file }}
+          check_name: Unit test report

--- a/.github/actions/run-unit-tests/action.yml
+++ b/.github/actions/run-unit-tests/action.yml
@@ -38,4 +38,4 @@ runs:
         if: always()
         with:
           files: ${{ inputs.test-report-file }}
-          check_name: Unit test report (Python ${{ inputs.python-version }}, Pydantic ${{ inputs.python-version }})
+          check_name: Unit test report (Python ${{ inputs.python-version }}, Pydantic ${{ inputs.pydantic-version }})

--- a/.github/actions/run-unit-tests/action.yml
+++ b/.github/actions/run-unit-tests/action.yml
@@ -38,4 +38,4 @@ runs:
         if: always()
         with:
           files: ${{ inputs.test-report-file }}
-          check_name: Unit test report
+          check_name: Unit test report (Python ${{ inputs.python-version }}, Pydantic ${{ inputs.python-version }})

--- a/.github/actions/send-slack-notification/action.yml
+++ b/.github/actions/send-slack-notification/action.yml
@@ -20,7 +20,7 @@ inputs:
   failure-message:
     description: "Message body on failure"
     required: false
-    default: ''
+    default: 'This pipeline has failed!'
 
 runs:
   using: "composite"

--- a/.github/actions/setup-uv-environment/action.yml
+++ b/.github/actions/setup-uv-environment/action.yml
@@ -4,8 +4,7 @@ description: "Sets up Python, UV and dependencies"
 inputs:
   python-version:
     description: "Python version to use"
-    default: 3.8.18
-    required: false
+    required: true
   uv-version:
     description: "UV version to use"
     default: 0.7.12

--- a/.github/workflows/publish_sdk.yml
+++ b/.github/workflows/publish_sdk.yml
@@ -5,7 +5,7 @@ on:
     types: [ published ]
 
 env:
-  PYTHON_VERSION: 3.8.18
+  PYTHON_VERSION: 3.8
   PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
 concurrency:
@@ -56,4 +56,3 @@ jobs:
           success-channel: ${{ secrets.SLACK_DEPLOYMENT_PROD_CHANNEL_ID }}
           failure-channel: ${{ secrets.SLACK_FAILURE_CHANNEL_ID }}
           success-message: Deployed to https://pypi.org/project/encord/
-          failure-message: This pipeline has failed!

--- a/.github/workflows/sdk-pr.yml
+++ b/.github/workflows/sdk-pr.yml
@@ -6,19 +6,8 @@ on:
       - master
 
 env:
-  PYTHON_VERSION_3_8: 3.8.18
-  PYTHON_VERSION_3_11: 3.11.13
-  PYDANTIC_VERSION_1: 1.10.22
-  PYDANTIC_VERSION_2: 2.10.6 # Latest Pydantic v2x that supports Python 3.8
-  UNIT_TEST_REPORT_PYTHON_3_8_P1: unit-test-report-python-3_8_p1.xml
-  UNIT_TEST_REPORT_PYTHON_3_8_P2: unit-test-report-python-3_8_p2.xml
-  BACKEND_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+  PYTHON_VERSION: 3.8
   BACKEND_REPO: cord-team/cord-backend
-
-  INTEGRATION_TEST_REPORT_PYTHON_3_11: integration-test-report-python3_11.xml
-  INTEGRATION_TESTS_PRIVATE_KEY: ${{ secrets.SDK_TESTS_PRIVATE_KEY }}
-  INTEGRATION_TESTS_PRIVATE_KEY_SERVICE_ACCOUNT: ${{ secrets.SDK_TESTS_PRIVATE_KEY_SERVICE_ACCOUNT }}
-  INTEGRATION_TESTS_PRIVATE_KEY_NON_ORG: ${{ secrets.SDK_TESTS_PRIVATE_KEY_NON_ORG }}
 
 concurrency:
   group: cord-client-${{ github.ref }}-pr
@@ -35,7 +24,7 @@ jobs:
       - name: Setup uv environment
         uses: ./.github/actions/setup-uv-environment
         with:
-          python-version: ${{ env.PYTHON_VERSION_3_8 }}
+          python-version: ${{ env.PYTHON_VERSION }}
           with-dev-dependencies: true
 
       - name: Run linting, type checking and testing
@@ -43,51 +32,32 @@ jobs:
         with:
           extra_args: "--all-files --hook-stage=push"
 
-  unit-tests-python-3-8:
-    name: Run unit tests (Python 3.8, Pydantic 1.x)
+  unit-tests:
+    name: Unit Tests (Python ${{ matrix.python.major_minor }}, Pydantic ${{ matrix.pydantic.version }})
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python:
+          - { version: '3.8.18',  major_minor: '3.8', major_minor_test_report: '3_8' }
+
+        pydantic:
+          - { version: '1.10.22', suffix: 'p1' }
+          - { version: '2.10.6', suffix: 'p2' } # Latest Pydantic v2x that supports Python 3.8
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Run unit tests for Python 3.8 (Pydantic 1.x)
+      - name: Run unit tests
         uses: ./.github/actions/run-unit-tests
         with:
-          python-version: ${{ env.PYTHON_VERSION_3_8 }}
-          pydantic-version: ${{ env.PYDANTIC_VERSION_1 }}
-          test-report-file: ${{ env.UNIT_TEST_REPORT_PYTHON_3_8_P1 }}
-
-      - name: Publish unit test report Python 3.8 (Pydantic 1.x)
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        with:
-          files: ${{ env.UNIT_TEST_REPORT_PYTHON_3_8_P1 }}
-          check_name: Unit test report (Pydantic 1.x)
-
-  unit-tests-python-3-8-pydantic-2:
-    name: Run unit tests (Python 3.8, Pydantic 2.x)
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Run unit tests for Python 3.8 (Pydantic 2.x)
-        uses: ./.github/actions/run-unit-tests
-        with:
-          python-version: ${{ env.PYTHON_VERSION_3_8 }}
-          pydantic-version: ${{ env.PYDANTIC_VERSION_2 }}
-          test-report-file: ${{ env.UNIT_TEST_REPORT_PYTHON_3_8_P2 }}
-
-      - name: Publish unit test report Python 3.8 (Pydantic 2.x)
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        with:
-          files: ${{ env.UNIT_TEST_REPORT_PYTHON_3_8_P2 }}
-          check_name: Unit test report ((Pydantic 2.x)
+          python-version: ${{ matrix.python.version }}
+          pydantic-version: ${{ matrix.pydantic.version }}
+          test-report-file: unit-test-report-python${{ matrix.python.major_minor_test_report }}_${{ matrix.pydantic.suffix }}.xml
 
 
-  integration-tests-python-3-11:
-    name: Run integration tests for Python 3.11
+  integration-tests:
+    name: Run integration tests
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
@@ -97,23 +67,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ env.BACKEND_REPO }}
-          token: ${{ env.BACKEND_ACCESS_TOKEN }}
+          token: ${{ secrets.ACCESS_TOKEN }}
           path: encord-backend
 
-      - name: Run integration tests for Python 3.11
+      - name: Run integration tests
         uses: ./.github/actions/run-integration-tests
         with:
-          python-version: ${{ env.PYTHON_VERSION_3_11 }}
-          integration-tests-location: ./encord-backend/projects/sdk-integration-tests
-          test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_11 }}
-          private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
-          private-key-service-account: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY_SERVICE_ACCOUNT }}
-          private-key-non-org: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY_NON_ORG }}
+          private-key: ${{ secrets.SDK_TESTS_PRIVATE_KEY }}
+          private-key-service-account: ${{ secrets.SDK_TESTS_PRIVATE_KEY_SERVICE_ACCOUNT }}
+          private-key-non-org: ${{ secrets.SDK_TESTS_PRIVATE_KEY_NON_ORG }}
           sdk-repository-url: https://github.com/encord-team/encord-client-python@${{ github.sha }}
-
-      - name: Publish integration test report Python 3.11
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        with:
-          files: ./encord-backend/projects/sdk-integration-tests/${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_11 }}
-          check_name: SDK integration test report

--- a/.github/workflows/sdk_code_to_docs.yml
+++ b/.github/workflows/sdk_code_to_docs.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master  # Trigger on push to the 'master' branch
 
+env:
+  PYTHON_VERSION: 3.13
+
 jobs:
   update_docs:
     runs-on: ubuntu-latest
@@ -27,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: useblacksmith/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies (if any)
         run: |

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -7,15 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  INTEGRATION_TEST_PYTHON_VERSION_3_11: 3.11.13
-  INTEGRATION_TEST_REPORT_PYTHON_3_11: integration-test-report-python3_11.xml
-  INTEGRATION_TESTS_PRIVATE_KEY: ${{ secrets.SDK_TESTS_PRIVATE_KEY }}
-  INTEGRATION_TESTS_PRIVATE_KEY_SERVICE_ACCOUNT: ${{ secrets.SDK_TESTS_PRIVATE_KEY_SERVICE_ACCOUNT }}
-  INTEGRATION_TESTS_PRIVATE_KEY_NON_ORG: ${{ secrets.SDK_TESTS_PRIVATE_KEY_NON_ORG }}
-
-  BACKEND_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
   BACKEND_REPO: cord-team/cord-backend
-
 
 concurrency:
   group: cord-client-${{ github.ref }}-test
@@ -34,6 +26,7 @@ jobs:
           - { version: '3.10.18', major_minor: '3.10', major_minor_test_report: '3_10' }
           - { version: '3.11.13', major_minor: '3.11', major_minor_test_report: '3_11' }
           - { version: '3.12.11', major_minor: '3.12', major_minor_test_report: '3_12' }
+          - { version: '3.13.5', major_minor: '3.13', major_minor_test_report: '3_13' }
 
         pydantic:
           - { version: '1.10.22', suffix: 'p1' }
@@ -49,22 +42,9 @@ jobs:
           pydantic-version: ${{ matrix.pydantic.version }}
           test-report-file: unit-test-report-python${{ matrix.python.major_minor_test_report }}_${{ matrix.pydantic.suffix }}.xml
 
-      - name: Download unit test report
-        uses: actions/download-artifact@v4
-        with:
-          name: unit-test-report-python${{ matrix.python.major_minor_test_report }}_${{ matrix.pydantic.suffix }}.xml
-          path: unit-test-report-python${{ matrix.python.major_minor_test_report }}_${{ matrix.pydantic.suffix }}
 
-      - name: Publish unit test report
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        with:
-          files: unit-test-report-python${{ matrix.python.major_minor_test_report }}_${{ matrix.pydantic.suffix }}/*.xml
-          check_name: Unit test report
-
-
-  integration-tests-python-3-11:
-    name: Run integration tests for Python 3.11
+  integration-tests:
+    name: Run integration tests
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
@@ -74,39 +54,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ env.BACKEND_REPO }}
-          token: ${{ env.BACKEND_ACCESS_TOKEN }}
+          token: ${{ secrets.ACCESS_TOKEN }}
           path: encord-backend
 
-      - name: Run integration tests for Python 3.11
+      - name: Run integration tests
         uses: ./.github/actions/run-integration-tests
         with:
-          python-version: ${{ env.INTEGRATION_TEST_PYTHON_VERSION_3_11 }}
-          integration-tests-location: ./encord-backend/projects/sdk-integration-tests
-          test-report-file: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_11 }}
-          private-key: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY }}
-          private-key-service-account: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY_SERVICE_ACCOUNT }}
-          private-key-non-org: ${{ env.INTEGRATION_TESTS_PRIVATE_KEY_NON_ORG }}
+          private-key: ${{ secrets.SDK_TESTS_PRIVATE_KEY }}
+          private-key-service-account: ${{ secrets.SDK_TESTS_PRIVATE_KEY_SERVICE_ACCOUNT }}
+          private-key-non-org: ${{ secrets.SDK_TESTS_PRIVATE_KEY_NON_ORG }}
           sdk-repository-url: https://github.com/encord-team/encord-client-python@${{ github.sha }}
-
-      - name: Download integration test report Python 3.11
-        uses: actions/download-artifact@v4
-        if: always()
-        with:
-          name: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_11 }}
-          path: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_11 }}
-
-      - name: Publish integration test report Python 3.11
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        with:
-          files: ${{ env.INTEGRATION_TEST_REPORT_PYTHON_3_11 }}/*.xml
-          check_name: SDK integration test report
 
 
   send-slack-notification:
     name: Send notification
     runs-on: ubuntu-24.04
-    needs: [ unit-tests, integration-tests-python-3-11 ]
+    needs: [ unit-tests, integration-tests ]
     if: always()
     env:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -122,4 +85,3 @@ jobs:
         with:
           success-parameter: ${{ env.WORKFLOW_CONCLUSION }}
           failure-channel: ${{ secrets.SLACK_FAILURE_CHANNEL_ID }}
-          failure-message: This pipeline has failed!

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## 💻 Features
 
 - Minimal low-level Python client that allows you to interact with Encord's API
-- Supports Python: `3.8`, `3.9`, `3.10` and `3.11`
+- Supports Python: `3.8`, `3.9`, `3.10`, `3.11`, `3.12` and `3.13`
 
 ## ✨ Relevant Links
 


### PR DESCRIPTION
# Introduction and Explanation
* Adds Python 3.13 to the unit tests suit.
* Switches integration tests to run on python 3.13.
* Moves test reports publishing steps to unit and integration tests custom actions.
* Simplifies PR actions unit tests to use matrix tests.
* Small refactorings all round.

# JIRA
[FOU-300](https://linear.app/encord/issue/FOU-300)