### PR TITLE
fix(coco): prevent IndexError in get_radio_answer on empty answers list

### DIFF
--- a/encord/utilities/coco/exporter.py
+++ b/encord/utilities/coco/exporter.py
@@ -1108,7 +1108,13 @@ class CocoExporter:
 
         return ret
 
-    def get_radio_answer(self, attribute: Attribute, answers: List[Dict[str, str]]) -> Dict[str, str]:
+    def get_radio_answer(self, attribute: Attribute, answers: List[Dict[str, str]]) -> Dict[str, Any]:
+        if len(answers) == 0:
+            # An empty answers array is equivalent to "no such attribute" (see
+            # ClassificationInstance._set_answer_from_dict) and should be treated like an
+            # unselected attribute (add_unselected_attributes will fill it with `None`),
+            # instead of raising an IndexError during export.
+            return {}
         answer = answers[0]  # radios only have one answer by definition
         return {attribute.name: answer["name"]}
 

--- a/tests/utilities/coco/test_exporter.py
+++ b/tests/utilities/coco/test_exporter.py
@@ -4,6 +4,8 @@ import pytest
 from deepdiff import DeepDiff
 from shapely.geometry import MultiPolygon
 
+from encord.objects import RadioAttribute
+from encord.objects.options import NestableOption
 from encord.utilities.coco.exporter import CocoExporter, OntologyStructure
 from tests.utilities.coco.data.exporter import (
     COCO_EXPORTER_EXPECTED_RES,
@@ -98,3 +100,37 @@ def test_get_rle_segmentation_from_multipolygon(
     segmentation = coco_exporter.get_rle_segmentation_from_multipolygon(multipolygon, w, h)
 
     assert not DeepDiff(segmentation, expected_segmentation)
+    assert not DeepDiff(segmentation, expected_segmentation)
+
+
+def test_get_radio_answer_with_empty_answers_does_not_raise(coco_exporter: CocoExporter) -> None:
+    """Regression test: an unanswered radio classification ("answers": []) used to raise an
+    IndexError during COCO export. It must be treated as an unselected attribute instead."""
+    radio_attribute = RadioAttribute(
+        uid=[1, 1],
+        feature_node_hash="MjI5MTA5",
+        name="Radio classification 1",
+        required=False,
+        archived=False,
+        dynamic=False,
+        options=[
+            NestableOption(
+                uid=[1, 1, 1],
+                feature_node_hash="MTcwMjM5",
+                label="cl 1 option 1",
+                value="cl_1_option_1",
+                archived=False,
+                nested_options=[],
+            ),
+        ],
+    )
+
+    # Empty answers list (unanswered radio attribute) must not crash.
+    assert coco_exporter.get_radio_answer(radio_attribute, []) == {}
+
+    # Sanity check: a properly answered radio still resolves to the answer name.
+    answered = coco_exporter.get_radio_answer(
+        radio_attribute,
+        [{"name": "cl 1 option 1", "featureHash": "MTcwMjM5"}],
+    )
+    assert answered == {"Radio classification 1": "cl 1 option 1"}


### PR DESCRIPTION
#### Summary
When exporting label datasets with radio classifications to COCO format, `CocoExporter.get_radio_answer` directly accessed `answers[0]` without validating if the list was empty. Unanswered radio attributes produce `"answers": []` in the Encord payload, causing an `IndexError: list index out of range` during export.

#### Changes
* Added an empty check in `get_radio_answer` returning `{}` (aligning with `classification_instance.py` logic where an empty array represents an unselected/missing attribute).
* Added regression test `test_get_radio_answer_with_empty_answers_does_not_raise` in `tests/utilities/coco/test_exporter.py`.

---

P.S. I really admire Encord's tech stack and work in the AI space, and I'm currently looking for full-stack / backend engineering roles. If your team is hiring or open to a quick chat, I'd love to connect!