### PR TITLE
feat: PLA-1189 Support for moving tasks to an arbitrary workflow stage

### DIFF
--- a/encord/exceptions.py
+++ b/encord/exceptions.py
@@ -271,3 +271,9 @@ class WrongProjectTypeError(CordException):
     """An error thrown when project type does not match the operation
     E.g. when TMS2 specific operations are attempted on non-TMS2 project
     """
+
+
+class BundledMoveWorkflowTasksPayloadError(EncordException):
+    """An error thrown when an invalid item is added to the bundle to move workflow tasks"""
+
+    pass

--- a/encord/workflow/common.py
+++ b/encord/workflow/common.py
@@ -90,12 +90,14 @@ class BundledMoveTasksPayload:
 
     def add(self, other: BundledMoveTasksPayload) -> BundledMoveTasksPayload:
         if self.origin_stage_uuid != other.origin_stage_uuid:
-            raise BundledWorkflowMoveTasksError(
+            raise BundledMoveWorkflowTasksPayloadError(
                 "It's only possilbe to bundle move tasks for one origin stage at a time"
             )
 
         if self.destination_stage_uuid != other.destination_stage_uuid:
-            raise BundledWorkflowMoveTasksError("It's only possilbe to bundle move tasks for one destination at a time")
+            raise BundledMoveWorkflowTasksPayloadError(
+                "It's only possilbe to bundle move tasks for one destination at a time"
+            )
 
         self.task_uuids.extend(other.task_uuids)
         return self

--- a/encord/workflow/common.py
+++ b/encord/workflow/common.py
@@ -152,6 +152,7 @@ class WorkflowClient:
                     destination_stage_uuid=destination_stage_uuid,
                     task_uuids=task_uuids,
                 ),
+                limit=500,
             )
 
     def _move(self, origin_stage_uuid: UUID, destination_stage_uuid: UUID, task_uuids: List[UUID]) -> None:

--- a/encord/workflow/common.py
+++ b/encord/workflow/common.py
@@ -46,7 +46,7 @@ class WorkflowAction(BaseDTO):
 
 class WorkflowMoveTasksRequest(BaseDTO):
     task_uuids: list[UUID]
-    target_stage_uuid: UUID
+    destination_stage_uuid: UUID
 
 
 TaskT = TypeVar("TaskT", bound=WorkflowTask)
@@ -153,7 +153,7 @@ class WorkflowClient:
         self.api_client.post(
             path=f"/projects/{self.project_hash}/workflow/stages/{origin_stage_uuid}/move-tasks",
             params=None,
-            payload=WorkflowMoveTasksRequest(task_uuids=task_uuids, target_stage_uuid=destination_stage_uuid),
+            payload=WorkflowMoveTasksRequest(task_uuids=task_uuids, destination_stage_uuid=destination_stage_uuid),
             result_type=None,
         )
 

--- a/encord/workflow/common.py
+++ b/encord/workflow/common.py
@@ -96,7 +96,7 @@ class BundledMoveTasksPayload:
 
         if self.destination_stage_uuid != other.destination_stage_uuid:
             raise BundledMoveWorkflowTasksPayloadError(
-                "It's only possilbe to bundle move tasks for one destination at a time"
+                "It's only possilbe to bundle move tasks for one destination stage at a time"
             )
 
         self.task_uuids.extend(other.task_uuids)

--- a/encord/workflow/common.py
+++ b/encord/workflow/common.py
@@ -45,7 +45,7 @@ class WorkflowAction(BaseDTO):
 
 
 class WorkflowMoveTasksRequest(BaseDTO):
-    task_uuids: list[UUID]
+    task_uuids: List[UUID]
     destination_stage_uuid: UUID
 
 

--- a/encord/workflow/common.py
+++ b/encord/workflow/common.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Iterable, List, Optional, Sequence, Tuple, Type, TypeVar
 from uuid import UUID
 
+from encord.exceptions import BundledMoveWorkflowTasksPayloadError
 from encord.http.bundle import Bundle, bundled_operation
 from encord.http.v2.api_client import ApiClient
 from encord.issues.issue_client import TaskIssues
@@ -88,12 +89,14 @@ class BundledMoveTasksPayload:
     task_uuids: List[UUID]
 
     def add(self, other: BundledMoveTasksPayload) -> BundledMoveTasksPayload:
-        assert self.origin_stage_uuid == other.origin_stage_uuid, (
-            "It's only possilbe to bundle move tasks for one origin stage at a time"
-        )
-        assert self.destination_stage_uuid == other.destination_stage_uuid, (
-            "It's only possilbe to bundle move tasks for one destination at a time"
-        )
+        if self.origin_stage_uuid != other.origin_stage_uuid:
+            raise BundledWorkflowMoveTasksError(
+                "It's only possilbe to bundle move tasks for one origin stage at a time"
+            )
+
+        if self.destination_stage_uuid != other.destination_stage_uuid:
+            raise BundledWorkflowMoveTasksError("It's only possilbe to bundle move tasks for one destination at a time")
+
         self.task_uuids.extend(other.task_uuids)
         return self
 

--- a/encord/workflow/common.py
+++ b/encord/workflow/common.py
@@ -44,6 +44,11 @@ class WorkflowAction(BaseDTO):
     task_uuid: UUID
 
 
+class WorkflowMoveTasksRequest(BaseDTO):
+    task_uuids: list[UUID]
+    target_stage_uuid: UUID
+
+
 TaskT = TypeVar("TaskT", bound=WorkflowTask)
 ReviewT = TypeVar("ReviewT", bound=BaseDTO)
 
@@ -77,6 +82,23 @@ class BundledReviewActionPayload:
 
 
 @dataclass
+class BundledMoveTasksPayload:
+    origin_stage_uuid: UUID
+    destination_stage_uuid: UUID
+    task_uuids: List[UUID]
+
+    def add(self, other: BundledMoveTasksPayload) -> BundledMoveTasksPayload:
+        assert self.origin_stage_uuid == other.origin_stage_uuid, (
+            "It's only possilbe to bundle move tasks for one origin stage at a time"
+        )
+        assert self.destination_stage_uuid == other.destination_stage_uuid, (
+            "It's only possilbe to bundle move tasks for one destination at a time"
+        )
+        self.task_uuids.extend(other.task_uuids)
+        return self
+
+
+@dataclass
 class WorkflowClient:
     api_client: ApiClient
     project_hash: UUID
@@ -103,6 +125,35 @@ class WorkflowClient:
             path=f"/projects/{self.project_hash}/workflow/stages/{stage_uuid}/actions",
             params=None,
             payload=actions,
+            result_type=None,
+        )
+
+    def move(
+        self,
+        *,
+        origin_stage_uuid: UUID,
+        destination_stage_uuid: UUID,
+        task_uuids: List[UUID],
+        bundle: Optional[Bundle] = None,
+    ) -> None:
+        if not bundle:
+            self._move(origin_stage_uuid, destination_stage_uuid, task_uuids)
+        else:
+            bundled_operation(
+                bundle=bundle,
+                operation=self._move,
+                payload=BundledMoveTasksPayload(
+                    origin_stage_uuid=origin_stage_uuid,
+                    destination_stage_uuid=destination_stage_uuid,
+                    task_uuids=task_uuids,
+                ),
+            )
+
+    def _move(self, origin_stage_uuid: UUID, destination_stage_uuid: UUID, task_uuids: List[UUID]) -> None:
+        self.api_client.post(
+            path=f"/projects/{self.project_hash}/workflow/stages/{origin_stage_uuid}/move-tasks",
+            params=None,
+            payload=WorkflowMoveTasksRequest(task_uuids=task_uuids, target_stage_uuid=destination_stage_uuid),
             result_type=None,
         )
 

--- a/encord/workflow/stages/agent.py
+++ b/encord/workflow/stages/agent.py
@@ -71,6 +71,15 @@ class AgentTask(WorkflowTask):
             bundle=bundle,
         )
 
+    def move(self, *, destination_stage_uuid: UUID, bundle: Optional[Bundle] = None) -> None:
+        workflow_client, stage_uuid = self._get_client_data()
+        workflow_client.move(
+            origin_stage_uuid=stage_uuid,
+            destination_stage_uuid=destination_stage_uuid,
+            task_uuids=[self.uuid],
+            bundle=bundle,
+        )
+
 
 class _AgentTasksQueryParams(TasksQueryParams):
     user_emails: Optional[List[str]] = None

--- a/encord/workflow/stages/annotation.py
+++ b/encord/workflow/stages/annotation.py
@@ -178,6 +178,15 @@ class AnnotationTask(WorkflowTask):
         workflow_client, stage_uuid = self._get_client_data()
         workflow_client.action(stage_uuid, _ActionRelease(task_uuid=self.uuid), bundle=bundle)
 
+    def move(self, *, destination_stage_uuid: UUID, bundle: Optional[Bundle] = None) -> None:
+        workflow_client, stage_uuid = self._get_client_data()
+        workflow_client.move(
+            origin_stage_uuid=stage_uuid,
+            destination_stage_uuid=destination_stage_uuid,
+            task_uuids=[self.uuid],
+            bundle=bundle,
+        )
+
     @property
     def issues(self) -> TaskIssues:
         """Returns the issue client for the task."""

--- a/encord/workflow/stages/consensus_review.py
+++ b/encord/workflow/stages/consensus_review.py
@@ -228,6 +228,15 @@ class ConsensusReviewTask(WorkflowTask):
         workflow_client, stage_uuid = self._get_client_data()
         workflow_client.action(stage_uuid, _ActionRelease(task_uuid=self.uuid), bundle=bundle)
 
+    def move(self, *, destination_stage_uuid: UUID, bundle: Optional[Bundle] = None) -> None:
+        workflow_client, stage_uuid = self._get_client_data()
+        workflow_client.move(
+            origin_stage_uuid=stage_uuid,
+            destination_stage_uuid=destination_stage_uuid,
+            task_uuids=[self.uuid],
+            bundle=bundle,
+        )
+
     @property
     def issues(self) -> TaskIssues:
         """Returns the issue client for the task."""

--- a/encord/workflow/stages/final.py
+++ b/encord/workflow/stages/final.py
@@ -15,6 +15,7 @@ from typing import Iterable, List, Literal, Optional, Union
 from uuid import UUID
 
 from encord.common.utils import ensure_uuid_list
+from encord.http.bundle import Bundle
 from encord.orm.workflow import WorkflowStageType
 from encord.workflow.common import TasksQueryParams, WorkflowStageBase, WorkflowTask
 
@@ -76,3 +77,12 @@ class FinalStageTask(WorkflowTask):
     - `data_hash` (UUID): Unique ID for the data unit.
     - `data_title` (str): Name of the data unit.
     """
+
+    def move(self, *, destination_stage_uuid: UUID, bundle: Optional[Bundle] = None) -> None:
+        workflow_client, stage_uuid = self._get_client_data()
+        workflow_client.move(
+            origin_stage_uuid=stage_uuid,
+            destination_stage_uuid=destination_stage_uuid,
+            task_uuids=[self.uuid],
+            bundle=bundle,
+        )

--- a/encord/workflow/stages/final.py
+++ b/encord/workflow/stages/final.py
@@ -62,7 +62,10 @@ class FinalStage(WorkflowStageBase):
             data_title_contains=data_title,
         )
 
-        yield from self._workflow_client.get_tasks(self.uuid, params, type_=FinalStageTask)
+        for task in self._workflow_client.get_tasks(self.uuid, params, type_=FinalStageTask):
+            task._stage_uuid = self.uuid
+            task._workflow_client = self._workflow_client
+            yield task
 
 
 class FinalStageTask(WorkflowTask):

--- a/encord/workflow/stages/review.py
+++ b/encord/workflow/stages/review.py
@@ -299,6 +299,15 @@ class ReviewTask(WorkflowTask):
         workflow_client, stage_uuid = self._get_client_data()
         workflow_client.action(stage_uuid, _ActionRelease(task_uuid=self.uuid), bundle=bundle)
 
+    def move(self, *, destination_stage_uuid: UUID, bundle: Optional[Bundle] = None) -> None:
+        workflow_client, stage_uuid = self._get_client_data()
+        workflow_client.move(
+            origin_stage_uuid=stage_uuid,
+            destination_stage_uuid=destination_stage_uuid,
+            task_uuids=[self.uuid],
+            bundle=bundle,
+        )
+
     def get_label_reviews(
         self, status: Union[ReviewTaskStatus, List[ReviewTaskStatus], None] = None
     ) -> Iterable[LabelReview]:


### PR DESCRIPTION
# Introduction and Explanation
## How to test
- Run the BE locally to connect to dev DB etc
- install this PR version of the SDK in your local environment
- Join this project on dev and copy the project: `d0ec73a6-d4ab-4549-a862-946e86ec5283`
- As an example, you can run the following code snippet.

```python
from encord import EncordUserClient
from encord.workflow import AnnotationStage, ReviewStage,  AgentStage, FinalStage, ConsensusAnnotationStage

PROJECT_ID = '<project_hash>'
DATA_HASH = '<data_hash>'
user_client = EncordUserClient.create_with_ssh_private_key(
    ssh_private_key_path='<path_to_key>',
    domain="http://127.0.0.1:6969"
)

project = user_client.get_project(PROJECT_ID)

consensus_annotation_stage = project.workflow.get_stage(name='Consensus 1', type_=ConsensusAnnotationStage)
annotation_stage = project.workflow.get_stage(name='Annotate 1', type_=AnnotationStage)
review_stage = project.workflow.get_stage(name='Review 1', type_=ReviewStage)
agent_stage = project.workflow.get_stage(name='Agent 1', type_=AgentStage)
complete_stage = project.workflow.get_stage(name='Complete', type_=FinalStage)
archive_stage = project.workflow.get_stage(name='Archive', type_=FinalStage)

for task in consensus_annotation_stage.get_tasks(data_hash=DATA_HASH):
    print('moving to annotate stage')
    task.move(destination_stage_uuid=annotation_stage.uuid)

for task in annotation_stage.get_tasks(data_hash=DATA_HASH):
    print('moving to review stage')
    task.move(destination_stage_uuid=review_stage.uuid)

for task in review_stage.get_tasks(data_hash=DATA_HASH):
    print('moving to agent stage')
    task.move(destination_stage_uuid=agent_stage.uuid)

for task in agent_stage.get_tasks(data_hash=DATA_HASH):
    print('moving to complete stage')
    task.move(destination_stage_uuid=complete_stage.uuid)

for task in complete_stage.get_tasks(data_hash=DATA_HASH):
    print('moving to archive stage')
    task.move(destination_stage_uuid=archive_stage.uuid)

for task in archive_stage.get_tasks(data_hash=DATA_HASH):
    print('moving to agent stage')
    task.move(destination_stage_uuid=agent_stage.uuid)
```

If you want to bundle operations, you can do this:
```python
with project.create_bundle() as bundle:
    for task in annotation_stage.get_tasks():
        task.move(destination_stage_uuid=review_stage.uuid, bundle=bundle)
```


# Documentation
_There should be enough internal documentation for a product owner to write customer-facing documentation or a separate PR linked if writing the customer documentation directly. Link all that are relevant below_.
- Internal: NA
- Customer docs PR: NA
- OpenAPI/SDK
    - Generated docs: NA
    - Command to generate: NA

# Tests
None

# Known issues
None