### PR TITLE
feat: FDE-23 New classification only export endpoint

### DIFF
--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -600,3 +600,59 @@ class ProjectUserResponse(BaseDTO):
 
     user_email: str
     user_role: ProjectUserRole
+
+
+# --- Bulk classifications endpoint DTOs ---
+
+
+class BulkClassificationsPayload(BaseDTO):
+    """Request payload for ``POST /projects/{uuid}/label-rows/classifications``."""
+
+    label_uuids: List[str]
+    branch_name: str = "main"
+
+
+class ClassificationAnswerObject(BaseDTO):
+    """Nested answer within a :class:`ClassificationAnswerEntry`."""
+
+    name: str
+    value: str
+    answers: Any  # list[AnswersAnswer] | str | float
+    feature_hash: str
+    manual_annotation: bool
+
+
+class ClassificationAnswerEntry(BaseDTO):
+    """Single classification answer returned by the bulk classifications endpoint.
+
+    Matches the ``ClassificationAnswer`` shape produced by the legacy
+    ``initialise_labels`` SDK path.
+    """
+
+    classification_hash: str
+    feature_hash: Optional[str] = None
+    classifications: List[ClassificationAnswerObject]
+    range: Optional[List[Tuple[int, int]]] = None
+    created_at: Optional[str] = None
+    created_by: Optional[str] = None
+    last_edited_at: Optional[str] = None
+    last_edited_by: Optional[str] = None
+    manual_annotation: Optional[bool] = None
+
+
+class LabelClassificationsEntry(BaseDTO):
+    """One label row's classification data in the bulk response."""
+
+    label_uuid: UUID
+    data_uuid: UUID
+    data_title: Optional[str] = None
+    branch_name: str = "main"
+    classification_answers: Dict[str, ClassificationAnswerEntry] = {}
+    export_uuid: Optional[UUID] = None
+    exported_at: Optional[datetime.datetime] = None
+
+
+class BulkClassificationsResponse(BaseDTO):
+    """Response from ``POST /projects/{uuid}/label-rows/classifications``."""
+
+    labels: List[LabelClassificationsEntry]

--- a/encord/project.py
+++ b/encord/project.py
@@ -50,8 +50,11 @@ from encord.orm.label_row import (
 )
 from encord.orm.project import (
     AddProjectIssueTagsPayload,
+    BulkClassificationsPayload,
+    BulkClassificationsResponse,
     CopyDatasetOptions,
     CopyLabelsOptions,
+    LabelClassificationsEntry,
     ProjectDataset,
     ProjectDTO,
     ProjectStatus,
@@ -286,6 +289,43 @@ class Project:
             LabelRowV2(label_row_metadata, self._client, self._ontology) for label_row_metadata in label_row_metadatas
         ]
         return label_rows
+
+    def get_label_classifications(
+        self,
+        label_uuids: List[Union[str, UUID]],
+        branch_name: str = "main",
+        batch_size: int = 500,
+    ) -> List[LabelClassificationsEntry]:
+        """Fast bulk fetch of classification answers only.
+
+        Calls the ``POST /projects/{uuid}/label-rows/classifications`` endpoint
+        which skips the full enrichment pipeline (no objects, no data-units, no
+        signed URLs). Returns classification answers in the same shape as the
+        legacy ``initialise_labels`` path so existing SDK types can consume them.
+
+        Args:
+            label_uuids: Label row UUIDs to fetch classifications for.
+                Obtain these from :meth:`list_label_rows_v2` (``row.label_hash``).
+            branch_name: Label branch to read from (default ``"main"``).
+            batch_size: Number of labels per server request (max 1000).
+
+        Returns:
+            A flat list of :class:`~encord.orm.project.LabelClassificationsEntry`,
+            one per label row. Each entry contains ``classification_answers``
+            keyed by classification hash.
+        """
+        uuid_strs = [str(u) for u in label_uuids]
+        results: List[LabelClassificationsEntry] = []
+        for i in range(0, len(uuid_strs), batch_size):
+            batch = uuid_strs[i : i + batch_size]
+            response = self._api_client.post(
+                f"projects/{self.project_hash}/label-rows/classifications",
+                params=None,
+                payload=BulkClassificationsPayload(label_uuids=batch, branch_name=branch_name),
+                result_type=BulkClassificationsResponse,
+            )
+            results.extend(response.labels)
+        return results
 
     def add_users(self, user_emails: List[str], user_role: ProjectUserRole) -> List[ProjectUser]:
         """Add users to the project.

--- a/encord/project.py
+++ b/encord/project.py
@@ -295,13 +295,8 @@ class Project:
         label_uuids: List[Union[str, UUID]],
         branch_name: str = "main",
         batch_size: int = 500,
-    ) -> List[LabelClassificationsEntry]:
+    ) -> Iterable[LabelClassificationsEntry]:
         """Fast bulk fetch of classification answers only.
-
-        Calls the ``POST /projects/{uuid}/label-rows/classifications`` endpoint
-        which skips the full enrichment pipeline (no objects, no data-units, no
-        signed URLs). Returns classification answers in the same shape as the
-        legacy ``initialise_labels`` path so existing SDK types can consume them.
 
         Args:
             label_uuids: Label row UUIDs to fetch classifications for.
@@ -310,12 +305,11 @@ class Project:
             batch_size: Number of labels per server request (max 1000).
 
         Returns:
-            A flat list of :class:`~encord.orm.project.LabelClassificationsEntry`,
+            An iterable of :class:`~encord.orm.project.LabelClassificationsEntry`,
             one per label row. Each entry contains ``classification_answers``
             keyed by classification hash.
         """
         uuid_strs = [str(u) for u in label_uuids]
-        results: List[LabelClassificationsEntry] = []
         for i in range(0, len(uuid_strs), batch_size):
             batch = uuid_strs[i : i + batch_size]
             response = self._api_client.post(
@@ -324,8 +318,7 @@ class Project:
                 payload=BulkClassificationsPayload(label_uuids=batch, branch_name=branch_name),
                 result_type=BulkClassificationsResponse,
             )
-            results.extend(response.labels)
-        return results
+            yield from response.labels
 
     def add_users(self, user_emails: List[str], user_role: ProjectUserRole) -> List[ProjectUser]:
         """Add users to the project.

--- a/tests/test_label_classifications.py
+++ b/tests/test_label_classifications.py
@@ -1,5 +1,5 @@
 import uuid
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from encord.http.v2.api_client import ApiClient
 from encord.orm.project import (

--- a/tests/test_label_classifications.py
+++ b/tests/test_label_classifications.py
@@ -26,7 +26,7 @@ def test_single_batch(api_post: MagicMock, project: Project) -> None:
     api_post.return_value = _make_response(entry)
 
     label_uuids = [uuid.uuid4() for _ in range(3)]
-    result = project.get_label_classifications(label_uuids)
+    result = list(project.get_label_classifications(label_uuids))
 
     api_post.assert_called_once()
     _, kwargs = api_post.call_args
@@ -46,7 +46,7 @@ def test_multiple_batches(api_post: MagicMock, project: Project) -> None:
     api_post.side_effect = [_make_response(entry_a), _make_response(entry_b)]
 
     label_uuids = [uuid.uuid4() for _ in range(5)]
-    result = project.get_label_classifications(label_uuids, batch_size=3)
+    result = list(project.get_label_classifications(label_uuids, batch_size=3))
 
     assert api_post.call_count == 2
 
@@ -62,7 +62,7 @@ def test_multiple_batches(api_post: MagicMock, project: Project) -> None:
 def test_custom_branch_name(api_post: MagicMock, project: Project) -> None:
     api_post.return_value = _make_response(_make_entry())
 
-    project.get_label_classifications([uuid.uuid4()], branch_name="my-branch")
+    list(project.get_label_classifications([uuid.uuid4()], branch_name="my-branch"))
 
     payload = api_post.call_args[1]["payload"]
     assert payload.branch_name == "my-branch"
@@ -70,7 +70,7 @@ def test_custom_branch_name(api_post: MagicMock, project: Project) -> None:
 
 @patch.object(ApiClient, "post")
 def test_empty_input(api_post: MagicMock, project: Project) -> None:
-    result = project.get_label_classifications([])
+    result = list(project.get_label_classifications([]))
 
     api_post.assert_not_called()
     assert result == []

--- a/tests/test_label_classifications.py
+++ b/tests/test_label_classifications.py
@@ -1,0 +1,76 @@
+import uuid
+from unittest.mock import MagicMock, call, patch
+
+from encord.http.v2.api_client import ApiClient
+from encord.orm.project import (
+    BulkClassificationsPayload,
+    BulkClassificationsResponse,
+    LabelClassificationsEntry,
+)
+from encord.project import Project
+
+
+def _make_entry(**overrides) -> LabelClassificationsEntry:
+    defaults = dict(label_uuid=uuid.uuid4(), data_uuid=uuid.uuid4())
+    defaults.update(overrides)
+    return LabelClassificationsEntry(**defaults)
+
+
+def _make_response(*entries: LabelClassificationsEntry) -> BulkClassificationsResponse:
+    return BulkClassificationsResponse(labels=list(entries))
+
+
+@patch.object(ApiClient, "post")
+def test_single_batch(api_post: MagicMock, project: Project) -> None:
+    entry = _make_entry()
+    api_post.return_value = _make_response(entry)
+
+    label_uuids = [uuid.uuid4() for _ in range(3)]
+    result = project.get_label_classifications(label_uuids)
+
+    api_post.assert_called_once()
+    _, kwargs = api_post.call_args
+    assert kwargs["payload"] == BulkClassificationsPayload(
+        label_uuids=[str(u) for u in label_uuids],
+        branch_name="main",
+    )
+    assert kwargs["result_type"] is BulkClassificationsResponse
+    assert f"projects/{project.project_hash}/label-rows/classifications" in api_post.call_args.args[0]
+    assert result == [entry]
+
+
+@patch.object(ApiClient, "post")
+def test_multiple_batches(api_post: MagicMock, project: Project) -> None:
+    entry_a = _make_entry()
+    entry_b = _make_entry()
+    api_post.side_effect = [_make_response(entry_a), _make_response(entry_b)]
+
+    label_uuids = [uuid.uuid4() for _ in range(5)]
+    result = project.get_label_classifications(label_uuids, batch_size=3)
+
+    assert api_post.call_count == 2
+
+    first_payload = api_post.call_args_list[0][1]["payload"]
+    second_payload = api_post.call_args_list[1][1]["payload"]
+    assert first_payload.label_uuids == [str(u) for u in label_uuids[:3]]
+    assert second_payload.label_uuids == [str(u) for u in label_uuids[3:]]
+
+    assert result == [entry_a, entry_b]
+
+
+@patch.object(ApiClient, "post")
+def test_custom_branch_name(api_post: MagicMock, project: Project) -> None:
+    api_post.return_value = _make_response(_make_entry())
+
+    project.get_label_classifications([uuid.uuid4()], branch_name="my-branch")
+
+    payload = api_post.call_args[1]["payload"]
+    assert payload.branch_name == "my-branch"
+
+
+@patch.object(ApiClient, "post")
+def test_empty_input(api_post: MagicMock, project: Project) -> None:
+    result = project.get_label_classifications([])
+
+    api_post.assert_not_called()
+    assert result == []


### PR DESCRIPTION
# Introduction and Explanation
Adding support for the new classification export public endpoint for a specific use case when customers want to export just classifications from a project. Many of the robotics customers just get videos captioned and want to export them. The volume is quite high. Example: 1x wants to be able to export 600k tasks a day at one point and current SDK will take around 400 minutes (~7 hours) for the same. This new method is 17x faster as it doesn't do any other label row enrichments.

# Linear

Fixes https://linear.app/encord/issue/FDE-23/sdk-function-for-exporting-only-classifications


# Documentation
_There should be enough internal documentation for a product owner to write customer-facing documentation or a separate PR linked if writing the customer documentation directly. Link all that are relevant below_.
- Internal: _notion link_
- Customer docs PR: _link_
- OpenAPI/SDK
    - Generated docs: _link to example if possible_
    - Command to generate: _here_

# Tests

_Make a quick statement and post any relevant links of CI / test results. If the testing infrastructure isn’t yet in-place, note that instead._

- _What are the critical unit tests?_
- _Explain the Integration Tests such that it’s clear Correctness is satisfied. Link to test results if possible._

# Known issues

_If there are any known issues with the solution, make a statement about what they are and why they are Ok to leave unsolved for now. Make tickets for the known issues linked to the original ticket linked above_
