### PR TITLE
fix: add missing scene enum

### DIFF
--- a/encord/orm/storage.py
+++ b/encord/orm/storage.py
@@ -28,6 +28,7 @@ class StorageItemType(CamelStrEnum):
     NIFTI = auto()
     PLAIN_TEXT = auto()
     PDF = auto()
+    SCENE = auto()
 
 
 class StorageUserRole(CamelStrEnum):


### PR DESCRIPTION
# Introduction and Explanation

Adds missing `SCENE` storage item enum, which was preventing the use of `folder.list_items()` if the folder contained scene items.