### PR TITLE
feat: [EC-6249] Make `create_backing_folder default` to `False` when creating datasets

### DIFF
--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -300,9 +300,9 @@ class EncordUserClient:
             dataset_title (str): Title of the dataset.
             dataset_type (StorageLocation): Type of storage location where the data will be stored.
             dataset_description (Optional[str]): Optional description of the dataset.
-            create_backing_folder (bool): Whether to create a mirrored backing Folder. If True,
-                the Folder and Dataset are synced. Recommended to set False for complex
-                or large-scale projects.
+            create_backing_folder (bool): Whether to create a mirrored backing Folder. Defaults to `False`.
+                If set to `True`, the Folder and Dataset are synced. This is not recommended
+                for complex or large-scale projects.
 
         Returns:
             CreateDatasetResponse:

--- a/encord/user_client.py
+++ b/encord/user_client.py
@@ -293,14 +293,14 @@ class EncordUserClient:
         dataset_title: str,
         dataset_type: StorageLocation,
         dataset_description: Optional[str] = None,
-        create_backing_folder: bool = True,
+        create_backing_folder: bool = False,
     ) -> CreateDatasetResponse:
         """
         Args:
             dataset_title (str): Title of the dataset.
             dataset_type (StorageLocation): Type of storage location where the data will be stored.
             dataset_description (Optional[str]): Optional description of the dataset.
-            create_backing_folder (bool): Whether to create a mirrored backing Folder. If True (default),
+            create_backing_folder (bool): Whether to create a mirrored backing Folder. If True,
                 the Folder and Dataset are synced. Recommended to set False for complex
                 or large-scale projects.
 


### PR DESCRIPTION
# Introduction and Explanation
Make `create_backing_folder default` to `False` when creating datasets

# JIRA
[EC-6249](https://linear.app/encord/issue/EC-6249)
