### PR TITLE
feat: [COR-80] add Shape.ELLIPSE support

### DIFF
--- a/encord/objects/common.py
+++ b/encord/objects/common.py
@@ -56,6 +56,7 @@ class Shape(StringEnum):
         cuboid_2d
         segmentation
         circle
+        ellipse
     """
 
     BOUNDING_BOX = "bounding_box"
@@ -70,6 +71,7 @@ class Shape(StringEnum):
     CUBOID = "cuboid"
     CUBOID_2D = "cuboid_2d"
     CIRCLE = "circle"
+    ELLIPSE = "ellipse"
     SEGMENTATION = "segmentation"
 
 

--- a/encord/objects/coordinates.py
+++ b/encord/objects/coordinates.py
@@ -147,6 +147,14 @@ class RotatableBoundingBoxCoordinates:
         }
 
 
+# TODO: rename `CircleCoordinates` -> `EllipseCoordinates`. The class already
+# carries `stretch` and `theta`, so it represents an oriented ellipse — a true
+# circle is just the special case `stretch=1, theta=0`. With `Shape.ELLIPSE`
+# now also mapping to this same coords class, the "Circle" name is misleading.
+# Safe to rename in a follow-up: the wire format is the `circle: {...}` field
+# (untouched), so existing labels parse identically. Provide
+# `CircleCoordinates = EllipseCoordinates` as a backwards-compat alias so
+# downstream SDK consumers don't break on the rename.
 @dataclass(frozen=True)
 class CircleCoordinates:
     """Represents circle coordinates, where values are normalized relative to image size.
@@ -756,6 +764,7 @@ ACCEPTABLE_COORDINATES_FOR_ONTOLOGY_ITEMS: Dict[Shape, List[Type[Coordinates]]] 
     Shape.BOUNDING_BOX: [BoundingBoxCoordinates],
     Shape.ROTATABLE_BOUNDING_BOX: [RotatableBoundingBoxCoordinates],
     Shape.CIRCLE: [CircleCoordinates],
+    Shape.ELLIPSE: [CircleCoordinates],
     Shape.POINT: [PointCoordinate, PointCoordinate3D],
     Shape.POLYGON: [PolygonCoordinates],
     Shape.POLYLINE: [PolylineCoordinates],
@@ -774,42 +783,52 @@ def add_coordinates_to_frame_object_dict(
     base_frame_object: BaseFrameObject,
     width: int,
     height: int,
+    shape: Optional[Shape] = None,
 ) -> FrameObject:
+    """Attach geometry to a frame object.
+
+    ``shape`` must be passed for shapes whose coordinates class is shared with
+    another shape — currently only ``Shape.ELLIPSE`` (uses ``CircleCoordinates``).
+    If omitted, the shape is inferred from the coordinates type, which fails to
+    distinguish Circle from Ellipse.
+    """
     result: Dict[str, Any] = dict(base_frame_object)
 
     if isinstance(coordinates, BoundingBoxCoordinates):
         result["boundingBox"] = coordinates.to_dict()
-        result["shape"] = Shape.BOUNDING_BOX.value
+        result["shape"] = (shape or Shape.BOUNDING_BOX).value
     elif isinstance(coordinates, RotatableBoundingBoxCoordinates):
         result["rotatableBoundingBox"] = coordinates.to_dict()
-        result["shape"] = Shape.ROTATABLE_BOUNDING_BOX.value
+        result["shape"] = (shape or Shape.ROTATABLE_BOUNDING_BOX).value
     elif isinstance(coordinates, PolygonCoordinates):
         result["polygon"] = coordinates.to_dict()
         result["polygons"] = coordinates.to_dict(PolygonCoordsToDict.multiple_polygons)
-        result["shape"] = Shape.POLYGON.value
+        result["shape"] = (shape or Shape.POLYGON).value
     elif isinstance(coordinates, PolylineCoordinates):
         result["polyline"] = coordinates.to_dict()
-        result["shape"] = Shape.POLYLINE.value
+        result["shape"] = (shape or Shape.POLYLINE).value
     elif isinstance(coordinates, (PointCoordinate, PointCoordinate3D)):
         result["point"] = coordinates.to_dict()
-        result["shape"] = Shape.POINT.value
+        result["shape"] = (shape or Shape.POINT).value
     elif isinstance(coordinates, BitmaskCoordinates):
         if not (height == coordinates._encoded_bitmask.height and width == coordinates._encoded_bitmask.width):
             raise ValueError("Bitmask dimensions don't match the media dimensions")
         result["bitmask"] = coordinates.to_dict()
-        result["shape"] = Shape.BITMASK.value
+        result["shape"] = (shape or Shape.BITMASK).value
     elif isinstance(coordinates, SkeletonCoordinates):
         result["skeleton"] = coordinates.to_dict()
-        result["shape"] = Shape.SKELETON.value
+        result["shape"] = (shape or Shape.SKELETON).value
     elif isinstance(coordinates, CuboidCoordinates):
         result["cuboid"] = coordinates.to_dict()
-        result["shape"] = Shape.CUBOID.value
+        result["shape"] = (shape or Shape.CUBOID).value
     elif isinstance(coordinates, (Cuboid2DPerspectiveCoordinates, Cuboid2DIsometricCoordinates)):
         result["cuboid_2d"] = coordinates.to_dict()
-        result["shape"] = Shape.CUBOID_2D.value
+        result["shape"] = (shape or Shape.CUBOID_2D).value
     elif isinstance(coordinates, CircleCoordinates):
         result["circle"] = coordinates.to_dict()
-        result["shape"] = Shape.CIRCLE.value
+        # Circle and Ellipse share CircleCoordinates — caller must pass shape
+        # to disambiguate. Default to CIRCLE for legacy callers.
+        result["shape"] = (shape or Shape.CIRCLE).value
     else:
         raise NotImplementedError(f"adding coordinates for this type not yet implemented {type(coordinates)}")
 
@@ -837,7 +856,8 @@ def get_coordinates_from_frame_object_dict(frame_object_dict: FrameObject) -> Co
             raise ValueError(f"Invalid point coordinates in {frame_object_dict}")
     elif frame_object_dict["shape"] == Shape.POLYLINE:
         return PolylineCoordinates.from_dict(frame_object_dict)
-    elif frame_object_dict["shape"] == Shape.CIRCLE:
+    elif frame_object_dict["shape"] == Shape.CIRCLE or frame_object_dict["shape"] == Shape.ELLIPSE:
+        # Ellipse shares Circle's wire payload — same parser.
         return CircleCoordinates.from_dict(frame_object_dict)
     elif "skeleton" in frame_object_dict:
 

--- a/encord/objects/spaces/image_space.py
+++ b/encord/objects/spaces/image_space.py
@@ -259,6 +259,7 @@ class ImageSpace(Space[_GeometricObjectAnnotation, _GlobalClassificationAnnotati
             base_frame_object=frame_object_dict,
             width=self._width,
             height=self._height,
+            shape=ontology_object.shape,
         )
 
         return frame_object_dict

--- a/encord/objects/spaces/multiframe_space/multiframe_space.py
+++ b/encord/objects/spaces/multiframe_space/multiframe_space.py
@@ -833,6 +833,7 @@ class MultiFrameSpace(Space[_GeometricFrameObjectAnnotation, _FrameClassificatio
             base_frame_object=base_frame_object,
             width=width,
             height=height,
+            shape=ontology_object.shape,
         )
 
         return frame_object

--- a/encord/objects/types.py
+++ b/encord/objects/types.py
@@ -189,6 +189,10 @@ class CircleFrameObject(BaseFrameObject, CircleFrameCoordinatesDict):
     shape: Literal[Shape.CIRCLE]
 
 
+class EllipseFrameObject(BaseFrameObject, CircleFrameCoordinatesDict):
+    shape: Literal[Shape.ELLIPSE]
+
+
 FrameObject = Union[
     BoundingBoxFrameObject,
     RotatableBoundingBoxFrameObject,
@@ -198,6 +202,7 @@ FrameObject = Union[
     Cuboid2DFrameObject,
     SegmentationObject,
     CircleFrameObject,
+    EllipseFrameObject,
 ]
 """ Frame object in the label blob. Contains shape data, and is differentiated by the 'shape' field. """
 

--- a/tests/objects/data/all_types_ontology_structure.py
+++ b/tests/objects/data/all_types_ontology_structure.py
@@ -452,6 +452,15 @@ all_types_structure = OntologyStructure(
             archived=False,
             attributes=[],
         ),
+        Object(
+            uid=14,
+            name="Ellipse",
+            color="#FFA500",
+            shape=Shape.ELLIPSE,
+            feature_node_hash="ellipseFeatureNodeHash",
+            archived=False,
+            attributes=[],
+        ),
     ],
     classifications=[
         RADIO_CLASSIFICATION,

--- a/tests/objects/test_ellipse_coordinates.py
+++ b/tests/objects/test_ellipse_coordinates.py
@@ -1,0 +1,116 @@
+"""Ellipse coordinates — same wire shape as Circle.
+
+Ellipse reuses ``CircleCoordinates``. These tests verify the enum entry, the
+ontology registry mapping, and the round-trip serialisation under an
+``ELLIPSE``-shaped ontology object.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from encord.exceptions import LabelRowError
+from encord.objects import LabelRowV2, Object, ObjectInstance
+from encord.objects.common import Shape
+from encord.objects.coordinates import (
+    ACCEPTABLE_COORDINATES_FOR_ONTOLOGY_ITEMS,
+    BoundingBoxCoordinates,
+    CircleCoordinates,
+)
+from tests.objects.common import BASE_LABEL_ROW_METADATA
+from tests.objects.data.all_types_ontology_structure import all_types_structure
+from tests.objects.data.empty_image_group import empty_image_group_labels
+from tests.objects.objects_test_utils import validate_label_row_serialisation
+
+ELLIPSE_ONTOLOGY_ITEM: Object = all_types_structure.get_child_by_hash("ellipseFeatureNodeHash", Object)
+
+
+def test_ellipse_enum_value() -> None:
+    assert Shape.ELLIPSE.value == "ellipse"
+
+
+def test_ellipse_in_acceptable_coordinates_registry() -> None:
+    """Ellipse must accept CircleCoordinates — same wire payload as Circle."""
+    assert Shape.ELLIPSE in ACCEPTABLE_COORDINATES_FOR_ONTOLOGY_ITEMS
+    assert CircleCoordinates in ACCEPTABLE_COORDINATES_FOR_ONTOLOGY_ITEMS[Shape.ELLIPSE]
+
+
+def _make_label_row(all_types_ontology) -> LabelRowV2:
+    label_row = LabelRowV2(BASE_LABEL_ROW_METADATA, Mock(), all_types_ontology)
+    label_row.from_labels_dict(empty_image_group_labels)
+    return label_row
+
+
+def test_add_ellipse_instance_to_label_row(all_types_ontology) -> None:
+    label_row = _make_label_row(all_types_ontology)
+
+    # Stretch and theta are the whole point of Ellipse — exercise both.
+    coords = CircleCoordinates(center_x=0.5, center_y=0.5, radius=0.2, stretch=0.5, theta=30.0)
+    instance = ObjectInstance(ELLIPSE_ONTOLOGY_ITEM)
+    instance.set_for_frames(coordinates=coords, frames=1)
+    label_row.add_object_instance(instance)
+
+    objects = label_row.get_object_instances()
+    assert len(objects) == 1
+    assert objects[0].ontology_item.shape == Shape.ELLIPSE
+    validate_label_row_serialisation(label_row)
+
+
+def test_ellipse_coordinates_survive_serialisation_roundtrip(all_types_ontology) -> None:
+    label_row = _make_label_row(all_types_ontology)
+
+    coords = CircleCoordinates(center_x=0.25, center_y=0.75, radius=0.08, stretch=0.7, theta=15.0)
+    instance = ObjectInstance(ELLIPSE_ONTOLOGY_ITEM)
+    instance.set_for_frames(coordinates=coords, frames=0)
+    label_row.add_object_instance(instance)
+
+    validate_label_row_serialisation(label_row)
+
+    recovered = label_row.get_object_instances()[0].get_annotation(frame=0)
+    assert recovered is not None
+    assert recovered.coordinates == coords
+
+
+def test_ellipse_wire_format_tags_shape_as_ellipse(all_types_ontology) -> None:
+    """The exported label dict must carry shape="ellipse" — not "circle" —
+    even though the geometry payload still lives under the "circle" key.
+    """
+    label_row = _make_label_row(all_types_ontology)
+
+    coords = CircleCoordinates(center_x=0.5, center_y=0.5, radius=0.1, stretch=0.5, theta=45.0)
+    instance = ObjectInstance(ELLIPSE_ONTOLOGY_ITEM)
+    instance.set_for_frames(coordinates=coords, frames=0)
+    label_row.add_object_instance(instance)
+
+    blob = label_row.to_encord_dict()
+    assert blob is not None
+
+    # The blob nests "objects" deep under data_units → labels → frame keys.
+    # Walk the whole tree generically so the test isn't tied to the exact
+    # shape (it's evolved across SDK versions).
+    ellipse_objects: list[dict] = []
+
+    def _walk(node):
+        if isinstance(node, dict):
+            if node.get("objectHash") == instance.object_hash and "shape" in node:
+                ellipse_objects.append(node)
+            for v in node.values():
+                _walk(v)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+
+    _walk(blob)
+
+    assert len(ellipse_objects) >= 1, f"Expected at least one ellipse object; got {ellipse_objects}"
+    for obj in ellipse_objects:
+        assert obj["shape"] == "ellipse"
+        # Geometry still under "circle" key — that's Ellipse's storage choice.
+        assert obj.get("circle") == coords.to_dict()
+
+
+def test_wrong_coordinate_type_rejected_for_ellipse(all_types_ontology) -> None:
+    instance = ObjectInstance(ELLIPSE_ONTOLOGY_ITEM)
+    box_coords = BoundingBoxCoordinates(height=0.1, width=0.1, top_left_x=0.0, top_left_y=0.0)
+    with pytest.raises(LabelRowError):
+        instance.set_for_frames(coordinates=box_coords, frames=0)


### PR DESCRIPTION
# Introduction and Explanation

Adds `Shape.ELLIPSE` to the SDK so customers can read and write ellipse annotations programmatically. Ellipse reuses Circle's wire payload — a `circle: {x, y, r, stretch, theta}` field with `shape: "ellipse"` — because `CircleCoordinates` already carries `stretch` and `theta` (a true circle is just the `stretch=1, theta=0` special case). So this PR is mostly enum-and-registry plumbing, with one signature tweak on `add_coordinates_to_frame_object_dict` so it can disambiguate Circle from Ellipse.

Pairs with:
- Backend ellipse PR — [encord-team/cord-backend#7960](https://github.com/encord-team/cord-backend/pull/7960) (COR-78)
- Frontend ellipse PR — [encord-team/cord-frontend#11519](https://github.com/encord-team/cord-frontend/pull/11519) (COR-79)

Changes:
- `Shape.ELLIPSE = "ellipse"` added to `encord/objects/common.py`
- `EllipseFrameObject` TypedDict in `encord/objects/types.py` — same payload as `CircleFrameObject`, only the `shape` discriminator differs; added to the `FrameObject` union
- `Shape.ELLIPSE: [CircleCoordinates]` registered in `ACCEPTABLE_COORDINATES_FOR_ONTOLOGY_ITEMS` so the ontology validator accepts `CircleCoordinates` for either shape
- `add_coordinates_to_frame_object_dict()` gained an optional `shape: Shape | None = None` param so callers with a `CircleCoordinates` can tag the wire payload as either `CIRCLE` or `ELLIPSE`. Backwards-compatible — defaults to inferring from the coords class (CIRCLE for `CircleCoordinates`).
- `ImageSpace` / `MultiFrameSpace` pass `ontology_object.shape` to `add_coordinates_to_frame_object_dict` so the wire payload picks up the right discriminator for ellipse instances
- `get_coordinates_from_frame_object_dict` handles `Shape.ELLIPSE` in the same branch as `Shape.CIRCLE` (shared parser)
- TODO comment on `CircleCoordinates` noting it should be renamed to `EllipseCoordinates` in a follow-up — semantically more accurate since the class already represents an oriented ellipse. Will keep `CircleCoordinates = EllipseCoordinates` as a backwards-compat alias when we do it.

# JIRA

COR-80

# Documentation

- Internal: TODO link Notion page if/when one exists
- Customer docs PR: TODO — once we ship a PyPI release, customer docs should describe `Shape.ELLIPSE`, mention that it reuses `CircleCoordinates`, and note that the backend requires the matching ellipse support (release coordination below).
- OpenAPI/SDK: hand-written; no codegen for this SDK.

# Tests

- **New unit tests** — `tests/objects/test_ellipse_coordinates.py`, 6 tests:
  - Shape enum value
  - Ellipse in `ACCEPTABLE_COORDINATES_FOR_ONTOLOGY_ITEMS` registry
  - Instance creation against an `Shape.ELLIPSE` ontology object
  - Serialisation roundtrip preserves `stretch` and `theta`
  - Wire format check (`shape: "ellipse"`, geometry under `circle:` key)
  - Wrong-coord-type rejection (BoundingBoxCoordinates against an ellipse ontology raises `LabelRowError`)
- **Existing tests untouched** — full `tests/objects/` suite passes (354 tests, run locally with `uv run pytest tests/objects/`)
- **End-to-end manual test** — ran a full CRUD cycle against a local backend running the matching backend PR:
  - Create an ellipse annotation via `ObjectInstance(ellipse_ontology) + CircleCoordinates(stretch=0.45, theta=35°)`, save
  - Read it back — `stretch` and `theta` preserved exactly
  - Update radius 2.5× — re-read still preserves stretch/theta
  - Delete — confirmed removed via fresh fetch
- Test fixture `tests/objects/data/all_types_ontology_structure.py` now contains an Ellipse object so the integration tests can exercise it.

# Release coordination

**Do NOT cut a PyPI release until the backend ellipse support is in prod.** Customers on the default prod cloud will get 422s if they try `Shape.ELLIPSE` against a backend that doesn't accept the value yet. Master can hold the merged code indefinitely; the version bump + PyPI publish is the gating step. Suggested order:

1. Backend PR ships → deploy to dev → staging → prod
2. (this PR can merge any time after backend is in dev so internal users can test against local/dev)
3. Once backend is in prod, bump `version` in `pyproject.toml` and release. Release notes should note "Requires backend version X.Y.Z+".

# Known issues

- **`CircleCoordinates` is misnamed** for the ellipse case — it actually represents an oriented ellipse (carries `stretch` + `theta`). TODO comment in `encord/objects/coordinates.py` documents the rename plan. Future PR: rename to `EllipseCoordinates` and add `CircleCoordinates = EllipseCoordinates` backwards-compat alias.
- **No `ObjectShape` enum entry**. The lower-level `encord/project_ontology/object_type.py::ObjectShape` enum doesn't include Circle either — that enum is used in legacy ontology creation flows and is intentionally narrower. If we ever want to create an ellipse ontology via that path, we'd add `ELLIPSE` there too. Out of scope for this PR.