### PR TITLE
feat: COR-422 new add_skeleton_object function to simplify skeleton usage

### DIFF
--- a/encord/objects/ontology_structure.py
+++ b/encord/objects/ontology_structure.py
@@ -12,7 +12,7 @@ category: "64e481b57b6027003f20aaa0"
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Type, cast
+from typing import Any, Dict, List, Optional, Tuple, Type, cast
 from uuid import uuid4
 
 from encord.exceptions import OntologyError
@@ -263,6 +263,46 @@ class OntologyStructure:
         cls = Classification(uid=uid, feature_node_hash=feature_node_hash, attributes=list(), _level=level)
         self.classifications.append(cls)
         return cls
+
+    def add_skeleton_object(
+        self,
+        name: str,
+        skeleton_template: SkeletonTemplate,
+        uid: Optional[int] = None,
+        color: Optional[str] = None,
+        feature_node_hash: Optional[str] = None,
+    ) -> Tuple[Object, SkeletonTemplate]:
+        """Adds a skeleton object and its template as a linked pair.
+
+        The object is minted first and the template reuses the object's ``feature_node_hash``.
+        The two hashes must be equal for the skeleton to render in the label editor, which keys
+        the object's template option (``skeleton_<objectHash>``) off the template's
+        ``feature_node_hash``. Prefer this over calling ``add_object`` and ``add_skeleton_template``
+        separately: it removes the need to manage feature hashes by hand.
+
+        Args:
+            name: The user-visible name of the skeleton object.
+            skeleton_template: The SkeletonTemplate to link to the object.
+            uid: Integer identifier of the object. Normally auto-generated; omit this unless the aim is to create an exact clone of existing structure.
+            color: The color of the object in the label editor. Normally auto-assigned, should be in '#1A2B3F' syntax.
+            feature_node_hash: Global identifier shared by the object and its template. Normally auto-generated; omit this unless the aim is to create an exact clone of existing structure.
+
+        Returns:
+            Tuple[Object, SkeletonTemplate]: The created skeleton object and its linked template,
+                sharing one feature_node_hash. The template is the same instance that was passed in.
+
+        Raises:
+            ValueError: If a duplicate uid or feature_node_hash is provided, or a skeleton template
+                with the same name already exists. The structure is left unchanged when this is raised.
+        """
+        if skeleton_template.name in self.skeleton_templates:
+            raise ValueError("Already a template with this name associated to this ontology")
+
+        obj = self.add_object(
+            name=name, shape=Shape.SKELETON, uid=uid, color=color, feature_node_hash=feature_node_hash
+        )
+        self.add_skeleton_template(skeleton_template, feature_node_hash=obj.feature_node_hash)
+        return obj, skeleton_template
 
     def add_skeleton_template(
         self,

--- a/tests/objects/test_ontology.py
+++ b/tests/objects/test_ontology.py
@@ -379,6 +379,77 @@ def build_expected_ontology():
     assert ontology.to_dict() == EXPECTED_ONTOLOGY.to_dict()
 
 
+def _make_skeleton_template(name: str = "Line") -> SkeletonTemplate:
+    coordinates = [
+        SkeletonTemplateCoordinate(x=0, y=0, name="point_0"),
+        SkeletonTemplateCoordinate(x=1, y=1, name="point_1"),
+    ]
+    return SkeletonTemplate(
+        name=name,
+        width=100,
+        height=100,
+        skeleton={str(i): x for (i, x) in enumerate(coordinates)},
+        skeleton_edges={"0": {"1": {"color": "#00000"}}},
+    )
+
+
+def test_add_skeleton_object_shares_hash_with_template():
+    ontology = encord.objects.OntologyStructure()
+    template = _make_skeleton_template()
+
+    obj, returned_template = ontology.add_skeleton_object(name="Pose", skeleton_template=template)
+
+    assert obj.shape == Shape.SKELETON
+    assert obj.feature_node_hash
+    assert obj in ontology.objects
+    # The passed-in template is returned so callers who built it inline still have a handle on it.
+    assert returned_template is template
+    # The object hash is authoritative: the template must reuse it so the editor can
+    # key its template option (skeleton_<objectHash>) off the template's feature_node_hash.
+    assert obj.feature_node_hash == ontology.skeleton_templates[template.name].feature_node_hash
+
+
+def test_add_skeleton_object_respects_provided_hash():
+    ontology = encord.objects.OntologyStructure()
+    template = _make_skeleton_template()
+    feature_node_hash = short_uuid_str()
+
+    obj, _ = ontology.add_skeleton_object(
+        name="Pose",
+        skeleton_template=template,
+        feature_node_hash=feature_node_hash,
+    )
+
+    assert obj.feature_node_hash == feature_node_hash
+    assert ontology.skeleton_templates[template.name].feature_node_hash == feature_node_hash
+
+
+def test_add_skeleton_object_serializes_to_expected_shape():
+    ontology = encord.objects.OntologyStructure()
+    template = _make_skeleton_template()
+    obj, _ = ontology.add_skeleton_object(name="Pose", skeleton_template=template)
+
+    serialized = ontology.to_dict()
+
+    # The backend fix expects skeleton_templates=[{"template": <template>}] with the template's
+    # feature_node_hash equal to the object's, so the editor can render the skeleton object.
+    assert serialized["objects"][0]["shape"] == Shape.SKELETON.value
+    assert list(serialized["skeleton_templates"][0].keys()) == ["template"]
+    assert serialized["skeleton_templates"][0]["template"]["feature_node_hash"] == obj.feature_node_hash
+
+
+def test_add_skeleton_object_duplicate_template_name_leaves_structure_unchanged():
+    ontology = encord.objects.OntologyStructure()
+    ontology.add_skeleton_object(name="Pose", skeleton_template=_make_skeleton_template())
+
+    with pytest.raises(ValueError):
+        ontology.add_skeleton_object(name="Pose 2", skeleton_template=_make_skeleton_template())
+
+    # The clashing template must not leave a dangling object behind.
+    assert len(ontology.objects) == 1
+    assert len(ontology.skeleton_templates) == 1
+
+
 def test_ontology_getters():
     # Object
     assert EXPECTED_ONTOLOGY.get_child_by_hash(OBJECT_1.feature_node_hash) == OBJECT_1


### PR DESCRIPTION
# Introduction and Explanation

Users attempting to create ontologies with skeletons have been having a bad time of it lately. The [server side fixes exist here](https://app.graphite.com/github/pr/encord-team/cord-backend/8810/fix-COR-422-sdk-skeleton-creation?mode=tour), but to correctly attach a newly-created skeleton to a newly-created ontology object required the user to know about feature hashes. This is unnecessary for the common usage, so this PR adds a one-shot create-skeleton-attached-to-an-object function.

# JIRA

[COR-422](https://linear.app/encord/issue/COR-422/sdk-skeleton-creation-does-not-create-object-primitive)

# Documentation

n/a

# Tests

see graphite tour

# Known issues

n/a