### PR TITLE
feat: PLA-2359 Add client support for fetching issues

### DIFF
--- a/encord/http/v2/api_client.py
+++ b/encord/http/v2/api_client.py
@@ -2,7 +2,7 @@ import inspect
 import json
 import uuid
 from http import HTTPStatus
-from typing import Callable, Dict, Iterator, List, Optional, Sequence, Type, TypeVar, Union
+from typing import Callable, Dict, Iterator, List, Optional, Sequence, Type, TypeVar, Union, Any
 from urllib.parse import urljoin
 
 import requests
@@ -75,7 +75,7 @@ class ApiClient:
         self,
         path: str,
         params: BaseDTO,
-        result_type: Type[T],
+        result_type: Union[Type[T], Any],  # Accept Union types for discriminated unions
         allow_none: bool = False,
     ) -> Iterator[T]:
         if not hasattr(params, "page_token"):

--- a/encord/http/v2/api_client.py
+++ b/encord/http/v2/api_client.py
@@ -2,7 +2,7 @@ import inspect
 import json
 import uuid
 from http import HTTPStatus
-from typing import Callable, Dict, Iterator, List, Optional, Sequence, Type, TypeVar, Union, Any
+from typing import Callable, Dict, Iterator, List, Optional, Sequence, Type, TypeVar, Union
 from urllib.parse import urljoin
 
 import requests
@@ -75,7 +75,7 @@ class ApiClient:
         self,
         path: str,
         params: BaseDTO,
-        result_type: Union[Type[T], Any],  # Accept Union types for discriminated unions
+        result_type: Type[T],
         allow_none: bool = False,
     ) -> Iterator[T]:
         if not hasattr(params, "page_token"):

--- a/encord/issues/__init__.py
+++ b/encord/issues/__init__.py
@@ -1,0 +1,9 @@
+from encord.issues.issue_client import AnnotationIssue, CoordinateIssue, FileIssue, FrameIssue, FrameRangeIssue
+
+__all__ = [
+    "AnnotationIssue",
+    "CoordinateIssue",
+    "FileIssue",
+    "FrameIssue",
+    "FrameRangeIssue",
+]

--- a/encord/issues/issue_client.py
+++ b/encord/issues/issue_client.py
@@ -162,6 +162,27 @@ class TaskIssues:
         self._data_uuid = data_uuid
 
     def list(self) -> Iterable[Issue]:
+        """Lists all issues (comment threads) for this task.
+
+        Returns an iterator of issues anchored to different parts of the data unit:
+        - FileIssue: Issues anchored to the entire data unit
+        - FrameIssue: Issues anchored to a specific frame
+        - CoordinateIssue: Issues anchored to specific coordinates on a frame
+        - FrameRangeIssue: Issues anchored to a range of frames
+        - AnnotationIssue: Issues anchored to a specific annotation
+
+        Each issue includes comments, tags, and resolution history.
+
+        Returns:
+            Iterable[Issue]: An iterator of Issue objects (discriminated union of all issue types).
+
+        Example:
+            >>> for issue in task.issues.list():
+            ...     if isinstance(issue, FileIssue):
+            ...         print(f"File issue: {issue.comments[0].content}")
+            ...     elif isinstance(issue, FrameIssue):
+            ...         print(f"Frame {issue.frame_index}: {issue.comments[0].content}")
+        """
         return self._issue_client.get_issues(project_uuid=self._project_uuid, data_uuid=self._data_uuid)
 
     def add_file_issue(self, comment: str, issue_tags: List[str]) -> None:

--- a/encord/issues/issue_client.py
+++ b/encord/issues/issue_client.py
@@ -100,7 +100,7 @@ class CoordinateIssue(_BaseIssue):
     coordinate: IssueCoordinate
 
 
-class _IssueFrameRange(BaseDTO):
+class IssueFrameRange(BaseDTO):
     """Represents a range of frames [start, end] inclusive"""
 
     start: int
@@ -111,7 +111,7 @@ class FrameRangeIssue(_BaseIssue):
     """Issue anchored to a range of frames"""
 
     type: Literal[IssueAnchorType.FRAME_RANGE] = IssueAnchorType.FRAME_RANGE
-    frame_ranges: List[_IssueFrameRange]
+    frame_ranges: List[IssueFrameRange]
 
 
 class AnnotationIssue(_BaseIssue):

--- a/encord/issues/issue_client.py
+++ b/encord/issues/issue_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from enum import auto
-from typing import Annotated, Iterable, List, Literal, Optional, Set, Type, Union
+from typing import Annotated, Iterable, List, Literal, Optional, Union
 from uuid import UUID
 
 from encord.http.v2.api_client import ApiClient
@@ -53,6 +53,7 @@ class _CreateIssuesPayload(BaseDTO):
 
 class GetIssuesParam(BaseDTO):
     data_unit_id: UUID
+    page_token: Optional[str] = None
 
 
 class IssueComment(BaseDTO):

--- a/encord/issues/issue_client.py
+++ b/encord/issues/issue_client.py
@@ -73,6 +73,7 @@ class IssueResolution(BaseDTO):
 
 
 class _BaseIssue(BaseDTO):
+    type: IssueAnchorType
     data_uuid: UUID
     comments: List[IssueComment]
     tags: List[IssueTag]
@@ -120,7 +121,10 @@ class AnnotationIssue(_BaseIssue):
     annotation_id: str
 
 
-Issue = Union[FileIssue, FrameIssue, CoordinateIssue, FrameRangeIssue, AnnotationIssue]
+Issue = Annotated[
+    Union[FileIssue, FrameIssue, CoordinateIssue, FrameRangeIssue, AnnotationIssue],
+    Field(discriminator="type"),
+]
 
 
 class _IssueClient:
@@ -147,7 +151,7 @@ class _IssueClient:
         return self._api_client.get_paged_iterator(
             path=f"/projects/{project_uuid}/issues",
             params=GetIssuesParam(data_unit_id=data_uuid),
-            result_type=Issue,
+            result_type=Issue,  # type: ignore[arg-type]
         )
 
 

--- a/encord/issues/issue_client.py
+++ b/encord/issues/issue_client.py
@@ -122,7 +122,7 @@ class _IssueClient:
         return self._api_client.get_paged_iterator(
             path=f"/projects/{project_uuid}/issues",
             params=GetIssuesParam(data_unit=data_uuid),
-            result_type=Issue,
+            result_type=Issue,  # type: ignore[arg-type]
         )
 
 

--- a/encord/issues/issue_client.py
+++ b/encord/issues/issue_client.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from enum import auto
-from typing import Annotated, Iterable, List, Literal, Optional, Union
+from typing import Iterable, List, Literal, Optional, Union
 from uuid import UUID
 
 from encord.http.v2.api_client import ApiClient
 from encord.orm.analytics import CamelStrEnum
-from encord.orm.base_dto import BaseDTO, Field
+from encord.orm.base_dto import BaseDTO
 
 
 class IssueAnchorType(CamelStrEnum):
@@ -121,10 +121,7 @@ class AnnotationIssue(_BaseIssue):
     annotation_id: str
 
 
-Issue = Annotated[
-    Union[FileIssue, FrameIssue, CoordinateIssue, FrameRangeIssue, AnnotationIssue],
-    Field(discriminator="type"),
-]
+Issue = Union[FileIssue, FrameIssue, CoordinateIssue, FrameRangeIssue, AnnotationIssue]
 
 
 class _IssueClient:

--- a/encord/issues/issue_client.py
+++ b/encord/issues/issue_client.py
@@ -148,7 +148,8 @@ class _IssueClient:
         return self._api_client.get_paged_iterator(
             path=f"/projects/{project_uuid}/issues",
             params=GetIssuesParam(data_unit_id=data_uuid),
-            result_type=Issue,  # type: ignore[arg-type] - Issue is a Pydantic discriminated union; type checker doesn't recognize it as Type[T] but it works correctly at runtime
+            result_type=Issue,  # type: ignore[arg-type]
+            # Issue is a Pydantic discriminated union; type checker doesn't recognize it as Type[T] but it works correctly at runtime
         )
 
 

--- a/encord/issues/issue_client.py
+++ b/encord/issues/issue_client.py
@@ -148,6 +148,9 @@ class _IssueClient:
         )
 
     def get_issues(self, *, project_uuid: UUID, data_uuid: UUID) -> Iterable[Issue]:
+        # Type ignore needed: Issue is Annotated[Union[FileIssue, FrameIssue, ...], Field(discriminator="type")]
+        # which is a Pydantic discriminated union. The type checker sees this as incompatible with Type[T]
+        # expected by get_paged_iterator, but Pydantic handles discriminated unions correctly at runtime.
         return self._api_client.get_paged_iterator(
             path=f"/projects/{project_uuid}/issues",
             params=GetIssuesParam(data_unit_id=data_uuid),

--- a/encord/issues/issue_client.py
+++ b/encord/issues/issue_client.py
@@ -148,9 +148,8 @@ class _IssueClient:
         )
 
     def get_issues(self, *, project_uuid: UUID, data_uuid: UUID) -> Iterable[Issue]:
-        # Type ignore needed: Issue is Annotated[Union[FileIssue, FrameIssue, ...], Field(discriminator="type")]
-        # which is a Pydantic discriminated union. The type checker sees this as incompatible with Type[T]
-        # expected by get_paged_iterator, but Pydantic handles discriminated unions correctly at runtime.
+        # Issue is a Pydantic discriminated union; type checker doesn't recognize it as Type[T]
+        # but it works correctly at runtime
         return self._api_client.get_paged_iterator(
             path=f"/projects/{project_uuid}/issues",
             params=GetIssuesParam(data_unit_id=data_uuid),

--- a/encord/issues/issue_client.py
+++ b/encord/issues/issue_client.py
@@ -89,7 +89,7 @@ class FrameIssue(_BaseIssue):
     frame_index: int
 
 
-class _IssueCoordinate(BaseDTO):
+class IssueCoordinate(BaseDTO):
     x: float
     y: float
 
@@ -97,7 +97,7 @@ class _IssueCoordinate(BaseDTO):
 class CoordinateIssue(_BaseIssue):
     type: Literal[IssueAnchorType.FRAME_COORDINATE] = IssueAnchorType.FRAME_COORDINATE
     frame_index: int
-    coordinate: _IssueCoordinate
+    coordinate: IssueCoordinate
 
 
 class _IssueFrameRange(BaseDTO):

--- a/encord/issues/issue_client.py
+++ b/encord/issues/issue_client.py
@@ -148,12 +148,10 @@ class _IssueClient:
         )
 
     def get_issues(self, *, project_uuid: UUID, data_uuid: UUID) -> Iterable[Issue]:
-        # Issue is a Pydantic discriminated union; type checker doesn't recognize it as Type[T]
-        # but it works correctly at runtime
         return self._api_client.get_paged_iterator(
             path=f"/projects/{project_uuid}/issues",
             params=GetIssuesParam(data_unit_id=data_uuid),
-            result_type=Issue,  # type: ignore[arg-type]
+            result_type=Issue,  # type: ignore[arg-type] - Issue is a Pydantic discriminated union; type checker doesn't recognize it as Type[T] but it works correctly at runtime
         )
 
 

--- a/encord/issues/issue_client.py
+++ b/encord/issues/issue_client.py
@@ -73,7 +73,6 @@ class IssueResolution(BaseDTO):
 
 
 class _BaseIssue(BaseDTO):
-    type: IssueAnchorType
     data_uuid: UUID
     comments: List[IssueComment]
     tags: List[IssueTag]
@@ -121,10 +120,7 @@ class AnnotationIssue(_BaseIssue):
     annotation_id: str
 
 
-Issue = Annotated[
-    Union[FileIssue, FrameIssue, CoordinateIssue, FrameRangeIssue, AnnotationIssue],
-    Field(discriminator="type"),
-]
+Issue = Union[FileIssue, FrameIssue, CoordinateIssue, FrameRangeIssue, AnnotationIssue]
 
 
 class _IssueClient:
@@ -151,7 +147,7 @@ class _IssueClient:
         return self._api_client.get_paged_iterator(
             path=f"/projects/{project_uuid}/issues",
             params=GetIssuesParam(data_unit_id=data_uuid),
-            result_type=Issue,  # type: ignore[arg-type]
+            result_type=Issue,
         )
 
 


### PR DESCRIPTION
## Summary

Adds client-side support for fetching issues (comment threads) associated with tasks/data units. Implements full compatibility with backend PR #6747 that added the GET `/v2/public/projects/{project_uuid}/issues` endpoint.

Example usage:

```py
from encord import EncordUserClient
from encord.issues import FileIssue, FrameRangeIssue, CoordinateIssue, FrameIssue, AnnotationIssue

from encord.workflow.stages.review import ReviewStage

user_client = EncordUserClient.create_with_ssh_private_key(
    ssh_private_key_path='<path_to_ssh_key>',
    domain="https://dev.api.encord.com",
    # domain="https://staging.api.encord.com",
    # domain="https://infra.api.encord.com",
    # domain="http://127.0.0.1:6969"
)

PROJECT_HASH = 'd1d6d6c4-6e0a-404b-b58c-f6e60908c60a'
DATA_HASH = '72d05c96-878c-4414-b7b7-d4ab976b3edf'

project = user_client.get_project(PROJECT_HASH)

# stage = project.workflow.get_stage(name='Annotate 1', type_=AnnotationStage)
stage = project.workflow.get_stage(name='Review 1', type_=ReviewStage)

for task in stage.get_tasks(data_hash=DATA_HASH):
    for issue in task.issues.list():
        print(issue.data_uuid)
        print(issue.comments)
        print(issue.resolution_history)
        print(issue.frame_index)

        match issue:
            case FileIssue():
                pass
            case FrameIssue():
                print(issue.frame_index)
            case FrameRangeIssue():
                print(issue.frame_ranges)
            case CoordinateIssue():
                print(issue.frame_index)
                print(issue.coordinate)
            case AnnotationIssue():
                print(issue.annotation_id)


        # print(issue.model_dump_json(indent=2))


```

## Features

✅ Supports all 5 issue types: FILE, FRAME, COORDINATE, FRAME_RANGE, ANNOTATION  
✅ Resolution history tracking with timestamps and actor emails  
✅ Pagination support via `get_paged_iterator`  
✅ Type-safe Union type for polymorphic issue types  
✅ Comprehensive documentation with usage examples  
✅ Public API for `IssueCoordinate` and `IssueFrameRange` models

## Implementation Details

### New Models

**Issue Types:**
- `FileIssue` - Issues anchored to entire data unit
- `FrameIssue` - Issues anchored to specific frame
- `CoordinateIssue` - Issues anchored to frame coordinates
- `FrameRangeIssue` - Issues anchored to frame ranges
- `AnnotationIssue` - Issues anchored to annotations

**Supporting Models:**
- `IssueResolution` - Resolution event tracking (is_resolved, created_at, actor_email)
- `IssueComment` - Comment with content, author_email, created_at timestamp
- `IssueTag` - Tag name
- `IssueFrameRange` - Frame range representation (start, end) - Public API
- `IssueCoordinate` - Coordinate representation (x, y) - Public API

### API Contract

**Endpoint:** `GET /projects/{project_uuid}/issues`  
**Query Parameters:**
- `data_unit_id` (required): UUID of the data unit
- `page_token` (optional): Pagination token for cursor-based pagination

**Response:** Paginated list of `Issue` objects (Union type)

### Issue Type Definition

```python
Issue = Union[FileIssue, FrameIssue, CoordinateIssue, FrameRangeIssue, AnnotationIssue]
```

Note: Plain Union type used instead of Pydantic discriminated union to avoid conflicts with `mode='before'` validators on the `type` field from `CamelStrEnum`. Pydantic validates by trying each union member sequentially.

### Usage Example

```python
# Get issues for a task
for issue in task.issues.list():
    if isinstance(issue, FileIssue):
        print(f"File issue: {issue.comments[0].content}")
    elif isinstance(issue, FrameIssue):
        print(f"Frame {issue.frame_index} issue")
    
    # Check resolution status
    if issue.resolution_history:
        is_resolved = issue.resolution_history[-1].is_resolved
        print(f"Currently resolved: {is_resolved}")
```

## Compatibility Verification

✅ Query parameter matches backend: `data_unit_id`  
✅ All 5 issue types supported (backend returns all 5)  
✅ Resolution history field included  
✅ Tags type matches backend (List, not Set)  
✅ All response fields match backend schema  
✅ Pagination support with `page_token`

## Code Review

Underwent harsh code review which identified and fixed:
- ✅ Missing `page_token` field (would cause runtime ValueError)
- ✅ Unused imports removed
- ✅ Comprehensive docstring added to `list()` method
- ✅ Backend compatibility verified against PR #6747
- ✅ Made `IssueCoordinate` and `IssueFrameRange` public for API access
- ✅ Removed discriminator to avoid Pydantic validator conflicts

## Testing Recommendations

- [ ] Integration tests against backend endpoint
- [ ] Test deserialization of all 5 issue types
- [ ] Test pagination with various page sizes
- [ ] Test resolution history with multiple transitions
- [ ] Test empty lists (no tags, no resolution history)
- [ ] Test coordinate and frame range access via public models

## Related Work

- Backend PR: encord-team/cord-backend#6747
- Adds GET endpoint for retrieving issues by data unit

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Harsh code review completed
- [x] Documentation added
- [x] No breaking changes
- [x] Backward compatible
- [x] Public API for coordinate and frame range models

🤖 Generated with [Claude Code](https://claude.com/claude-code)