### PR TITLE
Make typing decorators backwards-compatible with Python3.9

### DIFF
--- a/encord/orm/editor_log.py
+++ b/encord/orm/editor_log.py
@@ -52,7 +52,7 @@ class EditorLogCommon(BaseDTO):
     data_unit_dataset_title: str
     ontology_id: UUID
     label_id: str
-    workflow_stage_type: ActionableWorkflowNodeType | Literal[""]
+    workflow_stage_type: Union[ActionableWorkflowNodeType, Literal[""]]
     workflow_stage_title: str
     event_information: dict[str, Any]
 


### PR DESCRIPTION
# Introduction and Explanation

A super cosmetic fix that should hopefully make the pipeline green again

# Known issues

We should make everything except maybe the integration tests a required check, they are fast enough.
