### PR TITLE
feat: PLA-1549 Enable issues SDK in agent stages

### DIFF
--- a/encord/workflow/stages/agent.py
+++ b/encord/workflow/stages/agent.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from encord.common.utils import ensure_list, ensure_uuid_list
 from encord.http.bundle import Bundle
+from encord.issues.issue_client import TaskIssues
 from encord.orm.workflow import WorkflowStageType
 from encord.workflow.common import TasksQueryParams, WorkflowAction, WorkflowStageBase, WorkflowTask
 
@@ -104,6 +105,12 @@ class AgentTask(WorkflowTask):
             bundle=bundle,
         )
 
+    @property
+    def issues(self) -> TaskIssues:
+        """Returns the issue client for the task."""
+        assert self._task_issues
+        return self._task_issues
+
 
 class _AgentTasksQueryParams(TasksQueryParams):
     user_emails: Optional[List[str]] = None
@@ -163,4 +170,9 @@ class AgentStage(WorkflowStageBase):
         for task in self._workflow_client.get_tasks(self.uuid, params, type_=AgentTask):
             task._stage_uuid = self.uuid
             task._workflow_client = self._workflow_client
+            task._task_issues = TaskIssues(
+                api_client=self._workflow_client.api_client,
+                project_uuid=self._workflow_client.project_hash,
+                data_uuid=task.data_hash,
+            )
             yield task

--- a/encord/workflow/stages/agent.py
+++ b/encord/workflow/stages/agent.py
@@ -108,7 +108,8 @@ class AgentTask(WorkflowTask):
     @property
     def issues(self) -> TaskIssues:
         """Returns the issue client for the task."""
-        assert self._task_issues
+        if self._task_issues is None:
+            raise RuntimeError("Task issues are not initialized for this task.")
         return self._task_issues
 
 


### PR DESCRIPTION
# Introduction and Explanation

This PR enables the issues SDK functionality in agent workflow stages by adding the `issues` property to `AgentTask` objects. This allows users to access and manage issues for tasks within agent stages, matching the functionality available in other workflow stage types.

## Changes
- Added `issues` property to `AgentTask` class that returns a `TaskIssues` client
- Initialized `_task_issues` attribute when creating `AgentTask` instances in `AgentStage.get_tasks()`
- Imported `TaskIssues` from `encord.issues.issue_client`

## Usage
```python
agent_stage = workflow.get_agent_stage()
for task in agent_stage.get_tasks():
    # Now you can access issues for agent tasks
    task.issues.list()
    task.issues.create(...)
```

# JIRA

PLA-1549

# Tests

- Existing unit tests continue to pass
- The implementation follows the same pattern as other workflow stage types (e.g., `ReviewTask`, `AnnotateTask`)

# Known issues

None