### PR TITLE
feat: Allow to have variable trace_id_provider and stateful.

### DIFF
--- a/encord/http/constants.py
+++ b/encord/http/constants.py
@@ -46,5 +46,7 @@ class RequestsSettings:
     trace_id_provider: Optional[Callable[[], str]] = None
     """Function that supplies trace id for every request issued by the library. Random if not provided."""
 
+    update_trace_id_provider: Optional[Callable[[int], None]] = None
+
 
 DEFAULT_REQUESTS_SETTINGS = RequestsSettings()

--- a/encord/http/v2/api_client.py
+++ b/encord/http/v2/api_client.py
@@ -264,6 +264,16 @@ class ApiClient:
                         ", expected content",
                         context=context,
                     )
+            if update_trace_id_provider := self._config.requests_settings.update_trace_id_provider:
+                if x_cloud_trace_context := res.headers.get(HEADER_CLOUD_TRACE_CONTEXT, None):
+                    x_cloud_trace_context = x_cloud_trace_context.split(";")[0]
+                    span_id = (x_cloud_trace_context.split("/") + [None, None])[1]
+                    if span_id is not None:
+                        try:
+                            span_id_int = int(span_id)
+                            update_trace_id_provider(span_id_int)
+                        except:
+                            pass
             try:
                 res_json = res.json()
             except Exception as e:


### PR DESCRIPTION
If we want to use the Encord SDK client for a multi-request transaction, then in order to tag logs together appropriately, then we need a method of recording the current span id and updating it in response to what the server says. If the server tells us we are on Span 7, we should update appropriately.

Bit of weirdness going on here.
Having the trace_id_provider historically also include the span_id means that this is best handled via some closure that mutates some state that seeds the trace_id_provider.

This way gives an interface that allows the code to call the span id store and update appropriately. This means that we will only be incrementing the span_id if explicitly told too. So we should support all cases. Very hairy
