### PR TITLE
feat: add entity user management methods DS-89

### DIFF
--- a/encord/client.py
+++ b/encord/client.py
@@ -60,6 +60,7 @@ from encord.orm.bearer_request import BearerTokenResponse
 from encord.orm.cloud_integration import CloudIntegration, GetCloudIntegrationsResponse
 from encord.orm.dataset import (
     DEFAULT_DATASET_ACCESS_SETTINGS,
+    AddDatasetUsersPayload,
     AddPrivateDataResponse,
     DataLinkDuplicatesBehavior,
     DataRow,
@@ -69,15 +70,18 @@ from encord.orm.dataset import (
     DatasetDataLongPolling,
     DatasetLinkItems,
     DatasetUser,
+    DatasetUserResponse,
     DatasetUserRole,
     DatasetUsers,
     DicomSeries,
+    GetDatasetUsersPayload,
     Image,
     ImageGroup,
     ImageGroupOCR,
     Images,
     LongPollingStatus,
     ReEncodeVideoTask,
+    RemoveDatasetUsersPayload,
     Video,
 )
 from encord.orm.dataset import Dataset as OrmDataset
@@ -113,6 +117,7 @@ from encord.orm.project import (
     ProjectStatus,
     ProjectUserResponse,
     ProjectUsers,
+    RemoveProjectUsersPayload,
     SetProjectStatusPayload,
     TaskPriorityParams,
 )
@@ -272,10 +277,30 @@ class EncordClientDataset(EncordClient):
 
     def add_users(self, user_emails: List[str], user_role: DatasetUserRole) -> List[DatasetUser]:
         """This function is documented in :meth:`encord.project.Dataset.add_users`."""
-        payload = {"user_emails": user_emails, "user_role": user_role}
-        users = self._querier.basic_setter(DatasetUsers, self._querier.resource_id, payload=payload)
+        page = self._api_client.post(
+            f"datasets/{self._querier.resource_id}/users",
+            params=None,
+            payload=AddDatasetUsersPayload(user_emails=user_emails, user_role=user_role),
+            result_type=Page[DatasetUserResponse],
+        )
 
-        return [DatasetUser.from_dict(user) for user in users]
+        return [
+            DatasetUser(user_email=user.user_email, user_role=user.user_role, dataset_hash=str(user.dataset_uuid))
+            for user in page.results
+        ]
+
+    def list_users(self, dataset_hash: uuid.UUID) -> Iterable[DatasetUser]:
+        for user in self._api_client.get_paged_iterator(
+            f"datasets/{dataset_hash}/users", params=GetDatasetUsersPayload(), result_type=DatasetUserResponse
+        ):
+            yield DatasetUser(user_email=user.user_email, user_role=user.user_role, dataset_hash=str(user.dataset_uuid))
+
+    def remove_users(self, dataset_hash: uuid.UUID, user_emails: List[str]) -> None:
+        self._api_client.delete(
+            f"datasets/{dataset_hash}/users",
+            params=RemoveDatasetUsersPayload(user_emails=user_emails),
+            result_type=None,
+        )
 
     def list_groups(self, dataset_hash: uuid.UUID) -> Page[DatasetGroup]:
         return self._api_client.get(f"datasets/{dataset_hash}/groups", params=None, result_type=Page[DatasetGroup])
@@ -888,6 +913,13 @@ class EncordClientProject(EncordClient):
             f"projects/{project_hash}/users", params=GetProjectUsersPayload(), result_type=ProjectUserResponse
         ):
             yield ProjectUser(user_email=user.user_email, user_role=user.user_role, project_hash=str(project_hash))
+
+    def remove_users(self, project_hash: uuid.UUID, user_emails: List[str]) -> None:
+        self._api_client.delete(
+            f"projects/{project_hash}/users",
+            params=RemoveProjectUsersPayload(user_emails=user_emails),
+            result_type=None,
+        )
 
     def list_groups(self, project_hash: uuid.UUID) -> Page[ProjectGroup]:
         return self._api_client.get(f"projects/{project_hash}/groups", params=None, result_type=Page[ProjectGroup])

--- a/encord/dataset.py
+++ b/encord/dataset.py
@@ -182,6 +182,22 @@ class Dataset:
         """
         return self._client.add_users(user_emails, user_role)
 
+    def list_users(self) -> Iterable[DatasetUser]:
+        """List all users that have access to the dataset.
+
+        Returns:
+            Iterable[DatasetUser]: An iterable of DatasetUser instances.
+        """
+        yield from self._client.list_users(convert_to_uuid(self.dataset_hash))
+
+    def remove_users(self, user_emails: List[str]) -> None:
+        """Remove users from the dataset.
+
+        Args:
+            user_emails: List of user emails to remove.
+        """
+        self._client.remove_users(convert_to_uuid(self.dataset_hash), user_emails)
+
     def list_groups(self) -> Iterable[DatasetGroup]:
         """List all groups that have access to the dataset.
 

--- a/encord/ontology.py
+++ b/encord/ontology.py
@@ -20,7 +20,13 @@ from encord.orm.group import AddOntologyGroupsPayload, OntologyGroup, RemoveGrou
 from encord.orm.ontology import CreateOrUpdateOntologyPayload
 from encord.orm.ontology import Ontology as OrmOntology
 from encord.utilities.hash_utilities import convert_to_uuid
-from encord.utilities.ontology_user import OntologyUserRole, OntologyWithUserRole
+from encord.utilities.ontology_user import (
+    AddOntologyUsersPayload,
+    OntologyUser,
+    OntologyUserRole,
+    OntologyWithUserRole,
+    RemoveOntologyUsersPayload,
+)
 
 
 class Ontology:
@@ -100,6 +106,31 @@ class Ontology:
                 params=None,
                 payload=payload,
             )
+
+    def add_users(self, user_emails: List[str], user_role: OntologyUserRole) -> None:
+        """Add users to the ontology."""
+        ontology_hash = convert_to_uuid(self.ontology_hash)
+        self.api_client.post(
+            f"ontologies/{ontology_hash}/users",
+            params=None,
+            payload=AddOntologyUsersPayload(user_emails=user_emails, user_role=user_role),
+            result_type=None,
+        )
+
+    def list_users(self) -> Iterable[OntologyUser]:
+        """List all users that have access to this ontology."""
+        ontology_hash = convert_to_uuid(self.ontology_hash)
+        page = self.api_client.get(f"ontologies/{ontology_hash}/users", params=None, result_type=Page[OntologyUser])
+        yield from page.results
+
+    def remove_users(self, user_emails: List[str]) -> None:
+        """Remove users from the ontology."""
+        ontology_hash = convert_to_uuid(self.ontology_hash)
+        self.api_client.delete(
+            f"ontologies/{ontology_hash}/users",
+            params=RemoveOntologyUsersPayload(user_emails=user_emails),
+            result_type=None,
+        )
 
     def list_groups(self) -> Iterable[OntologyGroup]:
         """List all groups that have access to a particular ontology."""

--- a/encord/orm/dataset.py
+++ b/encord/orm/dataset.py
@@ -71,6 +71,25 @@ class DatasetUser(BaseDTO):
     dataset_hash: str
 
 
+class DatasetUserResponse(BaseDTO):
+    dataset_uuid: UUID
+    user_email: str
+    user_role: DatasetUserRole
+
+
+class AddDatasetUsersPayload(BaseDTO):
+    user_emails: List[str]
+    user_role: DatasetUserRole
+
+
+class RemoveDatasetUsersPayload(BaseDTO):
+    user_emails: List[str]
+
+
+class GetDatasetUsersPayload(BaseDTO):
+    page_token: Optional[str] = None
+
+
 class DatasetUsers:
     pass
 

--- a/encord/orm/project.py
+++ b/encord/orm/project.py
@@ -591,6 +591,10 @@ class GetProjectUsersPayload(BaseDTO):
     page_token: Optional[str] = None
 
 
+class RemoveProjectUsersPayload(BaseDTO):
+    user_emails: List[str]
+
+
 class ProjectUserResponse(BaseDTO):
     """
     This one should be merged with ProjectUser class

--- a/encord/orm/storage.py
+++ b/encord/orm/storage.py
@@ -64,6 +64,24 @@ class StorageUserRole(CamelStrEnum):
     ADMIN = auto()
 
 
+class StorageFolderUser(BaseDTO):
+    item_uuid: UUID
+    user_email: str
+    user_role: StorageUserRole
+    indirect_via: Optional[UUID] = None
+    group_uuid: Optional[UUID] = None
+    group_name: Optional[str] = None
+
+
+class AddStorageFolderUsersPayload(BaseDTO):
+    user_emails: List[str]
+    user_role: StorageUserRole
+
+
+class RemoveStorageFolderUsersPayload(BaseDTO):
+    user_emails: List[str]
+
+
 class StorageLocationName(CamelStrEnum):
     """Storage backends supported by Encord.
 

--- a/encord/project.py
+++ b/encord/project.py
@@ -388,6 +388,14 @@ class Project:
         """
         yield from self._client.list_users(UUID(self.project_hash))
 
+    def remove_users(self, user_emails: List[str]) -> None:
+        """Remove users from the project.
+
+        Args:
+            user_emails: List of user emails to remove.
+        """
+        self._client.remove_users(UUID(self.project_hash), user_emails)
+
     def list_groups(self) -> Iterable[ProjectGroup]:
         """List all groups that have access to a particular project.
 

--- a/encord/storage.py
+++ b/encord/storage.py
@@ -37,6 +37,7 @@ from encord.http.v2.payloads import Page
 from encord.orm.dataset import LongPollingStatus
 from encord.orm.group import AddStorageFolderGroupsPayload, RemoveGroupsParams, StorageFolderGroup
 from encord.orm.storage import (
+    AddStorageFolderUsersPayload,
     CustomerProvidedAudioMetadata,
     CustomerProvidedVideoMetadata,
     DataGroupInput,
@@ -50,7 +51,9 @@ from encord.orm.storage import (
     PathElement,
     ReencodeVideoItemsRequest,
     ReencodeVideoItemsResponse,
+    RemoveStorageFolderUsersPayload,
     StorageFolderSummary,
+    StorageFolderUser,
     StorageItemSummary,
     StorageItemType,
     StorageLocationName,
@@ -1358,6 +1361,31 @@ class StorageFolder:
         )
 
         yield from page.results
+
+    def add_users(self, user_emails: List[str], user_role: StorageUserRole) -> None:
+        """Allow users to access this folder."""
+        self._api_client.post(
+            f"/storage/folders/{self.uuid}/users",
+            params=None,
+            payload=AddStorageFolderUsersPayload(user_emails=user_emails, user_role=user_role),
+            result_type=None,
+        )
+
+    def list_users(self) -> Iterable[StorageFolderUser]:
+        """List all users that have access to this folder."""
+        page = self._api_client.get(
+            f"/storage/folders/{self.uuid}/users", params=None, result_type=Page[StorageFolderUser]
+        )
+
+        yield from page.results
+
+    def remove_users(self, user_emails: List[str]) -> None:
+        """Revoke users' access to this folder."""
+        self._api_client.delete(
+            f"/storage/folders/{self.uuid}/users",
+            params=RemoveStorageFolderUsersPayload(user_emails=user_emails),
+            result_type=None,
+        )
 
     def add_group(self, group_hash: Union[List[UUID], UUID], user_role: StorageUserRole):
         """Allow access to this folder for members of a group.

--- a/encord/utilities/ontology_user.py
+++ b/encord/utilities/ontology_user.py
@@ -23,6 +23,21 @@ class OntologyUserRole(IntEnum):
     USER = 1
 
 
+class OntologyUser(BaseDTO):
+    ontology_uuid: UUID
+    user_email: str
+    user_role: OntologyUserRole
+
+
+class AddOntologyUsersPayload(BaseDTO):
+    user_emails: list[str]
+    user_role: OntologyUserRole
+
+
+class RemoveOntologyUsersPayload(BaseDTO):
+    user_emails: list[str]
+
+
 class OntologyWithUserRole(BaseDTO):
     """An on-the-wire representation from /v2/public/ontologies endpoints"""
 

--- a/tests/test_entity_users.py
+++ b/tests/test_entity_users.py
@@ -1,0 +1,81 @@
+import uuid
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from encord.client import EncordClientDataset
+from encord.dataset import Dataset
+from encord.http.v2.payloads import Page
+from encord.ontology import Ontology
+from encord.orm.dataset import Dataset as OrmDataset
+from encord.orm.dataset import DatasetUserRole
+from encord.orm.storage import StorageFolder, StorageUserRole
+from encord.storage import StorageFolder as SdkStorageFolder
+from encord.utilities.ontology_user import OntologyUserRole
+
+
+def test_dataset_users_use_v2_api() -> None:
+    dataset_hash = uuid.uuid4()
+    api_client = MagicMock()
+    api_client.post.return_value = Page(results=[])
+    querier = MagicMock(resource_id=dataset_hash)
+    client = EncordClientDataset(querier=querier, config=MagicMock(), api_client=api_client)
+    dataset = Dataset(client, MagicMock(spec=OrmDataset, dataset_hash=str(dataset_hash)))
+
+    dataset.add_users(["user@example.com"], DatasetUserRole.USER)
+    list(dataset.list_users())
+    dataset.remove_users(["user@example.com"])
+
+    api_client.post.assert_called_once()
+    assert api_client.post.call_args.args[0] == f"datasets/{dataset_hash}/users"
+    api_client.get_paged_iterator.assert_called_once()
+    assert api_client.get_paged_iterator.call_args.args[0] == f"datasets/{dataset_hash}/users"
+    api_client.delete.assert_called_once()
+    assert api_client.delete.call_args.args[0] == f"datasets/{dataset_hash}/users"
+
+
+def test_ontology_users_use_v2_api(ontology: Ontology) -> None:
+    ontology.api_client.get.return_value = Page(results=[])
+
+    ontology.add_users(["user@example.com"], OntologyUserRole.USER)
+    list(ontology.list_users())
+    ontology.remove_users(["user@example.com"])
+
+    ontology.api_client.post.assert_called_once()
+    assert ontology.api_client.post.call_args.args[0] == f"ontologies/{ontology.ontology_hash}/users"
+    ontology.api_client.get.assert_called_once()
+    assert ontology.api_client.get.call_args.args[0] == f"ontologies/{ontology.ontology_hash}/users"
+    ontology.api_client.delete.assert_called_once()
+    assert ontology.api_client.delete.call_args.args[0] == f"ontologies/{ontology.ontology_hash}/users"
+
+
+def test_storage_folder_users_use_v2_api() -> None:
+    folder_uuid = uuid.uuid4()
+    api_client = MagicMock()
+    api_client.get.return_value = Page(results=[])
+    folder = SdkStorageFolder(
+        api_client,
+        StorageFolder(
+            uuid=folder_uuid,
+            parent=None,
+            name="folder",
+            description="",
+            client_metadata=None,
+            owner="owner@example.com",
+            created_at=datetime.now(),
+            last_edited_at=datetime.now(),
+            user_role=StorageUserRole.ADMIN,
+            synced_dataset_hash=None,
+            path_to_root=[],
+        ),
+    )
+
+    folder.add_users(["user@example.com"], StorageUserRole.USER)
+    list(folder.list_users())
+    folder.remove_users(["user@example.com"])
+
+    api_client.post.assert_called_once()
+    assert api_client.post.call_args.args[0] == f"/storage/folders/{folder_uuid}/users"
+    api_client.get.assert_called_once()
+    assert api_client.get.call_args.args[0] == f"/storage/folders/{folder_uuid}/users"
+    api_client.delete.assert_called_once()
+    assert api_client.delete.call_args.args[0] == f"/storage/folders/{folder_uuid}/users"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -95,3 +95,17 @@ def test_get_tags_use_cache_false(api_get: MagicMock, project: Project) -> None:
     project.get_tags(use_cache=False)
 
     assert api_get.call_count == 2
+
+
+@patch.object(ApiClient, "delete")
+def test_remove_users(api_delete: MagicMock, project: Project) -> None:
+    user_emails = ["annotator@example.com", "reviewer@example.com"]
+
+    project.remove_users(user_emails)
+
+    api_delete.assert_called_once()
+    path = api_delete.call_args.args[0]
+    params = api_delete.call_args.kwargs["params"]
+    assert path == f"projects/{project.project_hash}/users"
+    assert params.user_emails == user_emails
+    assert api_delete.call_args.kwargs["result_type"] is None


### PR DESCRIPTION
## Summary
- Add SDK add/list/remove user methods for datasets, folders, and ontologies using /v2/public
- Add SDK project remove_users using /v2/public
- Add DTOs and focused tests for user-management call shapes

## Tests
- uv run pytest tests/test_project.py::test_remove_users tests/test_entity_users.py -v --tb=short
- uv run ruff check touched SDK files