### PR TITLE
fix: add querier to linked items

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -613,7 +613,12 @@ class EncordClientDataset(EncordClient):
                 "duplicates_behavior": duplicates_behavior.value,
             },
         )
-        return DataRow.from_dict_list(data_row_dicts)
+
+        data_rows = DataRow.from_dict_list(data_row_dicts)
+        for row in data_rows:
+            row["_querier"] = self._querier
+
+        return data_rows
 
     def delete_data(self, data_hashes: Union[List[str], str]):
         """This function is documented in :meth:`encord.dataset.Dataset.delete_data`."""


### PR DESCRIPTION
# Introduction and Explanation
Ensure data rows returned from `dataset.link_items()` have proper querier instances to enable read/write operations.

# Documentation
No need.

# Tests
Added to the integration tests.

# Known issues
Other methods that return data rows may have similar querier issues although I haven't found any after a quick investigation.
We might want to consider implementing comprehensive validation around querier functionality.