### PR TITLE
chore: bump version to 0.1.180

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "encord"
-version = "0.1.179"
+version = "0.1.180"
 description = "Encord Python SDK Client"
 authors = [
     { name = "Cord Technologies Limited", email = "hello@encord.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -265,7 +265,7 @@ wheels = [
 
 [[package]]
 name = "encord"
-version = "0.1.179"
+version = "0.1.180"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
# Introduction and Explanation
New sdk version making editor logs not return event_information anymore
