### PR TITLE
docs: COR-102 - Interpolation for circle & ellipse objects [SDK]

### DIFF
--- a/encord/project.py
+++ b/encord/project.py
@@ -578,7 +578,7 @@ class Project:
     ):
         """Run object interpolation algorithm on project labels (requires an editor ontology and feature uids).
 
-        Interpolation is supported for bounding box, polygon, and keypoint.
+        Interpolation is supported for bounding box, polygon, keypoint, circle and ellipse.
 
         Args:
             key_frames: Labels for frames to be interpolated. Key frames are consumed in the form::


### PR DESCRIPTION
**Linear:** [COR-102](https://linear.app/encord/issue/COR-102/circleellipse-tracking-interpolation)

## Summary

One-line docstring update on `Project.object_interpolation` to mention **circle** and **ellipse** as supported shapes.

## Why doc-only

`Project.object_interpolation` is shape-agnostic — it forwards `key_frames` + `object_hashes` straight to the backend's public-interpolation endpoint, which dispatches per-shape. The companion `cord-backend` PR (`feat: COR-102 - Interpolation for circle & ellipse objects`) adds the dispatch; no SDK code change is needed.

SDK label-model support for `Shape.ELLIPSE` / `EllipseCoordinates` (the `encord.objects` type system) is unrelated and out of scope.

## Test plan

- [x] `ruff check encord/project.py` — passes.
- Pre-existing `ruff format --check` finding at `encord/project.py:227` (multi-line `assert`) is unrelated and intentionally untouched.
