### PR TITLE
feat: propagate data group hash through label row

### DIFF
--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -153,6 +153,17 @@ class LabelRowV2:
         return self._label_row_read_only_data.data_hash
 
     @property
+    def group_hash(self) -> Optional[str]:
+        """Returns the group hash of the data row.
+
+        Only present if this label row is a child of a group
+
+        Returns:
+            str: The data group hash.
+        """
+        return self._label_row_read_only_data.group_hash
+
+    @property
     def dataset_hash(self) -> str:
         """Returns the hash of the dataset.
 
@@ -1633,6 +1644,7 @@ class LabelRowV2:
         created_at: Optional[datetime]
         last_edited_at: Optional[datetime]
         data_hash: str
+        group_hash: Optional[str]
         data_type: DataType
         backing_item_uuid: Optional[UUID]
         label_status: LabelStatus
@@ -2044,6 +2056,7 @@ class LabelRowV2:
             label_hash=label_row_metadata.label_hash,
             branch_name=label_row_metadata.branch_name,
             data_hash=label_row_metadata.data_hash,
+            group_hash=label_row_metadata.group_hash,
             data_title=label_row_metadata.data_title,
             dataset_hash=label_row_metadata.dataset_hash,
             dataset_title=label_row_metadata.dataset_title,
@@ -2160,6 +2173,7 @@ class LabelRowV2:
             dataset_title=label_row_dict["dataset_title"],
             data_title=label_row_dict["data_title"],
             data_hash=label_row_dict["data_hash"],
+            group_hash=label_row_dict.get("group_hash", self._label_row_read_only_data.group_hash),
             data_type=data_type,
             label_status=LabelStatus(label_row_dict["label_status"]),
             annotation_task_status=label_row_dict.get("annotation_task_status"),

--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -159,7 +159,7 @@ class LabelRowV2:
         Only present if this label row is a child of a group
 
         Returns:
-            str: The data group hash.
+            Optional[str]: The data group hash.
         """
         return self._label_row_read_only_data.group_hash
 

--- a/encord/objects/ontology_labels_impl.py
+++ b/encord/objects/ontology_labels_impl.py
@@ -156,7 +156,7 @@ class LabelRowV2:
     def group_hash(self) -> Optional[str]:
         """Returns the group hash of the data row.
 
-        Only present if this label row is a child of a group
+        Only present if this label row is a child of a data group
 
         Returns:
             Optional[str]: The data group hash.

--- a/encord/orm/label_row.py
+++ b/encord/orm/label_row.py
@@ -249,7 +249,6 @@ class LabelRowMetadata(Formatter):
     """Only present if the label row is initiated or branch_name is set specifically"""
 
     data_hash: str
-    group_hash: Optional[str]
     """Only present if the label row is for a child element of a group"""
     dataset_hash: str
     dataset_title: str
@@ -278,6 +277,8 @@ class LabelRowMetadata(Formatter):
     audio_codec: Optional[str]
     audio_bit_depth: Optional[int]
     audio_num_channels: Optional[int]
+
+    group_hash: Optional[str] = None
 
     task_uuid: Optional[UUID] = None
     priority: Optional[float] = None
@@ -392,7 +393,7 @@ class LabelRowMetadataDTO(BaseDTO):
     """Only present if the label row is initiated or branch_name is set specifically"""
 
     data_hash: str = Field(alias="data_uuid")
-    group_hash: Optional[str] = Field(alias="group_uuid")
+    group_hash: Optional[str] = Field(default=None, alias="group_uuid")
     dataset_hash: str = Field(alias="dataset_uuid")
     dataset_title: str
     data_title: str

--- a/encord/orm/label_row.py
+++ b/encord/orm/label_row.py
@@ -392,6 +392,7 @@ class LabelRowMetadataDTO(BaseDTO):
     """Only present if the label row is initiated or branch_name is set specifically"""
 
     data_hash: str = Field(alias="data_uuid")
+    group_hash: Optional[str] = Field(alias="group_uuid")
     dataset_hash: str = Field(alias="dataset_uuid")
     dataset_title: str
     data_title: str
@@ -441,6 +442,7 @@ def label_row_metadata_dto_to_label_row_metadata(label_row_metadata_dto: LabelRo
         created_at=label_row_metadata_dto.created_at,
         last_edited_at=label_row_metadata_dto.last_edited_at,
         data_hash=label_row_metadata_dto.data_hash,
+        group_hash=label_row_metadata_dto.group_hash,
         dataset_hash=label_row_metadata_dto.dataset_hash,
         dataset_title=label_row_metadata_dto.dataset_title,
         data_title=label_row_metadata_dto.data_title,

--- a/encord/orm/label_row.py
+++ b/encord/orm/label_row.py
@@ -249,6 +249,8 @@ class LabelRowMetadata(Formatter):
     """Only present if the label row is initiated or branch_name is set specifically"""
 
     data_hash: str
+    group_hash: Optional[str]
+    """Only present if the label row is for a child element of a group"""
     dataset_hash: str
     dataset_title: str
     data_title: str
@@ -309,6 +311,7 @@ class LabelRowMetadata(Formatter):
             created_at=created_at,
             last_edited_at=last_edited_at,
             data_hash=json_dict["data_hash"],
+            group_hash=json_dict.get("group_hash", None),
             dataset_hash=json_dict["dataset_hash"],
             dataset_title=json_dict["dataset_title"],
             data_title=json_dict["data_title"],


### PR DESCRIPTION
# Introduction and Explanation
Propagate and expose group_hash for child label rows of group items.

# Documentation
Inline sdk docs

# Tests
Added integration test

# Known issues
None
