### PR TITLE
Commit change to `pyproject.toml` following version bump

### DIFF
--- a/.github/workflows/publish_sdk.yml
+++ b/.github/workflows/publish_sdk.yml
@@ -29,6 +29,12 @@ jobs:
       - name: uv Version Bump
         run: uv version ${{ github.ref_name }}
 
+      - name: Commit version bump
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Bump version to ${{ github.ref_name }}"
+          push_options: --force
+
       - name: Build SDK
         run: uv build --sdist --wheel
 


### PR DESCRIPTION
# Introduction and Explanation
- The github action for publishing the SDK to pypi is supposed to auto-update the `pyproject.toml` to match the latest release
- [It currently does not work](https://github.com/encord-team/encord-client-python/actions/runs/16779117083/job/47512663974), since the `pyproject.toml` is updated but not committed 


