### PR TITLE
feat: PLA-2422 Add IN_REVIEW project status

### DIFF
--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -190,22 +190,36 @@ class ProjectType(str, Enum):
 class ProjectStatus(str, Enum):
     """Lifecycle status of a Project.
 
-     **Values**:
+    **Values**:
 
-     - **NOT_STARTED:** The project has been created but no work has begun.
-     - **IN_PROGRESS:** The project is active and annotation/review work is ongoing.
-     - **PAUSED:** The project is temporarily paused.
-     - **COMPLETED:** All work on the project has been completed.
-     - **CANCELLED:** The project has been canceled before completion.
+    - **NOT_STARTED:** The project has been created but no work has begun.
+    - **IN_PROGRESS:** The project is active and annotation/review work is ongoing.
+    - **IN_REVIEW:** The project is under review before completion.
+    - **PAUSED:** The project is temporarily paused.
+    - **COMPLETED:** All work on the project has been completed.
+    - **CANCELLED:** The project has been canceled before completion.
     - **ARCHIVED:** The project is archived and no further work is expected.
+    - **UNKNOWN:** An unrecognized status from a newer API version. Please update your SDK.
     """
 
     NOT_STARTED = "notStarted"
     IN_PROGRESS = "inProgress"
+    IN_REVIEW = "inReview"
     PAUSED = "paused"
     COMPLETED = "completed"
     CANCELLED = "cancelled"
     ARCHIVED = "archived"
+
+    UNKNOWN = "_unknown_"
+    """
+    This value will be returned if the Encord platform has a new project status that your SDK
+    version does not recognize yet. Please update your SDK to the latest version.
+    """
+
+    @classmethod
+    def _missing_(cls, value: Any) -> "ProjectStatus":
+        """Return UNKNOWN for any unrecognized project status values."""
+        return cls.UNKNOWN
 
 
 class ProjectCopyOptions(str, Enum):

--- a/tests/orm/test_project.py
+++ b/tests/orm/test_project.py
@@ -1,14 +1,16 @@
-from encord.orm.project import ProjectStatus
 import pytest
 
+from encord.orm.project import ProjectStatus
+
+
 @pytest.mark.parametrize(
-    ('status_str', 'expected_parsed_status'),
+    ("status_str", "expected_parsed_status"),
     [
-        ('inProgress', ProjectStatus.IN_PROGRESS),
+        ("inProgress", ProjectStatus.IN_PROGRESS),
         ("inReview", ProjectStatus.IN_REVIEW),
         ("someNewStatus1", ProjectStatus.UNKNOWN),
         ("someNewStatus2", ProjectStatus.UNKNOWN),
-    ]
+    ],
 )
 def test_project_status_unknown_fallback(
     status_str: str,

--- a/tests/orm/test_project.py
+++ b/tests/orm/test_project.py
@@ -1,0 +1,25 @@
+from encord.orm.project import ProjectStatus
+import pytest
+
+@pytest.mark.parametrize(
+    ('status_str', 'expected_parsed_status'),
+    [
+        ('inProgress', ProjectStatus.IN_PROGRESS),
+        ("inReview", ProjectStatus.IN_REVIEW),
+        ("someNewStatus1", ProjectStatus.UNKNOWN),
+        ("someNewStatus2", ProjectStatus.UNKNOWN),
+    ]
+)
+def test_project_status_unknown_fallback(
+    status_str: str,
+    expected_parsed_status: ProjectStatus,
+) -> None:
+    """Test that unknown project status values are handled gracefully.
+
+    When the backend API introduces new status values that this SDK version
+    doesn't recognize, they should be mapped to ProjectStatus.UNKNOWN instead
+    of raising a ValueError.
+    """
+    # Test direct enum construction with unknown value
+    unknown_status = ProjectStatus(status_str)
+    assert unknown_status == expected_parsed_status


### PR DESCRIPTION
## Summary

Adds support for the new `IN_REVIEW` project status from backend PR https://github.com/encord-team/cord-backend/pull/6909, plus a forward-compatible `UNKNOWN` fallback status to handle future status additions gracefully.